### PR TITLE
db(audit): migration 34 — colonnes profil manquantes (DRAFT)

### DIFF
--- a/supabase/migrations/34_missing_profile_columns.sql
+++ b/supabase/migrations/34_missing_profile_columns.sql
@@ -1,0 +1,51 @@
+-- =====================================================================
+-- HILMY · 34 — Ajout des colonnes profil manquantes (audit DB)
+-- Idempotent.
+--
+-- Contexte : audit autonome du 2026-05-03 — 4 colonnes sont écrites par
+-- le code (app/onboarding/prestataire/manuel/page.tsx + app/dashboard/
+-- prestataire/fiche/page.tsx) mais absentes du schéma migré (1 → 33).
+-- Probable cause : oubli lors d'un commit antérieur. Le INSERT échoue
+-- silencieusement côté Supabase ou drop ces clés selon la config PostgREST.
+--
+-- Colonnes ajoutées :
+--   • phone_public : téléphone affiché publiquement (séparé de whatsapp)
+--   • tiktok       : URL du compte TikTok
+--   • facebook     : URL de la page Facebook
+--   • youtube      : URL de la chaîne YouTube
+--
+-- ⚠️ AVANT EXÉCUTION : confirmer en prod via
+--   SELECT column_name FROM information_schema.columns
+--   WHERE table_schema='public' AND table_name='profiles'
+--     AND column_name IN ('phone_public','tiktok','facebook','youtube');
+-- Si les colonnes existent déjà (créées hors-migration), la migration est
+-- no-op grâce à IF NOT EXISTS.
+--
+-- Exécuter via : bash scripts/run-migration.sh 34_missing_profile_columns.sql
+-- =====================================================================
+
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS phone_public text;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS tiktok text;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS facebook text;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS youtube text;
+
+COMMENT ON COLUMN public.profiles.phone_public IS
+  'Numéro de téléphone affiché publiquement sur la fiche (distinct de whatsapp).';
+COMMENT ON COLUMN public.profiles.tiktok IS
+  'URL complète du compte TikTok (https://tiktok.com/@…).';
+COMMENT ON COLUMN public.profiles.facebook IS
+  'URL complète de la page/profil Facebook.';
+COMMENT ON COLUMN public.profiles.youtube IS
+  'URL complète de la chaîne YouTube (https://youtube.com/@…).';
+
+-- ─── Recharge le schema cache PostgREST ───────────────────────────────
+NOTIFY pgrst, 'reload schema';
+
+-- =====================================================================
+-- ROLLBACK (à utiliser uniquement si données nulles partout)
+-- =====================================================================
+-- ALTER TABLE public.profiles DROP COLUMN IF EXISTS phone_public;
+-- ALTER TABLE public.profiles DROP COLUMN IF EXISTS tiktok;
+-- ALTER TABLE public.profiles DROP COLUMN IF EXISTS facebook;
+-- ALTER TABLE public.profiles DROP COLUMN IF EXISTS youtube;
+-- =====================================================================


### PR DESCRIPTION
## Quoi

Audit autonome du **2026-05-03** — détection de **4 colonnes manquantes** sur la table `profiles` :

| Colonne | Type | Insertion code | Migration |
|---|---|---|---|
| `phone_public` | text | ✅ | ❌ |
| `tiktok` | text | ✅ | ❌ |
| `facebook` | text | ✅ | ❌ |
| `youtube` | text | ✅ | ❌ |

Les colonnes sont écrites par :
- `app/onboarding/prestataire/manuel/page.tsx` (lignes 205-211)
- `app/dashboard/prestataire/fiche/page.tsx` (lignes 145-150)

Mais aucune migration `1 → 33` ne les ajoute. La référence TS existe (`lib/supabase/types.ts:73-77`) — d'où un build vert qui masque le bug.

## Pourquoi

Côté PostgREST/Supabase, écrire un `phone_public` qui n'existe pas en DB se traduit soit par :
- **422 / column does not exist** → l'utilisatrice voit \"impossible de sauvegarder\"
- **Drop silencieux** selon config → l'utilisatrice croit avoir sauvé, le champ disparaît

Dans tous les cas : perte de données utilisatrice + mauvaise UX.

## Comment tester en local

1. Vérifier en prod l'état réel des colonnes :
   \`\`\`sql
   SELECT column_name FROM information_schema.columns
   WHERE table_schema='public' AND table_name='profiles'
     AND column_name IN ('phone_public','tiktok','facebook','youtube');
   \`\`\`
2. Si vide → migration nécessaire (lancer 34)
3. Si déjà présentes → no-op grâce à \`IF NOT EXISTS\`, on peut juste merger pour formaliser

## Risques

- ✅ Migration idempotente (\`ADD COLUMN IF NOT EXISTS\`)
- ✅ Aucun \`DROP\`, aucune perte de donnée
- ✅ \`NOTIFY pgrst, 'reload schema'\` pour rafraîchir le cache PostgREST
- ⚠️ La migration ne touche PAS les RLS — la table `profiles` a déjà ses policies depuis l'origine
- ⚠️ Si on confirme que les colonnes existent déjà (créées hors-migration), garder la PR pour formaliser le schéma versionné

## Sécurité

- Pas de touches à auth / Stripe / branch protection
- Pas de PII dans les colonnes ajoutées (URLs publiques + numéro public que la prestataire choisit d'afficher)

## Verdict

🟡 **DRAFT — à merger manuellement** par Jiji après :
1. Vérification SQL de l'état actuel des colonnes en prod
2. Décision : exécuter migration 34 ou simplement merger pour formaliser le schéma

⚠️ **Cette PR ne lance pas la migration** — voir rapport \`docs/session-claude-code-2026-05-03.md\` pour la commande exacte.