### PR TITLE
feat(stats): stats hebdo email Premium/Cercle Pro + cron Vercel + opt-in

### DIFF
--- a/app/api/cron/stats-hebdo/route.ts
+++ b/app/api/cron/stats-hebdo/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from 'next/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { sendStatsHebdoPrestataire } from '@/lib/email/transactional'
+import { isAuthorizedCronRequest } from '@/lib/cron-auth'
+
+export const runtime = 'nodejs'
+// Pas de cache : appelé par Vercel Cron, doit toujours s'exécuter frais.
+export const dynamic = 'force-dynamic'
+
+const PALIER_LABEL: Record<string, string> = {
+  premium: 'Premium',
+  cercle_pro: 'Cercle Pro',
+}
+
+/**
+ * Cron Vercel hebdomadaire (lundi 9h UTC, cf vercel.json).
+ *
+ * Pour chaque prestataire approved et payante (Premium / Cercle Pro)
+ * qui n'a PAS opt-out (preferences.notifications.statsHebdoPrestataire !== false),
+ * envoie un email résumant les stats de la semaine.
+ *
+ * Utilise service-role pour bypasser RLS (cron interne, pas de session
+ * utilisatrice). Best-effort : un envoi raté n'arrête pas les autres.
+ *
+ * Sécurité : header Authorization: Bearer ${CRON_SECRET} obligatoire.
+ */
+export async function GET(request: Request) {
+  if (!isAuthorizedCronRequest(request)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const startedAt = Date.now()
+  const admin = createAdminClient()
+
+  // Fenêtres temporelles
+  const now = new Date()
+  const since7d = new Date(now.getTime() - 7 * 86_400_000).toISOString()
+  const since14d = new Date(now.getTime() - 14 * 86_400_000).toISOString()
+
+  // 1. Liste des prestataires éligibles (Premium + Cercle Pro, approved)
+  const { data: prestataires, error: pErr } = await admin
+    .from('profiles')
+    .select('id, user_id, nom, slug, palier')
+    .in('palier', ['premium', 'cercle_pro'])
+    .eq('status', 'approved')
+
+  if (pErr) {
+    return NextResponse.json(
+      { error: 'fetch_prestataires_failed', detail: pErr.message },
+      { status: 500 },
+    )
+  }
+
+  const list = prestataires ?? []
+  let sent = 0
+  let skipped = 0
+  let failed = 0
+  const errors: { profile_id: string; reason: string }[] = []
+
+  for (const p of list) {
+    try {
+      // Lit l'email + opt-out dans une seule passe.
+      const [
+        { data: authUser },
+        { data: userProfile },
+        { count: views7d },
+        { count: views7dPrev },
+        { count: contacts7d },
+        { count: contacts7dPrev },
+      ] = await Promise.all([
+        admin.auth.admin.getUserById(p.user_id),
+        admin
+          .from('user_profiles')
+          .select('prenom, preferences')
+          .eq('user_id', p.user_id)
+          .maybeSingle(),
+        admin
+          .from('profile_views')
+          .select('id', { count: 'exact', head: true })
+          .eq('profile_id', p.id)
+          .gte('viewed_at', since7d),
+        admin
+          .from('profile_views')
+          .select('id', { count: 'exact', head: true })
+          .eq('profile_id', p.id)
+          .gte('viewed_at', since14d)
+          .lt('viewed_at', since7d),
+        admin
+          .from('profile_contacts')
+          .select('id', { count: 'exact', head: true })
+          .eq('profile_id', p.id)
+          .gte('clicked_at', since7d),
+        admin
+          .from('profile_contacts')
+          .select('id', { count: 'exact', head: true })
+          .eq('profile_id', p.id)
+          .gte('clicked_at', since14d)
+          .lt('clicked_at', since7d),
+      ])
+
+      const email = authUser?.user?.email
+      if (!email) {
+        skipped++
+        continue
+      }
+
+      // Opt-out : si statsHebdoPrestataire === false, on saute
+      const prefs = (userProfile?.preferences ?? {}) as Record<string, unknown>
+      const notifs = (prefs.notifications ?? {}) as Record<string, unknown>
+      if (notifs.statsHebdoPrestataire === false) {
+        skipped++
+        continue
+      }
+
+      const prenom =
+        (userProfile?.prenom as string | undefined) ??
+        p.nom.split(' ')[0] ??
+        'Toi'
+
+      await sendStatsHebdoPrestataire({
+        to: email,
+        prenom,
+        nomFiche: p.nom,
+        ficheSlug: p.slug,
+        views7d: views7d ?? 0,
+        views7dPrev: views7dPrev ?? 0,
+        contacts7d: contacts7d ?? 0,
+        contacts7dPrev: contacts7dPrev ?? 0,
+        palierLabel: PALIER_LABEL[p.palier] ?? p.palier,
+      })
+      sent++
+    } catch (err) {
+      failed++
+      errors.push({
+        profile_id: p.id,
+        reason: err instanceof Error ? err.message : String(err),
+      })
+      // On continue les suivantes (best-effort)
+    }
+  }
+
+  const durationMs = Date.now() - startedAt
+
+  return NextResponse.json({
+    ok: true,
+    eligible: list.length,
+    sent,
+    skipped,
+    failed,
+    errors: errors.slice(0, 10), // limite log payload
+    durationMs,
+  })
+}

--- a/app/dashboard/prestataire/parametres/page.tsx
+++ b/app/dashboard/prestataire/parametres/page.tsx
@@ -19,6 +19,12 @@ export default function ParametresPrestatairePage() {
   const [status, setStatus] = useState<
     'pending' | 'approved' | 'rejected' | 'ghost' | 'paused'
   >('pending')
+  const [palier, setPalier] = useState<'standard' | 'premium' | 'cercle_pro'>(
+    'standard',
+  )
+  const [statsHebdoOptIn, setStatsHebdoOptIn] = useState(true)
+  const [statsHebdoSaving, setStatsHebdoSaving] = useState(false)
+  const [userIdState, setUserIdState] = useState<string | null>(null)
 
   useEffect(() => {
     const run = async () => {
@@ -32,19 +38,82 @@ export default function ParametresPrestatairePage() {
         return
       }
       setEmail(user.email ?? '')
-      const { data } = await supabase
-        .from('profiles')
-        .select('id, status')
-        .eq('user_id', user.id)
-        .maybeSingle()
-      if (data) {
-        setProfileId(data.id)
-        setStatus(data.status)
+      setUserIdState(user.id)
+
+      const [profileRes, prefsRes] = await Promise.all([
+        supabase
+          .from('profiles')
+          .select('id, status, palier')
+          .eq('user_id', user.id)
+          .maybeSingle(),
+        supabase
+          .from('user_profiles')
+          .select('preferences')
+          .eq('user_id', user.id)
+          .maybeSingle(),
+      ])
+
+      if (profileRes.data) {
+        setProfileId(profileRes.data.id)
+        setStatus(profileRes.data.status)
+        const p = profileRes.data.palier
+        setPalier(
+          p === 'premium' ? 'premium' : p === 'cercle_pro' ? 'cercle_pro' : 'standard',
+        )
       }
+
+      // Opt-in stats hebdo : default true (active si pas opt-out explicite)
+      const prefs = (prefsRes.data?.preferences ?? {}) as Record<string, unknown>
+      const notifs = (prefs.notifications ?? {}) as Record<string, unknown>
+      setStatsHebdoOptIn(notifs.statsHebdoPrestataire !== false)
+
       setLoading(false)
     }
     run()
   }, [])
+
+  const toggleStatsHebdo = async () => {
+    if (!userIdState) return
+    const next = !statsHebdoOptIn
+    setStatsHebdoOptIn(next) // optimistic
+    setStatsHebdoSaving(true)
+    setError(null)
+    const supabase = createClient()
+    // Read-then-merge pour preserver les autres cles preferences (cf PR #16 fix bug 1)
+    const { data: existing, error: readErr } = await supabase
+      .from('user_profiles')
+      .select('preferences')
+      .eq('user_id', userIdState)
+      .maybeSingle()
+    if (readErr) {
+      setStatsHebdoOptIn(!next)
+      setStatsHebdoSaving(false)
+      setError(readErr.message)
+      return
+    }
+    const current = (existing?.preferences ?? {}) as Record<string, unknown>
+    const currentNotifs = (current.notifications ?? {}) as Record<string, unknown>
+    const merged = {
+      ...current,
+      notifications: { ...currentNotifs, statsHebdoPrestataire: next },
+    }
+    const { error: updErr } = await supabase
+      .from('user_profiles')
+      .update({ preferences: merged })
+      .eq('user_id', userIdState)
+    setStatsHebdoSaving(false)
+    if (updErr) {
+      setStatsHebdoOptIn(!next)
+      setError(updErr.message)
+      return
+    }
+    setMsg(
+      next
+        ? 'Tu recevras tes stats hebdo chaque lundi matin.'
+        : 'Stats hebdo désactivées. Tu peux les réactiver à tout moment.',
+    )
+    setTimeout(() => setMsg(null), 4000)
+  }
 
   const toggleVisibility = async () => {
     if (!profileId) return
@@ -170,6 +239,46 @@ export default function ParametresPrestatairePage() {
                 </div>
               )}
             </SettingsGroup>
+
+            {(palier === 'premium' || palier === 'cercle_pro') && (
+              <SettingsGroup
+                kicker="Notifications"
+                titre="Ce qu'on t'envoie."
+              >
+                <div className="flex items-start justify-between gap-6 px-6 py-5">
+                  <div className="max-w-lg">
+                    <p className="text-[14px] font-medium text-vert">
+                      Stats hebdo par email
+                    </p>
+                    <p className="mt-1 text-[12px] text-texte-sec">
+                      Chaque lundi matin, un récap des vues et des
+                      tap-to-contact de la semaine passée + comparaison avec
+                      la précédente.
+                    </p>
+                    <p className="mt-2 text-[11px] tracking-[0.22em] text-or uppercase">
+                      Inclus dans Premium et Cercle Pro
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={statsHebdoOptIn}
+                    aria-label="Activer les stats hebdo par email"
+                    disabled={statsHebdoSaving}
+                    onClick={toggleStatsHebdo}
+                    className={`relative h-7 w-12 shrink-0 rounded-full transition-colors ${
+                      statsHebdoOptIn ? 'bg-vert' : 'bg-creme-deep'
+                    } disabled:opacity-60`}
+                  >
+                    <span
+                      className={`absolute top-1 h-5 w-5 rounded-full shadow-sm transition-all ${
+                        statsHebdoOptIn ? 'left-6 bg-or' : 'left-1 bg-blanc'
+                      }`}
+                    />
+                  </button>
+                </div>
+              </SettingsGroup>
+            )}
 
             <SettingsGroup
               kicker="Confidentialité"

--- a/lib/cron-auth.ts
+++ b/lib/cron-auth.ts
@@ -1,0 +1,22 @@
+/**
+ * Auth helper pour les routes /api/cron/*.
+ *
+ * Vercel Cron envoie automatiquement le header `Authorization: Bearer ${CRON_SECRET}`
+ * où CRON_SECRET est une env var configurée côté Vercel (cf docs Vercel Cron).
+ *
+ * En l'absence de header valide, retourne `false` -> la route doit
+ * répondre 401 sans rien faire.
+ */
+
+export function isAuthorizedCronRequest(request: Request): boolean {
+  const expected = process.env.CRON_SECRET?.trim()
+  if (!expected) {
+    // Pas de CRON_SECRET configuré -> on refuse par sécurité
+    return false
+  }
+  const header = request.headers.get('authorization')
+  if (!header) return false
+  const expectedHeader = `Bearer ${expected}`
+  // Comparaison stricte (timing attack résistance non critique pour un cron interne)
+  return header === expectedHeader
+}

--- a/lib/email/transactional.ts
+++ b/lib/email/transactional.ts
@@ -628,3 +628,73 @@ export async function sendFounderSignupNotification({
 </html>`,
   });
 }
+
+/**
+ * Stats hebdo prestataires Premium / Cercle Pro (Phase 4 — promesse /tarifs).
+ * Envoyée chaque lundi matin par /api/cron/stats-hebdo.
+ *
+ * Best-effort : on ne block pas le cron si une seule envoi rate (catch
+ * côté caller pour log + continuer).
+ */
+export async function sendStatsHebdoPrestataire({
+  to,
+  prenom,
+  nomFiche,
+  ficheSlug,
+  views7d,
+  views7dPrev,
+  contacts7d,
+  contacts7dPrev,
+  palierLabel,
+}: {
+  to: string;
+  prenom: string;
+  nomFiche: string;
+  ficheSlug: string;
+  views7d: number;
+  views7dPrev: number;
+  contacts7d: number;
+  contacts7dPrev: number;
+  palierLabel: string;
+}) {
+  const dashboardUrl = `${getSiteUrl()}/dashboard/prestataire`;
+
+  function trendLine(label: string, current: number, prev: number): string {
+    if (prev === 0 && current === 0) {
+      return `${label} : ${current} cette semaine.`;
+    }
+    if (prev === 0) {
+      return `${label} : ${current} cette semaine (premier signal — bravo).`;
+    }
+    const delta = current - prev;
+    const pct = Math.round((delta / prev) * 100);
+    if (delta > 0) {
+      return `${label} : ${current} cette semaine (+${pct}% vs semaine dernière).`;
+    }
+    if (delta < 0) {
+      return `${label} : ${current} cette semaine (${pct}% vs semaine dernière).`;
+    }
+    return `${label} : ${current} cette semaine (stable).`;
+  }
+
+  await sendEmail({
+    to,
+    subject: `Tes stats Hilmy de la semaine — ${nomFiche}`,
+    html: buildRichLayout({
+      preview: `${views7d} vues · ${contacts7d} contacts cette semaine`,
+      title: `${prenom}, ta semaine en chiffres.`,
+      paragraphs: [
+        `Voici un petit résumé de ce qui s'est passé sur ta fiche ${nomFiche} (palier ${palierLabel}) ces 7 derniers jours.`,
+        trendLine("Vues fiche", views7d, views7dPrev),
+        trendLine("Tap-to-contact (WhatsApp, email, réseaux…)", contacts7d, contacts7dPrev),
+        contacts7d === 0 && views7d > 0
+          ? `Beaucoup de visites mais peu de contacts ? Vérifie tes canaux (WhatsApp, Instagram) — c'est souvent là que ça bloque.`
+          : `Continue ce que tu fais — chaque semaine, ça se construit.`,
+      ],
+      ctaLabel: "Voir mon dashboard détaillé",
+      ctaHref: dashboardUrl,
+      footer:
+        "Tu reçois cet email parce que tu es abonnée Premium ou Cercle Pro. Tu peux désactiver les stats hebdo depuis tes paramètres dashboard.",
+    }),
+  });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,9 @@
 {
-  "regions": ["cdg1"]
+  "regions": ["cdg1"],
+  "crons": [
+    {
+      "path": "/api/cron/stats-hebdo",
+      "schedule": "0 9 * * 1"
+    }
+  ]
 }


### PR DESCRIPTION
## Quoi
Implémente la promesse Premium \"Stats hebdo\" qui n'était que partielle (stats temps réel dans dashboard mais aucun envoi email récurrent).

## Architecture (zéro migration SQL, additif pur)

### 1. Template email \`lib/email/transactional.ts\`
- \`sendStatsHebdoPrestataire\` réutilise \`buildRichLayout\` (signature \"Sara, pour Hilmy\")
- Helper \`trendLine()\` avec wording adapté : premier signal, stable, +X%, -X%
- Conseil contextuel voix Sara si beaucoup de vues mais zéro contact

### 2. Auth cron \`lib/cron-auth.ts\`
- \`isAuthorizedCronRequest()\` vérifie \`Authorization: Bearer ${CRON_SECRET}\`
- Refuse par défaut si CRON_SECRET absent (sécurité)

### 3. Route \`app/api/cron/stats-hebdo/route.ts\` (GET)
- Service-role (bypass RLS, cron interne)
- Liste prestataires \`palier IN (premium, cercle_pro) AND status = approved\`
- Pour chaque : email + opt-out + 4 counts en parallèle (vues 7d, vues 7d-14d, contacts 7d, contacts 7d-14d)
- Skip si \`statsHebdoPrestataire === false\` dans \`preferences.notifications\`
- Best-effort : un envoi raté n'arrête pas les autres
- Retourne JSON \`{eligible, sent, skipped, failed, errors[10max], durationMs}\`

### 4. \`vercel.json\` cron
- \`schedule: \"0 9 * * 1\"\` = chaque lundi 9h UTC (10h Paris hiver / 11h été)

### 5. UI opt-in (\`app/dashboard/prestataire/parametres/page.tsx\`)
- Nouvelle section \"Notifications\" visible uniquement si Premium ou Cercle Pro
- Toggle \"Stats hebdo par email\" (default activé)
- Pattern read-then-merge sur \`preferences\` (cf PR #16 fix bug 1)
- Stocke dans \`preferences.notifications.statsHebdoPrestataire\` → **zéro migration SQL** (jsonb extensible existant)

## ⚠️ ENV VAR REQUISE
Avant que le cron tourne en prod, ajouter dans Vercel :
\`\`\`
CRON_SECRET=$(openssl rand -base64 32)
\`\`\`
Sans cette var : route retourne 401 (sécurité by default).

## Comment tester
1. **Preview locale** : \`curl http://localhost:3000/api/cron/stats-hebdo\` → 401 attendu sans header
2. **Avec CRON_SECRET** :
   \`\`\`bash
   curl -H \"Authorization: Bearer $CRON_SECRET\" http://localhost:3000/api/cron/stats-hebdo
   \`\`\`
   → JSON avec liste des envois
3. **Opt-out** : dashboard prestataire (Premium+) → Paramètres → Notifications → toggle Stats hebdo

## Risques
- Pas de migration SQL (réutilise \`preferences\` jsonb existant)
- Service-role utilisé uniquement dans la route cron protégée par CRON_SECRET
- Best-effort sur l'envoi : pas de blocage si Resend down ou un email invalide
- Build OK local + 401 confirmé en preview

## Verdict
🟢 **SAFE** — pas de SQL, additif pur, sécurité by default. Merge auto.

⚠️ **Action Jiji après merge** : ajouter \`CRON_SECRET\` dans Vercel env vars (sinon le cron retourne 401 chaque lundi mais ne casse rien).

Closes part of #30 (Premium \"Stats hebdo\").