### PR TITLE
feat(palier): limites photos par palier (Standard 5 / Premium 20 / Cercle Pro illimité)

### DIFF
--- a/app/dashboard/prestataire/fiche/page.tsx
+++ b/app/dashboard/prestataire/fiche/page.tsx
@@ -7,6 +7,12 @@ import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
 import { GoldLine } from '@/components/ui/GoldLine'
 import { createClient } from '@/lib/supabase/client'
 import { CATEGORIES_MAP } from '@/lib/constants'
+import {
+  PHOTO_LIMIT,
+  canUploadMorePhotos,
+  photoCountLabel,
+} from '@/lib/palier-limits'
+import type { Palier } from '@/app/tarifs/_lib/pricing'
 
 type Service = { nom: string; prix: string; duree: string }
 
@@ -43,6 +49,7 @@ export default function MaFichePage() {
   const [userId, setUserId] = useState<string | null>(null)
   const [profileId, setProfileId] = useState<string | null>(null)
   const [status, setStatus] = useState<string>('pending')
+  const [palier, setPalier] = useState<Palier>('standard')
   const [noteMoy, setNoteMoy] = useState(0)
   const [nbAvis, setNbAvis] = useState(0)
   const [editing, setEditing] = useState(false)
@@ -102,6 +109,13 @@ export default function MaFichePage() {
 
       setProfileId(data.id)
       setStatus(data.status)
+      setPalier(
+        data.palier === 'premium'
+          ? 'premium'
+          : data.palier === 'cercle_pro'
+            ? 'cercle_pro'
+            : 'standard',
+      )
       setNoteMoy(data.note_moyenne ?? 0)
       setNbAvis(data.nb_avis ?? 0)
       setDraft({
@@ -172,6 +186,15 @@ export default function MaFichePage() {
 
   const handlePhoto = async (file: File) => {
     if (!userId || !profileId) return
+    if (!canUploadMorePhotos(palier, draft.galerie.length)) {
+      const limit = PHOTO_LIMIT[palier]
+      setError(
+        limit !== null
+          ? `Limite atteinte (${limit} photos pour le palier ${palier === 'standard' ? 'Standard' : 'Premium'}). Passe au palier supérieur depuis /tarifs pour en ajouter plus.`
+          : 'Limite atteinte.',
+      )
+      return
+    }
     if (file.size > 5 * 1024 * 1024) {
       setError('Chaque photo doit faire moins de 5 Mo.')
       return
@@ -576,14 +599,22 @@ export default function MaFichePage() {
                 <Group
                   kicker="Galerie"
                   action={
-                    <button
-                      type="button"
-                      onClick={() => fileInputRef.current?.click()}
-                      disabled={uploading}
-                      className="text-[11px] tracking-[0.22em] text-or uppercase hover:text-or-deep disabled:opacity-60"
-                    >
-                      {uploading ? 'Envoi…' : '+ Ajouter'}
-                    </button>
+                    <div className="flex items-center gap-3">
+                      <span className="text-[11px] tracking-[0.22em] text-texte-sec uppercase">
+                        {photoCountLabel(palier, draft.galerie.length)}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={
+                          uploading ||
+                          !canUploadMorePhotos(palier, draft.galerie.length)
+                        }
+                        className="text-[11px] tracking-[0.22em] text-or uppercase hover:text-or-deep disabled:opacity-60"
+                      >
+                        {uploading ? 'Envoi…' : '+ Ajouter'}
+                      </button>
+                    </div>
                   }
                 >
                   <input

--- a/lib/palier-limits.ts
+++ b/lib/palier-limits.ts
@@ -1,0 +1,47 @@
+/**
+ * Limites quantitatives par palier prestataire.
+ * Single source of truth — alignée avec PALIER_INFO.features dans
+ * app/tarifs/_lib/pricing.ts.
+ *
+ * Quand on change ces valeurs, mettre à jour aussi :
+ *  - app/tarifs/_lib/pricing.ts (libellés des features)
+ *  - components/v2/PalierBadge.tsx (badges)
+ */
+
+import type { Palier } from '@/app/tarifs/_lib/pricing'
+
+/**
+ * Nombre maximum de photos dans la galerie prestataire selon le palier.
+ * - Standard : 5 photos (essentiel pour démarrer)
+ * - Premium : 20 photos (raconter en détail)
+ * - Cercle Pro : illimité (matérialisé par null)
+ */
+export const PHOTO_LIMIT: Record<Palier, number | null> = {
+  standard: 5,
+  premium: 20,
+  cercle_pro: null,
+}
+
+/**
+ * Helper boolean : la prestataire peut-elle ajouter une nouvelle photo ?
+ * Retourne true si le palier est illimité OU si le compteur est sous la limite.
+ */
+export function canUploadMorePhotos(
+  palier: Palier,
+  currentCount: number,
+): boolean {
+  const limit = PHOTO_LIMIT[palier]
+  if (limit === null) return true
+  return currentCount < limit
+}
+
+/**
+ * Libellé compteur affiché dans l'UI ("3 / 5 photos" ou "12 photos · illimité").
+ */
+export function photoCountLabel(palier: Palier, currentCount: number): string {
+  const limit = PHOTO_LIMIT[palier]
+  if (limit === null) {
+    return `${currentCount} photo${currentCount > 1 ? 's' : ''} · illimité`
+  }
+  return `${currentCount} / ${limit} photos`
+}


### PR DESCRIPTION
## Quoi
Implémente la promesse /tarifs Premium \"20 photos\" et Cercle Pro \"Photos illimitées\" qui n'était pas enforced backend ni client (audit PR #35, issue #30).

## Avant / Après

**AVANT** : aucune limite côté code, prestataires Standard pouvaient uploader autant qu'elles voulaient.

**APRÈS** :
| Palier | Limite | Affichage |
|---|---|---|
| Standard | 5 photos | \`3 / 5 photos\` |
| Premium | 20 photos | \`12 / 20 photos\` |
| Cercle Pro | illimité | \`14 photos · illimité\` |

Bouton \"+ Ajouter\" disabled visuellement quand limite atteinte. Tentative d'upload au-delà = message d'erreur explicite avec invitation à upgrade.

## Architecture
- Nouveau \`lib/palier-limits.ts\` (single source of truth) :
  - \`PHOTO_LIMIT: Record<Palier, number | null>\` (null = illimité)
  - \`canUploadMorePhotos(palier, currentCount)\` boolean helper
  - \`photoCountLabel(palier, currentCount)\` libellé UI
- Intégration dans \`app/dashboard/prestataire/fiche/page.tsx\` (lecture \`data.palier\` au load + check dans \`handlePhoto\`)
- Réutilise le type \`Palier\` depuis \`app/tarifs/_lib/pricing.ts\` (cohérence avec /tarifs)

## Comment tester
1. Connexion prestataire palier Standard → tu vois \`X / 5 photos\` à côté du bouton Ajouter
2. À 5 photos, le bouton est grisé + tentative drag-drop affiche message d'erreur
3. Idem palier Premium plafonné à 20
4. Palier Cercle Pro : compteur \`X photos · illimité\`, bouton jamais grisé

## Risques
- Pas de touche auth/Stripe/SQL/data fetching
- Server Action `update profiles` inchangée (la limite est purement côté client + UX)
- Aucune migration nécessaire
- Build OK local
- Page protégée par auth, pas testable en preview locale sans session prestataire

## Verdict
🟢 **SAFE** — pure logique client + UI. Merge auto.

Closes part of #30.