### PR TITLE
fix(manifeste): cohérence promesses vs tarifs payants + mot interdit

### DIFF
--- a/app/manifeste/page.tsx
+++ b/app/manifeste/page.tsx
@@ -74,12 +74,12 @@ export default function ManifestePage() {
               </span>
               <div>
                 <p className="font-serif text-[18px] italic text-vert">
-                  Zéro commission.
+                  Pas de commission sur tes prestations.
                 </p>
                 <p className="mt-1 text-texte-sec">
-                  Les prestataires ne nous paient rien sur leurs prestations. Ce
-                  que tu paies va entièrement dans leur poche. Notre business
-                  model, c&apos;est elles — pas nous sur leur dos.
+                  Ta fiche prestataire fonctionne par abonnement plat (3
+                  formules dès 19€/mois). Ce que ta cliente te paie, tu le
+                  gardes en entier. On ne prend rien sur tes prestations.
                 </p>
               </div>
             </li>
@@ -89,12 +89,13 @@ export default function ManifestePage() {
               </span>
               <div>
                 <p className="font-serif text-[18px] italic text-vert">
-                  Zéro pub.
+                  Pas de pub tierce.
                 </p>
                 <p className="mt-1 text-texte-sec">
-                  Aucune fiche n&apos;est mise en avant contre argent. L&apos;algorithme,
-                  c&apos;est la qualité de la recommandation et la proximité
-                  géographique, rien d&apos;autre.
+                  Aucune marque extérieure ne s&apos;affiche dans le carnet.
+                  Les seules mises en avant sont éditoriales (Sélection Hilmy,
+                  Voix de la semaine) ou intégrées aux paliers prestataires —
+                  jamais d&apos;achat publicitaire externe.
                 </p>
               </div>
             </li>
@@ -107,7 +108,7 @@ export default function ManifestePage() {
                   Zéro compromis.
                 </p>
                 <p className="mt-1 text-texte-sec">
-                  Chaque fiche passe entre les mains de notre équipe avant
+                  Chaque fiche passe entre les mains de la team Hilmy avant
                   d&apos;être visible. Si ça ne tient pas la route, ça ne passe
                   pas. C&apos;est notre seul filtre, et il ne bougera pas.
                 </p>

--- a/components/landing/Manifesto.tsx
+++ b/components/landing/Manifesto.tsx
@@ -24,7 +24,7 @@ export function Manifesto() {
           </p>
         </FadeInSection>
         <FadeInSection delay={0.4}>
-          <p className="mt-12 text-xs tracking-[0.05em] text-or-light">— L'équipe Hilmy</p>
+          <p className="mt-12 text-xs tracking-[0.05em] text-or-light">— La team Hilmy</p>
         </FadeInSection>
       </div>
     </section>


### PR DESCRIPTION
## Quoi
Réécriture des 3 promesses du manifeste pour ne plus contredire frontalement /tarifs (3 paliers prestataires payants 19/49/99€/mois).

## Avant / Après

| # | Avant | Après |
|---|---|---|
| 01 | \"Zéro commission. Les prestataires ne nous paient rien sur leurs prestations.\" | \"Pas de commission sur tes prestations. Ta fiche prestataire fonctionne par abonnement plat (3 formules dès 19€/mois). Ce que ta cliente te paie, tu le gardes en entier.\" |
| 02 | \"Zéro pub. Aucune fiche n'est mise en avant contre argent.\" | \"Pas de pub tierce. Aucune marque extérieure. Mises en avant éditoriales (Sélection Hilmy, Voix de la semaine) ou intégrées aux paliers prestataires uniquement.\" |
| 03 | \"Zéro compromis. Chaque fiche passe entre les mains de notre équipe.\" | \"Zéro compromis. Chaque fiche passe entre les mains de la team Hilmy.\" (mot interdit \"notre équipe\" remplacé) |

Bonus : \`components/landing/Manifesto.tsx:27\` signature \"L'équipe Hilmy\" → \"La team Hilmy\" (visible sur la home).

## Pourquoi
Audit promesses vs réalité 2026-05-03 (PR #35) a identifié ces 3 promesses comme contradictoires avec /tarifs → risque pub mensongère CH/FR + rejet App Store. Cette PR ferme partiellement #25 (manifeste + Manifesto.tsx). 6 autres surfaces traitées dans PRs séparées.

## Comment tester
1. \`/manifeste\` : section \"Nos trois promesses\" affiche les 3 nouvelles formules
2. \`/\` : la section Manifesto en bas signe \"— La team Hilmy\"

## Risques
- Pure copy text, aucune logique touchée
- Build OK local (npm run build)
- Vérifié en preview 60389 : pas de mention \"L'équipe Hilmy\", \"notre équipe\", \"Zéro commission\", \"Les prestataires ne nous paient rien\" sur /manifeste ni /
- Footer newsletter \"Zéro pub, désabonnement en un clic\" conservé (légitime : la newsletter est sans pub tierce)

## Verdict
🟢 **SAFE** — copy text, pas de touche auth/Stripe/SQL. Merge auto.

Closes part of #25.