### PR TITLE
feat(promo): code COPINE10 -10% Premium + UI tarifs + migration 35

### DIFF
--- a/app/tarifs/_components/WizardSection.tsx
+++ b/app/tarifs/_components/WizardSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   PRICING,
   PALIER_INFO,
@@ -11,6 +11,13 @@ import {
   type Palier,
   type Duree,
 } from '../_lib/pricing'
+import { createClient } from '@/lib/supabase/client'
+import {
+  applyDiscount,
+  promoErrorMessage,
+  validatePromoCode,
+  type PromoCodeRow,
+} from '@/lib/promo-codes'
 
 type WizardKey = 'standard' | 'premium' | 'cercle_pro'
 
@@ -116,6 +123,68 @@ export function WizardSection() {
   const [palier, setPalier] = useState<Palier>('premium')
   const [duree, setDuree] = useState<Duree>(1)
 
+  // Code promo (validation Supabase + recalcul prix)
+  const [promoInput, setPromoInput] = useState('')
+  const [promoStatus, setPromoStatus] = useState<
+    'idle' | 'checking' | 'valid' | 'invalid'
+  >('idle')
+  const [promoMessage, setPromoMessage] = useState<string | null>(null)
+  const [appliedPromo, setAppliedPromo] = useState<PromoCodeRow | null>(null)
+
+  // Reset le code si l'utilisatrice change de palier (le code peut ne plus être éligible)
+  useEffect(() => {
+    if (!appliedPromo) return
+    const check = validatePromoCode(appliedPromo, palier)
+    if (!check.ok) {
+      setAppliedPromo(null)
+      setPromoStatus('invalid')
+      setPromoMessage(
+        promoErrorMessage(check.reason, PALIER_INFO[palier].name),
+      )
+    }
+  }, [palier, appliedPromo])
+
+  const handleApplyPromo = async () => {
+    const trimmed = promoInput.trim()
+    if (!trimmed) return
+    setPromoStatus('checking')
+    setPromoMessage(null)
+    try {
+      const supabase = createClient()
+      const { data } = await supabase
+        .from('promo_codes')
+        .select('id, code, discount_pct, applies_to_palier, valid_from, valid_until, max_uses, current_uses, active')
+        .ilike('code', trimmed)
+        .maybeSingle()
+
+      const result = validatePromoCode(data as PromoCodeRow | null, palier)
+      if (result.ok) {
+        setAppliedPromo(result.code)
+        setPromoStatus('valid')
+        setPromoMessage(
+          `Code «${result.code.code}» appliqué : -${result.code.discount_pct}%.`,
+        )
+      } else {
+        setAppliedPromo(null)
+        setPromoStatus('invalid')
+        setPromoMessage(
+          promoErrorMessage(result.reason, PALIER_INFO[palier].name),
+        )
+      }
+    } catch {
+      setAppliedPromo(null)
+      setPromoStatus('invalid')
+      setPromoMessage('Petit pépin réseau. Réessaie dans un instant.')
+    }
+  }
+
+  const handleClearPromo = () => {
+    setAppliedPromo(null)
+    setPromoInput('')
+    setPromoStatus('idle')
+    setPromoMessage(null)
+  }
+
   const handleSelect = (step: 1 | 2 | 3, value: WizardKey) => {
     const nextAnswers = { ...answers, [step]: value }
     setAnswers(nextAnswers)
@@ -152,11 +221,15 @@ export function WizardSection() {
 
   const info = PALIER_INFO[palier]
   const price = PRICING[palier][duree]
+  const discountPct = appliedPromo?.discount_pct ?? 0
+  const monthlyAfterDiscount = applyDiscount(price.m, discountPct)
+  const totalAfterDiscount =
+    price.t !== null ? applyDiscount(price.t, discountPct) : null
   const totalLine =
-    price.t !== null
-      ? `Soit ${price.t}€ ${DUREE_PERIODE[duree]}`.trim()
+    totalAfterDiscount !== null
+      ? `Soit ${formatPrice(totalAfterDiscount)} ${DUREE_PERIODE[duree]}`.trim()
       : ''
-  const mailto = buildMailtoPalier(palier, duree)
+  const mailto = buildMailtoPalier(palier, duree, appliedPromo?.code ?? null)
 
   return (
     <div className="mx-auto max-w-[1200px] px-6 md:px-20">
@@ -308,13 +381,33 @@ export function WizardSection() {
                 {info.tagline}
               </p>
               <div className="mb-7 border-b border-or/25 pb-7">
-                <span className="font-serif text-[60px] font-light leading-none text-creme">
-                  {formatPrice(price.m)}
-                </span>
-                <span className="ml-1.5 text-sm text-or-light">/mois</span>
+                {appliedPromo ? (
+                  <div className="flex items-baseline gap-3">
+                    <span className="font-serif text-[60px] font-light leading-none text-creme">
+                      {formatPrice(monthlyAfterDiscount)}
+                    </span>
+                    <span className="text-sm text-or-light line-through opacity-70">
+                      {formatPrice(price.m)}
+                    </span>
+                    <span className="ml-1.5 text-sm text-or-light">/mois</span>
+                  </div>
+                ) : (
+                  <>
+                    <span className="font-serif text-[60px] font-light leading-none text-creme">
+                      {formatPrice(price.m)}
+                    </span>
+                    <span className="ml-1.5 text-sm text-or-light">/mois</span>
+                  </>
+                )}
                 <p className="mt-2 min-h-[18px] text-[13px] text-or-light">
                   {totalLine}
                 </p>
+                {appliedPromo && (
+                  <p className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-or/15 px-3 py-1 text-[11px] font-medium tracking-[0.18em] text-or uppercase">
+                    <span aria-hidden>✓</span>
+                    Code «{appliedPromo.code}» −{appliedPromo.discount_pct}%
+                  </p>
+                )}
               </div>
               <ul className="mb-8 space-y-1.5">
                 {info.features.map((f) => (
@@ -326,10 +419,84 @@ export function WizardSection() {
                   </li>
                 ))}
               </ul>
+              {/* Champ code promo "J'ai un code copine" */}
+              <div className="mb-5">
+                {!appliedPromo ? (
+                  <details className="group">
+                    <summary className="cursor-pointer list-none text-[12px] font-medium text-or-light transition-colors hover:text-or">
+                      <span className="border-b border-or-light/40 pb-0.5 group-open:hidden">
+                        + J&apos;ai un code copine
+                      </span>
+                      <span className="hidden border-b border-or-light/40 pb-0.5 group-open:inline">
+                        − Masquer le champ
+                      </span>
+                    </summary>
+                    <div className="mt-3 flex gap-2">
+                      <label className="sr-only" htmlFor="promo-input">
+                        Code copine
+                      </label>
+                      <input
+                        id="promo-input"
+                        type="text"
+                        autoCapitalize="characters"
+                        spellCheck={false}
+                        value={promoInput}
+                        onChange={(e) => setPromoInput(e.target.value)}
+                        placeholder="COPINE10"
+                        disabled={promoStatus === 'checking'}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault()
+                            handleApplyPromo()
+                          }
+                        }}
+                        className="flex-1 rounded-full border border-or/30 bg-vert-dark/40 px-4 py-2.5 text-[13px] uppercase tracking-[0.12em] text-creme placeholder:text-creme/40 placeholder:tracking-[0.18em] focus:border-or focus:outline-none focus:ring-1 focus:ring-or"
+                      />
+                      <button
+                        type="button"
+                        onClick={handleApplyPromo}
+                        disabled={
+                          promoStatus === 'checking' || promoInput.trim() === ''
+                        }
+                        className="rounded-full border border-or px-4 py-2.5 text-[11px] font-medium tracking-[0.22em] text-or uppercase transition-all hover:bg-or hover:text-vert disabled:opacity-50"
+                      >
+                        {promoStatus === 'checking' ? 'Vérif…' : 'Appliquer'}
+                      </button>
+                    </div>
+                    {promoMessage && (
+                      <p
+                        role="status"
+                        aria-live="polite"
+                        className={`mt-2 text-[12px] ${
+                          promoStatus === 'invalid'
+                            ? 'text-red-200'
+                            : 'text-or-light'
+                        }`}
+                      >
+                        {promoMessage}
+                      </p>
+                    )}
+                  </details>
+                ) : (
+                  <div className="flex items-center justify-between gap-3 rounded-full border border-or/40 bg-or/10 px-4 py-2.5">
+                    <span className="text-[12px] text-or-light">
+                      ✓ {promoMessage}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={handleClearPromo}
+                      className="text-[11px] tracking-[0.22em] text-or-light/80 uppercase transition-colors hover:text-or"
+                    >
+                      Retirer
+                    </button>
+                  </div>
+                )}
+              </div>
+
               <a
                 href={mailto}
                 className="block w-full rounded-full bg-or px-8 py-4 text-center text-[15px] font-semibold text-vert transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)]"
-                aria-label={`Choisir la formule ${info.name} (${formatPrice(price.m)} par mois)`}
+                aria-label={`Choisir la formule ${info.name} (${formatPrice(monthlyAfterDiscount)} par mois)`}
               >
                 Je choisis cette formule
               </a>

--- a/app/tarifs/_lib/pricing.ts
+++ b/app/tarifs/_lib/pricing.ts
@@ -140,11 +140,21 @@ export function formatPrice(value: number): string {
 
 const HELLO = 'hello@hilmy.io';
 
-/** Mailto pour les CTAs de commit prestataires (post-wizard ou switch). */
-export function buildMailtoPalier(palier: Palier, duree: Duree): string {
+/** Mailto pour les CTAs de commit prestataires (post-wizard ou switch).
+ *  Si un `promoCode` est fourni (validé côté client en amont), il est
+ *  injecté dans le body pour que la team Hilmy puisse l'appliquer
+ *  manuellement le temps que Stripe LIVE soit branché. */
+export function buildMailtoPalier(
+  palier: Palier,
+  duree: Duree,
+  promoCode?: string | null,
+): string {
   const name = PALIER_INFO[palier].name;
   const subject = `Je veux rejoindre la team Hilmy — ${name}`;
-  const body = `Bonjour, je suis intéressée par la formule ${name} pour ${DUREE_LABEL[duree]}.`;
+  const promoLine = promoCode
+    ? `\n\nCode promo : ${promoCode}`
+    : '';
+  const body = `Bonjour, je suis intéressée par la formule ${name} pour ${DUREE_LABEL[duree]}.${promoLine}`;
   return `mailto:${HELLO}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
 }
 

--- a/lib/promo-codes.ts
+++ b/lib/promo-codes.ts
@@ -1,0 +1,87 @@
+/**
+ * Validation des codes promo côté client (saisie /tarifs) et côté serveur
+ * (server action avant redirection Stripe).
+ *
+ * Source de vérité : table public.promo_codes (migration 35).
+ * Policy RLS SELECT public n'expose que les codes ACTIFS et valides
+ * dans la fenêtre temporelle, donc l'absence de retour = code invalide
+ * (sans révéler si c'est faute de frappe ou code expiré).
+ *
+ * Compatible Stripe Coupons : quand Stripe LIVE sera actif, ajouter une
+ * colonne stripe_coupon_id sur promo_codes et un mapping ici pour
+ * passer le coupon_id à Stripe Checkout au lieu de calculer le discount
+ * côté Hilmy.
+ */
+
+import type { Palier } from '@/app/tarifs/_lib/pricing'
+
+export interface PromoCodeRow {
+  id: string
+  code: string
+  discount_pct: number
+  applies_to_palier: 'standard' | 'premium' | 'cercle_pro' | 'all'
+  valid_from: string
+  valid_until: string | null
+  max_uses: number | null
+  current_uses: number
+  active: boolean
+}
+
+export type ValidatePromoResult =
+  | { ok: true; code: PromoCodeRow }
+  | { ok: false; reason: 'not_found' | 'wrong_palier' | 'max_uses_reached' }
+
+/**
+ * Vérifie qu'un code promo s'applique au palier demandé et n'a pas atteint
+ * son quota. Retourne un statut typé pour permettre des messages UX précis.
+ *
+ * À appeler après le SELECT Supabase (qui filtre déjà active + temporel
+ * grâce à la policy RLS).
+ */
+export function validatePromoCode(
+  code: PromoCodeRow | null,
+  palier: Palier,
+): ValidatePromoResult {
+  if (!code) return { ok: false, reason: 'not_found' }
+
+  if (
+    code.applies_to_palier !== 'all' &&
+    code.applies_to_palier !== palier
+  ) {
+    return { ok: false, reason: 'wrong_palier' }
+  }
+
+  if (code.max_uses !== null && code.current_uses >= code.max_uses) {
+    return { ok: false, reason: 'max_uses_reached' }
+  }
+
+  return { ok: true, code }
+}
+
+/**
+ * Calcule le prix après remise (arrondi 2 décimales).
+ */
+export function applyDiscount(price: number, discountPct: number): number {
+  if (discountPct <= 0) return price
+  if (discountPct >= 100) return 0
+  const factor = (100 - discountPct) / 100
+  return Math.round(price * factor * 100) / 100
+}
+
+/**
+ * Message UX standardisé pour chaque cas d'invalidité.
+ * Voix Sara : tutoiement, ton copine, pas corporate.
+ */
+export function promoErrorMessage(
+  reason: Exclude<ValidatePromoResult, { ok: true }>['reason'],
+  palierLabel: string,
+): string {
+  switch (reason) {
+    case 'not_found':
+      return "Ce code n'existe pas ou n'est plus valide. Re-vérifie la frappe."
+    case 'wrong_palier':
+      return `Ce code n'est pas applicable au palier ${palierLabel}.`
+    case 'max_uses_reached':
+      return 'Ce code a atteint sa limite de copines. Désolée !'
+  }
+}

--- a/supabase/migrations/35_promo_codes.sql
+++ b/supabase/migrations/35_promo_codes.sql
@@ -1,0 +1,115 @@
+-- =====================================================================
+-- HILMY · 35 — Codes promo (Premium "-10% pour les Copines")
+-- Idempotent.
+--
+-- Table publique en READ ONLY pour le client (validation d'un code saisi
+-- au moment du commit pricing). Seul le service-role peut INSERT/UPDATE
+-- (création de codes par admin).
+--
+-- Le seed initial crée le code "COPINE10" -10% pour les abonnements
+-- Premium uniquement, valide 1 an, sans limite d'usages.
+--
+-- ⚠️ Structure compatible Stripe Coupons : quand Stripe LIVE sera actif,
+-- chaque code sera répliqué côté Stripe (stripe_coupon_id à ajouter).
+--
+-- ATTENTION : ne pas exécuter en prod sans validation Jiji.
+-- Exécuter via : bash scripts/run-migration.sh 35_promo_codes.sql
+-- =====================================================================
+
+-- ─── Table promo_codes ───────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.promo_codes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  code TEXT NOT NULL,
+  discount_pct INTEGER NOT NULL CHECK (discount_pct > 0 AND discount_pct <= 100),
+  applies_to_palier TEXT NOT NULL CHECK (
+    applies_to_palier IN ('standard', 'premium', 'cercle_pro', 'all')
+  ),
+  valid_from TIMESTAMPTZ NOT NULL DEFAULT now(),
+  valid_until TIMESTAMPTZ,
+  max_uses INTEGER,
+  current_uses INTEGER NOT NULL DEFAULT 0,
+  active BOOLEAN NOT NULL DEFAULT true,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Code unique (case-insensitive)
+CREATE UNIQUE INDEX IF NOT EXISTS promo_codes_code_unique_idx
+  ON public.promo_codes (LOWER(code));
+
+CREATE INDEX IF NOT EXISTS promo_codes_active_idx
+  ON public.promo_codes (active, valid_until);
+
+COMMENT ON TABLE public.promo_codes IS
+  'Codes promo applicables aux abonnements prestataires. Compatible Stripe Coupons.';
+COMMENT ON COLUMN public.promo_codes.applies_to_palier IS
+  'Palier(s) éligible(s) : standard | premium | cercle_pro | all (tous).';
+COMMENT ON COLUMN public.promo_codes.max_uses IS
+  'NULL = illimité.';
+COMMENT ON COLUMN public.promo_codes.current_uses IS
+  'Incrementé via server-side trigger ou server action lors d''une souscription validée.';
+
+-- ─── Trigger updated_at ──────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.bump_promo_codes_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS promo_codes_updated_at_trg ON public.promo_codes;
+CREATE TRIGGER promo_codes_updated_at_trg
+  BEFORE UPDATE ON public.promo_codes
+  FOR EACH ROW EXECUTE FUNCTION public.bump_promo_codes_updated_at();
+
+-- ─── RLS ─────────────────────────────────────────────────────────────
+ALTER TABLE public.promo_codes ENABLE ROW LEVEL SECURITY;
+
+-- READ : tout le monde peut lire les codes ACTIFS et valides (validation
+-- côté tarifs). On ne révèle pas les codes inactifs ou expirés.
+DROP POLICY IF EXISTS "promo_codes_public_read_active" ON public.promo_codes;
+CREATE POLICY "promo_codes_public_read_active"
+  ON public.promo_codes
+  FOR SELECT
+  USING (
+    active = true
+    AND (valid_until IS NULL OR valid_until > now())
+    AND valid_from <= now()
+  );
+
+-- WRITE : aucune policy → seul le service-role (admin) peut créer/modifier.
+-- Le current_uses sera incrémenté par une server action côté admin
+-- quand Stripe webhook confirme une souscription.
+
+-- ─── Seed : code COPINE10 ─────────────────────────────────────────────
+-- -10% sur les abonnements Premium uniquement, valide 1 an, illimité.
+INSERT INTO public.promo_codes (code, discount_pct, applies_to_palier, valid_until, max_uses, notes)
+VALUES (
+  'COPINE10',
+  10,
+  'premium',
+  now() + INTERVAL '1 year',
+  NULL,
+  'Code "Pour les Copines" — promesse Premium /tarifs. Valide 1 an, illimité.'
+)
+ON CONFLICT ((LOWER(code))) DO UPDATE
+  SET discount_pct = EXCLUDED.discount_pct,
+      applies_to_palier = EXCLUDED.applies_to_palier,
+      valid_until = EXCLUDED.valid_until,
+      max_uses = EXCLUDED.max_uses,
+      active = true,
+      notes = EXCLUDED.notes;
+
+-- ─── Reload PostgREST schema cache ───────────────────────────────────
+NOTIFY pgrst, 'reload schema';
+
+-- =====================================================================
+-- ROLLBACK
+-- =====================================================================
+-- DROP POLICY IF EXISTS "promo_codes_public_read_active" ON public.promo_codes;
+-- DROP TRIGGER IF EXISTS promo_codes_updated_at_trg ON public.promo_codes;
+-- DROP FUNCTION IF EXISTS public.bump_promo_codes_updated_at();
+-- DROP TABLE IF EXISTS public.promo_codes;
+-- =====================================================================


### PR DESCRIPTION
## Quoi
Implémente la promesse Premium \"-10% pour les Copines\" via un système de codes promo générique compatible Stripe.

## Architecture

### Migration 35 (à exécuter Jiji avant merge)
- Table \`promo_codes\` avec contraintes (discount_pct 1-100, palier valide)
- UNIQUE INDEX case-insensitive sur \`code\`
- RLS : SELECT public limité aux codes actifs et valides temporellement
- Trigger updated_at
- Seed : code \`COPINE10\` -10% Premium, valide 1 an, illimité

### Module \`lib/promo-codes.ts\`
- \`validatePromoCode(row, palier)\` → \`{ ok, code }\` ou \`{ ok: false, reason }\`
- \`applyDiscount(price, pct)\` → arrondi 2 décimales
- \`promoErrorMessage()\` voix Sara

### UI \`/tarifs\` WizardSection
- Champ \"J'ai un code copine\" en details/summary (UI dépliée à la demande, ne surcharge pas)
- Validation Enter ou click Appliquer
- Auto-revalidation si palier change
- Prix barré + nouveau prix + badge code appliqué
- Mailto enrichi avec le code dans le body (pour application manuelle Jiji avant Stripe LIVE)

### Compatibilité Stripe LIVE
Quand Stripe LIVE sera actif, ajouter une colonne \`stripe_coupon_id\` sur \`promo_codes\` et un mapping dans \`lib/promo-codes.ts\` pour passer le \`coupon_id\` à Stripe Checkout au lieu de calculer le discount côté Hilmy.

## Comment tester (après migration appliquée)

1. \`/tarifs\` → wizard 3 étapes → reco Premium
2. Cliquer \"+ J'ai un code copine\" pour ouvrir le champ
3. Saisir \`COPINE10\` (ou \`copine10\` ou \`CoPiNe10\`, case-insensitive)
4. Click Appliquer → prix passe de 49€ à 44,10€/mois, badge \"−10%\" affiché
5. Cliquer durée 1 an : total mensuel reste à 44,10€ (mais le total annuel passe de 470€ à 423€)
6. Switch palier vers Standard → code se retire automatiquement avec message \"non applicable au palier Standard\"
7. Tester code invalide \"FAKEXX\" → message \"ce code n'existe pas\"

## Risques
- 🟡 **Migration SQL 35 requise avant merge** — sinon le SELECT plante côté prod
- Aucune touche auth/Stripe (pricing.ts \`buildMailtoPalier\` étendu de manière backward-compat)
- RLS pensée pour ne pas révéler les codes inactifs ou expirés
- Build OK local + UI testée en preview

## Verdict
🟡 **À MERGER MANUELLEMENT par Jiji après exécution migration 35**

Commande migration :
\`\`\`bash
bash scripts/run-migration.sh supabase/migrations/35_promo_codes.sql
\`\`\`

Vérification post-migration :
\`\`\`sql
SELECT code, discount_pct, applies_to_palier, valid_until FROM promo_codes;
SELECT polname, polcmd FROM pg_policies WHERE tablename='promo_codes';
\`\`\`

Closes part of #30 (Premium \"-10% pour les Copines\").