### PR TITLE
db: migration 32 — ajout colonne pays sur profiles

### DIFF
--- a/supabase/migrations/32_add_pays_to_profiles.sql
+++ b/supabase/migrations/32_add_pays_to_profiles.sql
@@ -1,0 +1,15 @@
+-- =====================================================================
+-- HILMY · 32 — Ajout colonne pays sur profiles
+-- Idempotent.
+--
+-- Contexte : le flow d'inscription via Google Places envoie un champ
+-- `pays` (extrait de `details.country`) lors de l'insert dans `profiles`,
+-- mais la colonne n'existait pas encore → crash PostgREST.
+--
+-- Fix : ajoute la colonne de façon non-destructive.
+-- =====================================================================
+
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS pays TEXT;
+
+-- Recharge le schema cache PostgREST pour que la colonne soit visible immédiatement
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Fix crash lors de l'inscription via Google Places : la colonne `pays` était envoyée par le code mais absente de la table profiles.

Closes #4