### PR TITLE
fix(content): respect AGENTS.md mots interdits dans evenements-v2

### DIFF
--- a/app/evenements-v2/page.tsx
+++ b/app/evenements-v2/page.tsx
@@ -176,7 +176,7 @@ export default function EvenementsV2Page() {
         <LiveEmptyState
           kicker="Zéro événement à venir"
           titre="Propose le premier."
-          pitch="Un brunch, un book club, une balade. L'équipe HILMY t'aide à remplir les places."
+          pitch="Un brunch, un book club, une balade. La team Hilmy t'aide à remplir les places."
           ctaLabel="Proposer un événement"
           ctaHref="/dashboard/utilisatrice/evenements/nouveau"
         />


### PR DESCRIPTION
Fix #18 — respect AGENTS.md mots interdits.

`L'équipe HILMY` → `La team Hilmy` dans `app/evenements-v2/page.tsx:179`.

Verdict 🟢 SAFE — juste du contenu texte, pas de SQL, pas d'auth/Stripe.