### PR TITLE
fix(signup): cohérence aside + onboarding prestataire vs /tarifs

### DIFF
--- a/components/auth/AuthShell.tsx
+++ b/components/auth/AuthShell.tsx
@@ -68,7 +68,7 @@ export function AuthShell({
 
           <div className="relative flex flex-wrap items-center justify-between gap-6 text-[11px] tracking-[0.22em] text-or uppercase">
             <span>Suisse · France · Belgique · Luxembourg · Monaco</span>
-            <span>Zéro commission · Zéro pub · Zéro compromis</span>
+            <span>Curation à la main · Pas de pub tierce · Entre copines</span>
           </div>
         </motion.aside>
 

--- a/components/onboarding/PrestataireMethodsClient.tsx
+++ b/components/onboarding/PrestataireMethodsClient.tsx
@@ -135,9 +135,16 @@ export function PrestataireMethodsClient() {
               }
               subtitle={
                 <>
-                  Ta fiche est complètement gratuite, sans commission. On te
-                  demande juste quelques infos et tu es en ligne. Les imports
-                  automatiques arriveront bientôt.
+                  Quelques infos et tu es prête à rejoindre la team. Trois
+                  formules d&apos;abonnement à partir de 19€/mois, sans
+                  commission sur tes prestations — le détail sur{' '}
+                  <a
+                    href="/tarifs"
+                    className="text-or-deep underline-offset-4 hover:text-or hover:underline"
+                  >
+                    /tarifs
+                  </a>
+                  . Les imports automatiques arriveront bientôt.
                 </>
               }
             />


### PR DESCRIPTION
## Quoi
2 fixes de copy dans le funnel d'inscription pour ne plus dire \"gratuit / sans commission\" alors que /tarifs vend 3 paliers payants 19/49/99€/mois.

## Avant / Après

### 1. \`components/auth/AuthShell.tsx\` ligne 71 (aside marketing signup/login)
- **AVANT** : \"Zéro commission · Zéro pub · Zéro compromis\"
- **APRÈS** : \"Curation à la main · Pas de pub tierce · Entre copines\"
- Pourquoi : reformulation honnête qui marche pour les deux types de comptes (utilisatrices ET prestataires).

### 2. \`components/onboarding/PrestataireMethodsClient.tsx\` ligne 138 (subtitle écran \"Comment veux-tu créer ta fiche ?\")
- **AVANT** : \"Ta fiche est complètement gratuite, sans commission. On te demande juste quelques infos et tu es en ligne. Les imports automatiques arriveront bientôt.\"
- **APRÈS** : \"Quelques infos et tu es prête à rejoindre la team. Trois formules d'abonnement à partir de 19€/mois, sans commission sur tes prestations — le détail sur [/tarifs](/tarifs). Les imports automatiques arriveront bientôt.\"
- Pourquoi : distinction claire abonnement (oui) vs commission sur prestations (non), avec lien direct vers /tarifs.

## Pourquoi
Audit PR #35 a identifié ces 2 surfaces comme contradictions actives dans le funnel d'inscription (issue #25).

## Comment tester
- Build OK local (npm run build)
- AuthShell : preview HTML \`/auth/signup\` confirme nouvelle copy présente, ancienne disparue (aside lg:flex masqué sur petits écrans, normal)
- PrestataireMethodsClient : page protégée auth, validation par build (redirect /auth/login sans session)

## Risques
- Pure copy text dans 2 composants client
- Pas de touche auth/Stripe/SQL
- Pas de modification de logique

## Verdict
🟢 **SAFE** — copy text uniquement. Merge auto.

Closes part of #25.