### PR TITLE
fix(evenements): corriger les 5 CTAs cassés pointant vers /proposer-u…

### DIFF
--- a/app/dashboard/prestataire/evenements/page.tsx
+++ b/app/dashboard/prestataire/evenements/page.tsx
@@ -39,7 +39,7 @@ export default async function MesEvenementsPrestataire() {
         lead="Ateliers, masterclass, rencontres — les moments que tu proposes à la communauté."
         actions={
           <Link
-            href="/proposer-un-evenement"
+            href="/dashboard/utilisatrice/evenements/nouveau"
             className="group inline-flex h-11 items-center gap-2 rounded-full bg-or px-5 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:bg-or-light"
           >
             Créer un événement
@@ -68,7 +68,7 @@ export default async function MesEvenementsPrestataire() {
             titre="Pas encore d'événement."
             pitch="Un atelier, un masterclass, un workshop : propose le premier. On aide à remplir les places."
             ctaLabel="Créer un événement"
-            ctaHref="/proposer-un-evenement"
+            ctaHref="/dashboard/utilisatrice/evenements/nouveau"
           />
         </section>
       ) : (

--- a/app/evenements-v2/page.tsx
+++ b/app/evenements-v2/page.tsx
@@ -178,7 +178,7 @@ export default function EvenementsV2Page() {
           titre="Propose le premier."
           pitch="Un brunch, un book club, une balade. L'équipe HILMY t'aide à remplir les places."
           ctaLabel="Proposer un événement"
-          ctaHref="/proposer-un-evenement"
+          ctaHref="/dashboard/utilisatrice/evenements/nouveau"
         />
       </PageShell>
     )
@@ -205,7 +205,7 @@ export default function EvenementsV2Page() {
         }
       >
         <Link
-          href="/proposer-un-evenement"
+          href="/dashboard/utilisatrice/evenements/nouveau"
           className="group inline-flex h-12 items-center gap-2.5 rounded-full bg-or px-6 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:bg-or-light"
         >
           Proposer un événement
@@ -296,7 +296,7 @@ export default function EvenementsV2Page() {
                     Tout réinitialiser
                   </button>
                   <Link
-                    href="/proposer-un-evenement"
+                    href="/dashboard/utilisatrice/evenements/nouveau"
                     className="inline-flex h-11 items-center gap-2 rounded-full bg-vert px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
                   >
                     Proposer un événement


### PR DESCRIPTION
…n-evenement

Remplace tous les href="/proposer-un-evenement" (route inexistante) par /dashboard/utilisatrice/evenements/nouveau (route existante et fonctionnelle).

La page destination gère déjà l'auth : redirect vers /auth/login?next=... si utilisatrice non connectée, puis retour sur la page de création après login.

Fichiers corrigés :
- app/evenements-v2/page.tsx — 3 occurrences (hero CTA, empty state, filtre vide)
- app/dashboard/prestataire/evenements/page.tsx — 2 occurrences (header action, empty state)