### PR TITLE
fix(contact): hilmy.io@hotmail.com → hello@hilmy.io (2 occurrences)

### DIFF
--- a/app/tarifs/_lib/pricing.ts
+++ b/app/tarifs/_lib/pricing.ts
@@ -138,7 +138,7 @@ export function formatPrice(value: number): string {
     : `${value.toFixed(2).replace('.', ',')}€`;
 }
 
-const HELLO = 'hilmy.io@hotmail.com';
+const HELLO = 'hello@hilmy.io';
 
 /** Mailto pour les CTAs de commit prestataires (post-wizard ou switch). */
 export function buildMailtoPalier(palier: Palier, duree: Duree): string {

--- a/app/tarifs/page.tsx
+++ b/app/tarifs/page.tsx
@@ -367,7 +367,7 @@ export default function TarifsPage() {
                 Choisir ma formule
               </a>
               <a
-                href="mailto:hilmy.io@hotmail.com"
+                href="mailto:hello@hilmy.io"
                 className="inline-block rounded-full border border-vert bg-transparent px-8 py-4 text-[15px] font-medium text-vert transition-all hover:bg-vert hover:text-creme"
               >
                 Poser ma question


### PR DESCRIPTION
## Quoi
Remplace les 2 dernières occurrences de \`hilmy.io@hotmail.com\` par \`hello@hilmy.io\` dans le repo.

## Avant / Après

| Fichier | Avant | Après |
|---|---|---|
| \`app/tarifs/_lib/pricing.ts:141\` | \`const HELLO = 'hilmy.io@hotmail.com'\` | \`const HELLO = 'hello@hilmy.io'\` |
| \`app/tarifs/page.tsx:370\` | \`href=\"mailto:hilmy.io@hotmail.com\"\` (CTA \"Poser ma question\") | \`href=\"mailto:hello@hilmy.io\"\` |

Impact : tous les CTAs commit pricing (prestataires \`buildMailtoPalier\` + lieu Sélection Hilmy \`buildMailtoLieu\` + \"Poser ma question\" FAQ) pointent maintenant vers \`hello@hilmy.io\`.

## Pourquoi
Issue audit #32 hygiène tech. Email business hotmail = signal faiblement professionnel pour 19/49/99€/mois. \`hello@hilmy.io\` est déjà utilisé partout ailleurs (mentions légales, privacy, dashboard abonnement, FAQ).

## Comment tester
- Aller sur \`/tarifs\`
- Cliquer un CTA \"Je choisis cette formule\" / \"Je veux ma fiche\" / \"Poser ma question\"
- Le mailto doit s'ouvrir vers \`hello@hilmy.io\`

✅ **Vérifié en preview locale** : 0 occurrence hotmail dans le HTML, tous les mailtos pointent vers \`hello@hilmy.io\`.

## Risques
- Pure remplacement string (2 lignes)
- Pas de touche auth/Stripe/SQL
- Build OK local
- Vérifier que la boîte \`hello@hilmy.io\` est bien monitorée — sinon les CTAs commit pricing tombent dans le vide. À confirmer côté Jiji avant Stripe (ou rediriger \`hello@\` vers \`hilmy.io@hotmail.com\` au niveau provider mail le temps que tout soit setup).

## Verdict
🟢 **SAFE** — string replacement. Merge auto.

Closes part of #32.