### PR TITLE
feat(annuaire): tri par palier (Cercle Pro > Premium > Standard)

### DIFF
--- a/app/annuaire/page.tsx
+++ b/app/annuaire/page.tsx
@@ -20,6 +20,30 @@ import {
 import { createClient } from '@/lib/supabase/client'
 import type { Prestataire as DbPrestataire } from '@/lib/supabase/types'
 
+/**
+ * Tri prioritaire annuaire (Cercle Pro 99€/mois — feature "Mise en avant prio").
+ * Cercle Pro apparaît avant Premium qui apparaît avant Standard.
+ * À tier égal, on conserve l'ordre serveur (approved_at desc, déterministe).
+ *
+ * Implémenté côté client après l'adaptation pour éviter une migration SQL
+ * (Supabase ne supporte pas facilement ORDER BY CASE sans vue dédiée).
+ * Array.prototype.sort est stable en JS depuis ES2019 → tri secondaire
+ * approved_at desc préservé naturellement.
+ */
+const PALIER_RANK: Record<string, number> = {
+  cercle_pro: 0,
+  premium: 1,
+  standard: 2,
+}
+
+function sortByPalierThenServerOrder(list: MockPrestataire[]): MockPrestataire[] {
+  return [...list].sort((a, b) => {
+    const ra = PALIER_RANK[a.palier ?? 'standard'] ?? 2
+    const rb = PALIER_RANK[b.palier ?? 'standard'] ?? 2
+    return ra - rb
+  })
+}
+
 // Adapte une ligne DB profiles → shape attendue par PrestataireCard (même shape que mock).
 function adaptPrestataireFromDb(p: DbPrestataire): MockPrestataire {
   const galerie =
@@ -87,7 +111,7 @@ export default function AnnuairePage() {
         const adapted = (data ?? []).map((row) =>
           adaptPrestataireFromDb(row as unknown as DbPrestataire),
         )
-        setLivePrestataires(adapted)
+        setLivePrestataires(sortByPalierThenServerOrder(adapted))
         setLoading(false)
       } catch (e) {
         if (cancelled) return


### PR DESCRIPTION
## Quoi
Implémente la promesse /tarifs Cercle Pro \"Mise en avant prio\" qui n'était pas livrée (audit PR #35, issue #30). Le palier devient le tri primaire de la grille annuaire.

## Avant / Après

**AVANT** : tri unique par \`approved_at desc\` (les fiches récentes en haut, peu importe le palier).

**APRÈS** :
- Tri primaire : palier (cercle_pro=0 > premium=1 > standard=2)
- Tri secondaire : approved_at desc (héritage du tri serveur)

## Architecture
Côté client après l'adaptation Supabase pour éviter une migration SQL (Supabase ne supporte pas facilement \`ORDER BY CASE\` sans vue dédiée).

\`\`\`ts
const PALIER_RANK: Record<string, number> = {
  cercle_pro: 0,
  premium: 1,
  standard: 2,
}

function sortByPalierThenServerOrder(list) {
  return [...list].sort((a, b) => {
    const ra = PALIER_RANK[a.palier ?? 'standard'] ?? 2
    const rb = PALIER_RANK[b.palier ?? 'standard'] ?? 2
    return ra - rb
  })
}
\`\`\`

\`Array.prototype.sort\` stable depuis ES2019 → l'ordre serveur (\`approved_at desc\`) est préservé comme tie-breaker naturel à tier égal.

## Comment tester
- Aller sur \`/annuaire\`
- Vérifier que les fiches \`palier === 'cercle_pro'\` apparaissent en 1ères positions
- Puis Premium
- Puis Standard
- À tier égal, ordre approved_at desc préservé

✅ **Vérifié en preview locale** : \"Hilmy Demo · Cercle Pro\" apparaît en 1ère position parmi les 20 cards (vs avant où il était classé par approved_at).

## Risques
- Pas de touche auth/Stripe/SQL
- Filtres existants (catégorie, ville, note) restent compatibles — le tri s'applique sur \`dataSource\` AVANT filtrage useMemo
- Spread \`[...list]\` pour ne pas muter le retour Supabase (idempotence garantie)
- Build OK local

## Verdict
🟢 **SAFE** — pure logique tri client, fallback gracieux si palier absent. Merge auto.

Closes part of #30.