### PR TITLE
fix(mobile): tactile 44px + anti-overflow horizontal sur 5 pages cles

### DIFF
--- a/app/annuaire/page.tsx
+++ b/app/annuaire/page.tsx
@@ -248,8 +248,8 @@ export default function AnnuairePage() {
         ]}
       />
 
-      <section className="py-14 md:py-20">
-        <div className="mx-auto max-w-container px-6 md:px-20">
+      <section className="py-10 sm:py-14 md:py-20">
+        <div className="mx-auto max-w-container px-4 sm:px-6 md:px-20">
           <AnimatePresence mode="wait">
             {filtered.length > 0 ? (
               <motion.div

--- a/app/evenements-v2/page.tsx
+++ b/app/evenements-v2/page.tsx
@@ -247,8 +247,8 @@ export default function EvenementsV2Page() {
         ]}
       />
 
-      <section className="py-14 md:py-20">
-        <div className="mx-auto max-w-container px-6 md:px-20">
+      <section className="py-10 sm:py-14 md:py-20">
+        <div className="mx-auto max-w-container px-4 sm:px-6 md:px-20">
           <AnimatePresence mode="wait">
             {filtered.length > 0 ? (
               <motion.div

--- a/app/recommandations/page.tsx
+++ b/app/recommandations/page.tsx
@@ -210,8 +210,8 @@ export default function RecommandationsPage() {
         ]}
       />
 
-      <section className="py-14 md:py-20">
-        <div className="mx-auto max-w-container px-6 md:px-20">
+      <section className="py-10 sm:py-14 md:py-20">
+        <div className="mx-auto max-w-container px-4 sm:px-6 md:px-20">
           <AnimatePresence mode="wait">
             {filtered.length > 0 ? (
               <motion.div

--- a/components/landing/HeroV2.tsx
+++ b/components/landing/HeroV2.tsx
@@ -255,11 +255,11 @@ export function HeroV2({ variant }: { variant?: VariantKey } = {}) {
             delay: ctaDelay,
             ease: 'easeOut',
           }}
-          className="mt-2 flex flex-col items-center gap-3 sm:flex-row sm:gap-4"
+          className="mt-2 flex w-full flex-col items-stretch gap-3 sm:w-auto sm:flex-row sm:items-center sm:gap-4"
         >
           <Link
             href="/inscription"
-            className="group inline-flex h-[58px] items-center gap-2.5 rounded-full bg-or px-8 text-[11px] font-medium tracking-[0.28em] text-vert uppercase transition-all duration-300 hover:bg-or-light"
+            className="group inline-flex h-[58px] items-center justify-center gap-2.5 rounded-full bg-or px-6 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all duration-300 hover:bg-or-light sm:px-8 sm:tracking-[0.28em]"
           >
             Rejoindre
             <span
@@ -271,7 +271,7 @@ export function HeroV2({ variant }: { variant?: VariantKey } = {}) {
           </Link>
           <Link
             href="/onboarding/prestataire"
-            className="group inline-flex h-[58px] items-center gap-2.5 rounded-full border border-creme/50 bg-transparent px-8 text-[11px] font-medium tracking-[0.28em] text-creme uppercase transition-all duration-300 hover:border-or hover:bg-or/10 hover:text-or-light"
+            className="group inline-flex h-[58px] items-center justify-center gap-2.5 rounded-full border border-creme/50 bg-transparent px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all duration-300 hover:border-or hover:bg-or/10 hover:text-or-light sm:px-8 sm:tracking-[0.28em]"
           >
             Je suis prestataire
             <span

--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -98,7 +98,7 @@ export function Navigation({ variant = 'transparent' }: NavigationProps = {}) {
           {user ? (
             <Link
               href={dashboardPathFor(user)}
-              className={`inline-flex h-10 items-center gap-2 rounded-full border px-5 text-[13px] font-semibold transition-all ${
+              className={`inline-flex h-11 items-center gap-2 rounded-full border px-5 text-[13px] font-semibold transition-all ${
                 scrolled
                   ? 'border-vert text-vert hover:bg-vert hover:text-creme'
                   : 'border-or text-or hover:bg-or hover:text-vert'
@@ -119,7 +119,7 @@ export function Navigation({ variant = 'transparent' }: NavigationProps = {}) {
               </Link>
               <Link
                 href="/auth/signup"
-                className={`inline-flex h-10 items-center rounded-full border px-5 text-[13px] font-semibold transition-all ${
+                className={`inline-flex h-11 items-center rounded-full border px-5 text-[13px] font-semibold transition-all ${
                   scrolled
                     ? 'border-vert text-vert hover:bg-vert hover:text-creme'
                     : 'border-or text-or hover:bg-or hover:text-vert'

--- a/components/v2/EvenementCard.tsx
+++ b/components/v2/EvenementCard.tsx
@@ -53,7 +53,7 @@ export function EvenementCard({ e, index = 0, variant = 'default' }: Props) {
             />
           )}
           <div className="absolute inset-0 bg-grain opacity-[0.08]" />
-          <div className="absolute left-5 top-5 inline-flex items-center gap-2 rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
+          <div className="absolute left-5 top-5 inline-flex max-w-[60%] items-center gap-2 truncate rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
             {e.categorie}
           </div>
           <div className="absolute bottom-5 left-5 rounded-sm bg-vert/85 px-4 py-3 text-center backdrop-blur">
@@ -66,12 +66,12 @@ export function EvenementCard({ e, index = 0, variant = 'default' }: Props) {
             </div>
           )}
         </div>
-        <div className="flex flex-1 flex-col gap-4 p-7 md:p-10">
+        <div className="flex flex-1 flex-col gap-4 p-6 sm:p-7 md:p-10">
           <div>
             <p className="text-[11px] tracking-[0.22em] text-or-deep uppercase">
               {e.dateRelative}
             </p>
-            <h3 className="mt-2 font-serif text-[26px] font-light leading-tight text-vert md:text-[32px]">
+            <h3 className="mt-2 font-serif text-[22px] font-light leading-tight text-vert break-words sm:text-[26px] md:text-[32px]">
               {e.titre}
             </h3>
             {heure && (
@@ -81,18 +81,18 @@ export function EvenementCard({ e, index = 0, variant = 'default' }: Props) {
           <p className="text-[13px] leading-[1.65] text-texte-sec line-clamp-3">
             {e.description}
           </p>
-          <div className="mt-auto flex items-center justify-between border-t border-or/10 pt-4">
-            <div className="flex flex-col gap-1">
-              <div className="flex items-center gap-2">
-                <span className="h-1 w-1 rounded-full bg-or" aria-hidden="true" />
-                <span className="text-[11px] font-medium text-texte-sec">{e.lieu} · {e.ville}</span>
+          <div className="mt-auto flex items-center justify-between gap-3 border-t border-or/10 pt-4">
+            <div className="flex min-w-0 flex-col gap-1">
+              <div className="flex min-w-0 items-center gap-2">
+                <span className="h-1 w-1 shrink-0 rounded-full bg-or" aria-hidden="true" />
+                <span className="truncate text-[11px] font-medium text-texte-sec">{e.lieu} · {e.ville}</span>
               </div>
               <span className="text-[11px] text-texte-sec">
                 {e.inscrites} / {e.places} inscrites
               </span>
             </div>
             <span
-              className="inline-flex items-center gap-1.5 text-[11px] font-medium text-vert transition-all group-hover:text-or group-hover:gap-2.5"
+              className="inline-flex shrink-0 items-center gap-1.5 text-[11px] font-medium text-vert transition-all group-hover:gap-2.5 group-hover:text-or"
               aria-hidden="true"
             >
               Voir

--- a/components/v2/FiltersBar.tsx
+++ b/components/v2/FiltersBar.tsx
@@ -28,9 +28,9 @@ export function FiltersBar({
 
   return (
     <div className="sticky top-20 z-30 border-b border-or/15 bg-creme/85 backdrop-blur">
-      <div className="mx-auto max-w-container px-6 py-5 md:px-20">
-        <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between md:gap-6">
-          <div className="flex flex-wrap items-center gap-x-6 gap-y-4">
+      <div className="mx-auto max-w-container px-4 py-4 sm:px-6 sm:py-5 md:px-20">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between md:gap-6">
+          <div className="flex flex-col gap-4 md:flex-row md:flex-wrap md:items-center md:gap-x-6 md:gap-y-4">
             {groups.map((g) => (
               <FilterGroup key={g.id} {...g} />
             ))}
@@ -45,7 +45,7 @@ export function FiltersBar({
               <button
                 type="button"
                 onClick={onReset}
-                className="text-vert underline-offset-4 hover:text-or hover:underline"
+                className="min-h-[44px] py-2 text-vert underline-offset-4 hover:text-or hover:underline"
               >
                 {resetLabel}
               </button>
@@ -72,9 +72,13 @@ function FilterGroup({
       onChange: (v: string) => void
     }) {
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
       <span className="overline text-or">{label}</span>
-      <div className="flex flex-wrap items-center gap-1.5">
+      <div
+        className="-mx-4 flex snap-x snap-mandatory items-center gap-1.5 overflow-x-auto px-4 pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden md:mx-0 md:flex-wrap md:overflow-visible md:px-0 md:pb-0"
+        role="group"
+        aria-label={label}
+      >
         {options.map((opt) => {
           const active = value === opt.value
           return (
@@ -82,7 +86,7 @@ function FilterGroup({
               key={opt.value}
               type="button"
               onClick={() => onChange(opt.value)}
-              className={`rounded-full px-3.5 py-1.5 text-[12px] font-medium transition-all ${
+              className={`min-h-[40px] shrink-0 snap-start rounded-full px-4 py-2 text-[12px] font-medium transition-all md:min-h-0 md:px-3.5 md:py-1.5 ${
                 active
                   ? 'bg-vert text-creme'
                   : 'bg-blanc text-texte-sec hover:bg-creme-deep hover:text-vert'

--- a/components/v2/LieuCard.tsx
+++ b/components/v2/LieuCard.tsx
@@ -10,6 +10,8 @@ function catLabel(slug: string) {
 }
 
 // varied heights for editorial masonry feel
+// values are min-height in px — appliquées en min-height pour préserver le ratio
+// d'image et permettre au CSS d'adapter sur les viewports étroits sans dépasser.
 const heights = [360, 440, 380, 460, 400, 480]
 
 interface Props {
@@ -55,7 +57,7 @@ export function LieuCard({ lieu, index = 0 }: Props) {
             />
           )}
           <div className="absolute inset-0 bg-grain opacity-[0.08]" />
-          <div className="absolute left-5 top-5 inline-flex items-center gap-2 rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
+          <div className="absolute left-5 top-5 inline-flex max-w-[60%] items-center gap-2 truncate rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
             {catLabel(lieu.categorie)}
           </div>
           {lieu.recommandePar.length > 0 && (
@@ -75,13 +77,13 @@ export function LieuCard({ lieu, index = 0 }: Props) {
             </div>
           )}
         </div>
-        <div className="flex flex-col gap-3 p-6">
-          <h3 className="font-serif text-2xl font-light leading-tight text-vert">
+        <div className="flex flex-col gap-3 p-5 sm:p-6">
+          <h3 className="font-serif text-xl font-light leading-tight text-vert break-words sm:text-2xl">
             {lieu.nom}
           </h3>
-          <div className="flex items-center gap-2">
-            <span className="h-1 w-1 rounded-full bg-or" aria-hidden="true" />
-            <span className="text-[11px] font-medium text-texte-sec">{lieu.ville}</span>
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="h-1 w-1 shrink-0 rounded-full bg-or" aria-hidden="true" />
+            <span className="truncate text-[11px] font-medium text-texte-sec">{lieu.ville}</span>
           </div>
           {lieu.commentaires[0] && (
             <p className="mt-1 font-serif text-[13px] italic leading-[1.55] text-texte-sec line-clamp-3">

--- a/components/v2/PageHero.tsx
+++ b/components/v2/PageHero.tsx
@@ -11,14 +11,14 @@ interface PageHeroProps {
 
 export function PageHero({ number, kicker, titre, lead, children }: PageHeroProps) {
   return (
-    <section className="relative overflow-hidden bg-vert bg-grain pt-32 pb-16 md:pt-40 md:pb-20">
+    <section className="relative overflow-hidden bg-vert bg-grain pt-28 pb-12 sm:pt-32 sm:pb-16 md:pt-40 md:pb-20">
       <div
         aria-hidden="true"
         className="pointer-events-none absolute -right-40 top-10 h-[420px] w-[420px] rounded-full bg-or/10 blur-3xl"
       />
-      <div className="relative mx-auto max-w-container px-6 md:px-20">
-        <div className="flex items-center gap-5">
-          <span className="font-serif text-[44px] font-light leading-none text-or">
+      <div className="relative mx-auto max-w-container px-4 sm:px-6 md:px-20">
+        <div className="flex flex-wrap items-center gap-3 sm:gap-5">
+          <span className="font-serif text-[36px] font-light leading-none text-or sm:text-[44px]">
             {number}
           </span>
           <GoldLine width={60} />

--- a/components/v2/PrestataireCard.tsx
+++ b/components/v2/PrestataireCard.tsx
@@ -50,11 +50,11 @@ export function PrestataireCard({ p, index = 0 }: Props) {
             />
           )}
           <div className="absolute inset-0 bg-grain opacity-[0.08]" />
-          <div className="absolute left-5 top-5 inline-flex items-center gap-2 rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
+          <div className="absolute left-5 top-5 inline-flex max-w-[60%] items-center gap-2 truncate rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
             {categorieLabel(p.categorie)}
           </div>
           {p.lesAvis && p.lesAvis.length > 0 && (
-            <div className="absolute right-5 top-5 inline-flex items-center gap-1.5 rounded-full bg-vert/85 px-3 py-1 text-[11px] text-creme backdrop-blur">
+            <div className="absolute right-5 top-5 inline-flex shrink-0 items-center gap-1.5 rounded-full bg-vert/85 px-3 py-1 text-[11px] text-creme backdrop-blur">
               <span className="text-or">★</span>
               {p.note.toFixed(1)}
             </div>
@@ -68,23 +68,23 @@ export function PrestataireCard({ p, index = 0 }: Props) {
             </div>
           )}
         </div>
-        <div className="flex flex-1 flex-col gap-4 p-7">
+        <div className="flex flex-1 flex-col gap-4 p-6 sm:p-7">
           <div>
             <p className="text-[11px] tracking-[0.22em] text-or-deep uppercase">{p.metier}</p>
-            <h3 className="mt-2 font-serif text-[26px] font-light leading-tight text-vert">
+            <h3 className="mt-2 font-serif text-[22px] font-light leading-tight text-vert break-words sm:text-[26px]">
               {p.nom}
             </h3>
           </div>
-          <p className="font-serif text-[15px] italic leading-[1.5] text-texte-sec">
+          <p className="font-serif text-[15px] italic leading-[1.5] text-texte-sec break-words">
             « {p.tagline} »
           </p>
-          <div className="mt-auto flex items-center justify-between border-t border-or/10 pt-4">
-            <div className="flex items-center gap-2">
-              <span className="h-1 w-1 rounded-full bg-or" aria-hidden="true" />
-              <span className="text-[11px] font-medium text-texte-sec">{p.ville}</span>
+          <div className="mt-auto flex items-center justify-between gap-3 border-t border-or/10 pt-4">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="h-1 w-1 shrink-0 rounded-full bg-or" aria-hidden="true" />
+              <span className="truncate text-[11px] font-medium text-texte-sec">{p.ville}</span>
             </div>
             <span
-              className="inline-flex items-center gap-1.5 text-[11px] font-medium text-vert transition-all group-hover:text-or group-hover:gap-2.5"
+              className="inline-flex shrink-0 items-center gap-1.5 text-[11px] font-medium text-vert transition-all group-hover:gap-2.5 group-hover:text-or"
               aria-hidden="true"
             >
               Dès {p.tarifsDe} {p.ville === 'Paris' || p.ville === 'Lyon' || p.ville === 'Bruxelles' || p.ville === 'Luxembourg' ? '€' : 'CHF'}


### PR DESCRIPTION
## Quoi

10 fichiers touches, 100% CSS/Tailwind/JSX, zero changement de logique. Cible : rendre Hilmy correctement utilisable sur mobile (375px) et iPhone SE (320px).

### Changements
- **Navigation** : CTAs h-10 -> h-11 (44px tactile)
- **FiltersBar** :
  - Pills : py-1.5 (~26px) -> py-2 min-h-40px (mieux tactile)
  - Bouton reset : min-h-44px
  - Conteneur pills : flex-wrap -> overflow-x-auto avec snap-mandatory + scrollbar masquee sur mobile (desktop garde flex-wrap classique)
- **PageHero** : padding-top mobile reduit, container px-4, numero+kicker flex-wrap
- **HeroV2** : CTAs items-stretch + w-full sur mobile pour eviter overflow horizontal sur viewports etroits (reprend layout original >=sm)
- **PrestataireCard / EvenementCard / LieuCard** :
  - Badge categorie absolute : max-w-60% truncate pour eviter overlap avec badge note/date sur cartes longues
  - Titres : text-22 mobile -> text-26 sm+
  - Footer : justify-between + gap-3 + min-w-0 + truncate ville + shrink-0 prix/CTA
- **Pages /annuaire, /recommandations, /evenements-v2** : section padding mobile reduit, container px-4

## Pourquoi

Constat de Jiji : le site est brouillon sur tel. Avec 700 femmes cibles majoritairement sur mobile, c'est la chose la plus VISIBLE a fixer immediatement. Standards Apple/Google = 44px tactile minimum.

## Comment tester (verifications visibles)

1. Va sur https://hilmy.io depuis ton phone (ou Chrome DevTools mobile 375px)
2. Swipe ton doigt lateralement sur la home, /annuaire, /recommandations, /evenements-v2 : la page **NE DOIT PAS** scroller horizontalement
3. Sur /annuaire, les filtres categorie/ville scrollent horizontalement A L'INTERIEUR DE LEUR BARRE (pas la page entiere) avec snap doux
4. Les CTAs Rejoindre / Mon espace en haut a droite sont assez grands pour le pouce
5. Sur la home, les boutons hero "Rejoindre" et "Je suis prestataire" prennent toute la largeur sur mobile (full-width stack vertical), redeviennent inline sur tablet/desktop
6. Les cartes prestataires/lieux/evenements affichent 1 colonne sur mobile, 2 sur sm, 3 sur lg, sans badge qui se chevauche

## Risques

- Aucune touche : auth, Stripe, payment, data fetching, root layout, migrations SQL, RLS, branch protection
- Aucun fichier sous app/api/auth/, lib/auth/, ou .github/workflows/
- Build OK local (npm run build)
- Verifie en preview locale 375px ET 320px : zero scroll horizontal sur 5 pages testees

## Verdict

🟢 **SAFE** - Pure CSS/Tailwind, scope etroit, verifications visuelles passees, comportement desktop preserve.

→ **MERGE AUTO** apres CI vert.