### PR TITLE
feat(devis): Devis Express Cercle Pro + migration 36 + RLS

### DIFF
--- a/app/api/devis-requests/route.ts
+++ b/app/api/devis-requests/route.ts
@@ -1,0 +1,194 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { sendDevisExpressEmail } from '@/lib/email/transactional'
+import { enforceRateLimit } from '@/lib/rate-limit'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/devis-requests
+ *
+ * Body : { prestataire_id, prenom, email, telephone?, message }
+ *
+ * Soumission d'une demande de devis par une utilisatrice authentifiée
+ * vers une prestataire Cercle Pro.
+ *
+ * Validations :
+ *  - Auth utilisatrice obligatoire
+ *  - prestataire_id existe ET palier === 'cercle_pro' ET status === 'approved'
+ *  - prenom 1-80 / email format simple / message 5-2000 chars
+ *  - Rate limit : max 3 soumissions / 5 min / utilisatrice (anti spam)
+ *
+ * Insertion via client RLS (la policy devis_requests_user_insert exige
+ * user_id = auth.uid()).
+ *
+ * Email best-effort : on stocke email_sent_at / email_error mais on ne
+ * fail pas la requête si l'envoi rate.
+ */
+export async function POST(request: Request) {
+  const limited = enforceRateLimit(request, {
+    tag: 'devis-requests',
+    max: 3,
+    windowMs: 5 * 60 * 1000,
+  })
+  if (limited) return limited
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Non authentifiée' }, { status: 401 })
+  }
+
+  const body = await request.json().catch(() => null)
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Body invalide' }, { status: 400 })
+  }
+
+  const {
+    prestataire_id,
+    prenom,
+    email,
+    telephone,
+    message,
+  } = body as Record<string, unknown>
+
+  // ─── Validation des champs ────────────────────────────────────────
+  if (typeof prestataire_id !== 'string' || prestataire_id.length < 8) {
+    return NextResponse.json({ error: 'prestataire_id manquant' }, { status: 400 })
+  }
+  if (typeof prenom !== 'string' || prenom.trim().length < 1 || prenom.length > 80) {
+    return NextResponse.json({ error: 'Prénom invalide.' }, { status: 400 })
+  }
+  if (
+    typeof email !== 'string' ||
+    !email.includes('@') ||
+    email.length > 200
+  ) {
+    return NextResponse.json({ error: 'Email invalide.' }, { status: 400 })
+  }
+  if (
+    typeof message !== 'string' ||
+    message.trim().length < 5 ||
+    message.length > 2000
+  ) {
+    return NextResponse.json(
+      { error: 'Message trop court ou trop long (5-2000 caractères).' },
+      { status: 400 },
+    )
+  }
+  const tel =
+    typeof telephone === 'string' && telephone.trim().length > 0
+      ? telephone.trim().slice(0, 50)
+      : null
+
+  // ─── Vérifie que la prestataire est bien Cercle Pro & approuvée ───
+  const { data: presta, error: pErr } = await supabase
+    .from('profiles')
+    .select('id, user_id, nom, palier, status')
+    .eq('id', prestataire_id)
+    .maybeSingle()
+
+  if (pErr || !presta) {
+    return NextResponse.json(
+      { error: 'Prestataire introuvable' },
+      { status: 404 },
+    )
+  }
+  if (presta.palier !== 'cercle_pro') {
+    return NextResponse.json(
+      { error: 'Devis express réservé aux fiches Cercle Pro.' },
+      { status: 403 },
+    )
+  }
+  if (presta.status !== 'approved') {
+    return NextResponse.json(
+      { error: 'Cette fiche n\'est pas active.' },
+      { status: 403 },
+    )
+  }
+
+  // ─── Insert via RLS (user_id = auth.uid() check par policy) ──────
+  const { data: inserted, error: insErr } = await supabase
+    .from('devis_requests')
+    .insert({
+      prestataire_id,
+      user_id: user.id,
+      prenom: prenom.trim().slice(0, 80),
+      email: email.trim().toLowerCase().slice(0, 200),
+      telephone: tel,
+      message: message.trim().slice(0, 2000),
+      status: 'pending',
+    })
+    .select('id')
+    .single()
+
+  if (insErr || !inserted) {
+    return NextResponse.json(
+      { error: insErr?.message || 'Insertion échouée' },
+      { status: 500 },
+    )
+  }
+
+  // ─── Email best-effort à la prestataire ──────────────────────────
+  // Service-role pour récupérer l'email auth de la prestataire (pas de
+  // table user_profiles email — on lit dans auth.users via admin).
+  let emailSent = false
+  let emailError: string | null = null
+
+  try {
+    const admin = createAdminClient()
+    const [{ data: prestaAuth }, { data: prestaUserProfile }] = await Promise.all([
+      admin.auth.admin.getUserById(presta.user_id),
+      admin
+        .from('user_profiles')
+        .select('prenom')
+        .eq('user_id', presta.user_id)
+        .maybeSingle(),
+    ])
+    const prestaEmail = prestaAuth?.user?.email
+    if (prestaEmail) {
+      const prestaPrenom =
+        (prestaUserProfile?.prenom as string | undefined) ??
+        presta.nom.split(' ')[0] ??
+        'Toi'
+      const siteUrl =
+        process.env.NEXT_PUBLIC_SITE_URL ||
+        process.env.SITE_URL ||
+        'https://hilmy.io'
+      await sendDevisExpressEmail({
+        to: prestaEmail,
+        prestaPrenom,
+        ficheNom: presta.nom,
+        utilisatricePrenom: prenom.trim().slice(0, 80),
+        utilisatriceEmail: email.trim().toLowerCase(),
+        utilisatriceTelephone: tel,
+        message: message.trim(),
+        dashboardUrl: `${siteUrl}/dashboard/prestataire/devis`,
+      })
+      emailSent = true
+    } else {
+      emailError = 'no_email_on_prestataire_account'
+    }
+  } catch (err) {
+    emailError = err instanceof Error ? err.message : String(err)
+  }
+
+  // Update best-effort de email_sent_at / email_error (admin pour bypass RLS update)
+  try {
+    const admin = createAdminClient()
+    await admin
+      .from('devis_requests')
+      .update({
+        email_sent_at: emailSent ? new Date().toISOString() : null,
+        email_error: emailError,
+      })
+      .eq('id', inserted.id)
+  } catch {
+    // Best-effort, on ne fail pas
+  }
+
+  return NextResponse.json({ ok: true, id: inserted.id, email_sent: emailSent })
+}

--- a/app/dashboard/prestataire/devis/_components/DevisRow.tsx
+++ b/app/dashboard/prestataire/devis/_components/DevisRow.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import { useState } from 'react'
+import { createClient } from '@/lib/supabase/client'
+
+interface DevisRowProps {
+  devis: {
+    id: string
+    prenom: string
+    email: string
+    telephone: string | null
+    message: string
+    status: string
+    email_sent_at: string | null
+    email_error: string | null
+    created_at: string
+    updated_at: string
+  }
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  pending: 'En attente',
+  replied: 'Répondu',
+  ignored: 'Ignoré',
+  archived: 'Archivé',
+}
+
+const STATUS_COLOR: Record<string, string> = {
+  pending: 'bg-or/15 text-or-deep',
+  replied: 'bg-vert/15 text-vert',
+  ignored: 'bg-texte-sec/15 text-texte-sec',
+  archived: 'bg-texte-sec/10 text-texte-sec/80',
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString('fr-FR', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function DevisRow({ devis }: DevisRowProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [status, setStatus] = useState(devis.status)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const updateStatus = async (next: string) => {
+    setSaving(true)
+    setError(null)
+    const supabase = createClient()
+    const { error: updErr } = await supabase
+      .from('devis_requests')
+      .update({ status: next })
+      .eq('id', devis.id)
+    setSaving(false)
+    if (updErr) {
+      setError(updErr.message)
+      return
+    }
+    setStatus(next)
+  }
+
+  return (
+    <li className="rounded-sm border border-or/15 bg-blanc transition-shadow hover:shadow-[0_8px_24px_-12px_rgba(15,61,46,0.15)]">
+      <div className="flex flex-col gap-3 px-6 py-5 md:flex-row md:items-center md:justify-between">
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="font-serif text-lg font-light text-vert">
+              {devis.prenom}
+            </p>
+            <span
+              className={`rounded-full px-2.5 py-0.5 text-[10px] font-medium tracking-[0.18em] uppercase ${STATUS_COLOR[status] ?? STATUS_COLOR.pending}`}
+            >
+              {STATUS_LABEL[status] ?? status}
+            </span>
+          </div>
+          <p className="truncate text-[12px] text-texte-sec">
+            {devis.email}
+            {devis.telephone ? ` · ${devis.telephone}` : ''}
+          </p>
+          <p className="text-[11px] text-texte-sec/80">
+            Reçue le {formatDate(devis.created_at)}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <a
+            href={`mailto:${devis.email}?subject=${encodeURIComponent(`Re: Ta demande de devis sur Hilmy`)}`}
+            className="inline-flex h-9 items-center gap-1.5 rounded-full bg-vert px-4 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+          >
+            Répondre
+          </a>
+          <button
+            type="button"
+            onClick={() => setExpanded((e) => !e)}
+            className="text-[11px] tracking-[0.22em] text-or-deep uppercase hover:text-or"
+            aria-expanded={expanded}
+          >
+            {expanded ? 'Masquer' : 'Voir +'}
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-or/10 px-6 py-5">
+          <p className="overline text-or">Son message</p>
+          <p className="mt-2 whitespace-pre-wrap font-serif text-[15px] italic leading-[1.65] text-texte">
+            « {devis.message} »
+          </p>
+
+          <div className="mt-5 flex flex-wrap items-center gap-2">
+            {status === 'pending' && (
+              <>
+                <button
+                  type="button"
+                  onClick={() => updateStatus('replied')}
+                  disabled={saving}
+                  className="inline-flex h-9 items-center gap-1.5 rounded-full border border-vert/40 px-4 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-vert hover:bg-vert hover:text-creme disabled:opacity-60"
+                >
+                  Marquer répondu
+                </button>
+                <button
+                  type="button"
+                  onClick={() => updateStatus('ignored')}
+                  disabled={saving}
+                  className="inline-flex h-9 items-center gap-1.5 rounded-full border border-texte-sec/30 px-4 text-[11px] font-medium tracking-[0.22em] text-texte-sec uppercase transition-all hover:border-texte-sec hover:bg-creme-deep disabled:opacity-60"
+                >
+                  Ignorer
+                </button>
+              </>
+            )}
+            {(status === 'replied' || status === 'ignored') && (
+              <button
+                type="button"
+                onClick={() => updateStatus('archived')}
+                disabled={saving}
+                className="inline-flex h-9 items-center gap-1.5 rounded-full border border-texte-sec/30 px-4 text-[11px] font-medium tracking-[0.22em] text-texte-sec uppercase transition-all hover:border-texte-sec hover:bg-creme-deep disabled:opacity-60"
+              >
+                Archiver
+              </button>
+            )}
+
+            {devis.email_sent_at ? (
+              <span className="ml-auto text-[11px] text-texte-sec">
+                ✓ Email envoyé
+              </span>
+            ) : devis.email_error ? (
+              <span
+                className="ml-auto text-[11px] text-red-900"
+                title={devis.email_error}
+              >
+                ⚠ Email non envoyé
+              </span>
+            ) : null}
+          </div>
+
+          {error && (
+            <p
+              role="alert"
+              className="mt-3 rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[11px] text-red-900"
+            >
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+    </li>
+  )
+}

--- a/app/dashboard/prestataire/devis/page.tsx
+++ b/app/dashboard/prestataire/devis/page.tsx
@@ -1,0 +1,112 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
+import { GoldLine } from '@/components/ui/GoldLine'
+import { EmptyState } from '@/components/dashboard/EmptyState'
+import { requirePrestataire } from '@/lib/supabase/session'
+import { createClient } from '@/lib/supabase/server'
+import { DevisRow } from './_components/DevisRow'
+
+export default async function MesDevisPage() {
+  const { prestataire } = await requirePrestataire()
+
+  // Garde Cercle Pro : si pas Cercle Pro, redirige vers tarifs
+  if (prestataire.palier !== 'cercle_pro') {
+    redirect('/dashboard/prestataire/abonnement')
+  }
+
+  const supabase = await createClient()
+  const { data: devis, error } = await supabase
+    .from('devis_requests')
+    .select(
+      'id, prenom, email, telephone, message, status, email_sent_at, email_error, created_at, updated_at',
+    )
+    .eq('prestataire_id', prestataire.id)
+    .order('created_at', { ascending: false })
+
+  const list = devis ?? []
+  const pending = list.filter((d) => d.status === 'pending')
+  const traitees = list.filter((d) => d.status !== 'pending')
+
+  return (
+    <>
+      <DashboardHeader
+        kicker="Devis Express"
+        titre={
+          <>
+            Tes demandes,{' '}
+            <em className="font-serif italic text-or">en direct.</em>
+          </>
+        }
+        lead="Les copines qui te demandent un devis depuis ta fiche apparaissent ici. À toi de leur répondre par email ou téléphone."
+        actions={
+          <Link
+            href={`/prestataire-v2/${prestataire.slug}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex h-11 items-center gap-2 rounded-full border border-or/40 px-5 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-or hover:bg-blanc"
+          >
+            Voir ma fiche publique
+            <span className="text-or" aria-hidden="true">
+              →
+            </span>
+          </Link>
+        }
+      />
+
+      {error && (
+        <section className="px-6 py-6 md:px-12">
+          <p className="rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[12px] text-red-900">
+            {error.message}
+          </p>
+        </section>
+      )}
+
+      <section className="px-6 py-10 md:px-12 md:py-14">
+        {list.length === 0 ? (
+          <EmptyState
+            kicker="Premiers devis"
+            titre="Pas encore de demande de devis."
+            pitch="Dès qu'une copine clique sur « Demander un devis » sur ta fiche, sa demande apparaît ici. Tu reçois aussi un email à chaque demande."
+            ctaLabel="Voir ma fiche publique"
+            ctaHref={`/prestataire-v2/${prestataire.slug}`}
+          />
+        ) : (
+          <div className="space-y-12">
+            {pending.length > 0 && (
+              <div>
+                <div className="mb-6 flex items-center gap-4">
+                  <GoldLine width={40} />
+                  <span className="overline text-or">
+                    À traiter — {pending.length}
+                  </span>
+                </div>
+                <ul className="space-y-3">
+                  {pending.map((d) => (
+                    <DevisRow key={d.id} devis={d} />
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {traitees.length > 0 && (
+              <div>
+                <div className="mb-6 flex items-center gap-4">
+                  <GoldLine width={40} />
+                  <span className="overline text-or">
+                    Historique — {traitees.length}
+                  </span>
+                </div>
+                <ul className="space-y-3">
+                  {traitees.map((d) => (
+                    <DevisRow key={d.id} devis={d} />
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+    </>
+  )
+}

--- a/app/dashboard/prestataire/layout.tsx
+++ b/app/dashboard/prestataire/layout.tsx
@@ -21,6 +21,18 @@ export default async function PrestataireLayout({
     .eq('status', 'published')
     .is('reponse_pro', null)
 
+  // Badge "nouveaux devis" — Cercle Pro uniquement (best-effort, table peut
+  // ne pas encore exister tant que migration 36 pas appliquée).
+  let pendingDevisCount = 0
+  if (prestataire.palier === 'cercle_pro') {
+    const { count } = await supabase
+      .from('devis_requests')
+      .select('id', { count: 'exact', head: true })
+      .eq('prestataire_id', prestataire.id)
+      .eq('status', 'pending')
+    pendingDevisCount = count ?? 0
+  }
+
   const items: SidebarItem[] = [
     { href: '/dashboard/prestataire', label: 'Accueil', icon: '·' },
     { href: '/dashboard/prestataire/fiche', label: 'Ma fiche', icon: '❋' },
@@ -38,6 +50,20 @@ export default async function PrestataireLayout({
       label: 'Mes événements',
       icon: '◇',
     },
+    // Devis Express : entrée Cercle Pro uniquement
+    ...(prestataire.palier === 'cercle_pro'
+      ? ([
+          {
+            href: '/dashboard/prestataire/devis',
+            label: 'Mes devis',
+            icon: '✨',
+            badge:
+              pendingDevisCount > 0
+                ? `${pendingDevisCount} nouveau${pendingDevisCount > 1 ? 'x' : ''}`
+                : undefined,
+          },
+        ] as SidebarItem[])
+      : []),
     {
       href: '/dashboard/prestataire/abonnement',
       label: 'Mon abonnement',

--- a/app/prestataire-v2/[slug]/page.tsx
+++ b/app/prestataire-v2/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { FadeInSection } from '@/components/ui/FadeInSection'
 import { PrestataireCard } from '@/components/v2/PrestataireCard'
 import { PhotoGallery } from '@/components/v2/PhotoGallery'
 import { GalleryAutoplayCarousel } from '@/components/v2/GalleryAutoplayCarousel'
+import { DevisExpressCTA } from '@/components/v2/DevisExpressCTA'
 import { SocialChannelsButtons } from '@/components/v2/SocialChannelsButtons'
 import { TrackPageView } from '@/components/v2/TrackPageView'
 import { AvisSection, type AvisItem } from '@/components/v2/AvisSection'
@@ -274,6 +275,14 @@ export default async function PrestatairePage({
                   profileId={finalRow!.id}
                 />
               </div>
+              {p.palier === 'cercle_pro' && !isPreview && (
+                <div className="mt-6">
+                  <DevisExpressCTA
+                    prestataireId={finalRow!.id}
+                    prestataireName={finalRow!.nom}
+                  />
+                </div>
+              )}
               {!isPreview && (
                 <div className="mt-6">
                   <FavoriteButton />

--- a/components/v2/DevisExpressCTA.tsx
+++ b/components/v2/DevisExpressCTA.tsx
@@ -1,0 +1,292 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createClient } from '@/lib/supabase/client'
+
+interface Props {
+  prestataireId: string
+  prestataireName: string
+}
+
+/**
+ * Bouton "Demander un devis" + modal de soumission.
+ * Réservé aux fiches Cercle Pro (le composant n'est rendu que conditionnel
+ * dans la page fiche prestataire — palier === 'cercle_pro').
+ *
+ * - Pré-remplit prénom + email depuis user_profiles si dispo
+ * - POST /api/devis-requests (validation + insert + email best-effort)
+ * - Si user non authentifiée : redirige vers /auth/signup avec retour
+ */
+export function DevisExpressCTA({ prestataireId, prestataireName }: Props) {
+  const [open, setOpen] = useState(false)
+  const [loadingMe, setLoadingMe] = useState(true)
+  const [authedUserEmail, setAuthedUserEmail] = useState<string | null>(null)
+  const [prenom, setPrenom] = useState('')
+  const [email, setEmail] = useState('')
+  const [telephone, setTelephone] = useState('')
+  const [message, setMessage] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  // Pré-fill au mount (si user authentifiée)
+  useEffect(() => {
+    let cancelled = false
+    async function fetchMe() {
+      const supabase = createClient()
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (cancelled) return
+      if (user) {
+        setAuthedUserEmail(user.email ?? null)
+        setEmail(user.email ?? '')
+        const { data: prof } = await supabase
+          .from('user_profiles')
+          .select('prenom')
+          .eq('user_id', user.id)
+          .maybeSingle()
+        if (!cancelled && prof?.prenom) setPrenom(prof.prenom as string)
+      }
+      setLoadingMe(false)
+    }
+    fetchMe()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleOpen = () => {
+    if (!authedUserEmail) {
+      // Redirect vers signup avec retour sur la fiche
+      window.location.href = `/auth/signup?redirect=${encodeURIComponent(window.location.pathname)}`
+      return
+    }
+    setOpen(true)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    if (prenom.trim().length < 1) {
+      setError("Ton prénom, c'est le minimum.")
+      return
+    }
+    if (!email.includes('@')) {
+      setError('Email invalide.')
+      return
+    }
+    if (message.trim().length < 5) {
+      setError('Dis-lui un peu plus (5 caractères minimum).')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const res = await fetch('/api/devis-requests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          prestataire_id: prestataireId,
+          prenom: prenom.trim(),
+          email: email.trim().toLowerCase(),
+          telephone: telephone.trim() || null,
+          message: message.trim(),
+        }),
+      })
+      const json = await res.json().catch(() => null)
+      if (!res.ok) {
+        setError((json?.error as string) || 'Petit pépin. Réessaie dans un instant.')
+        setSubmitting(false)
+        return
+      }
+      setSuccess(true)
+      setSubmitting(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Petit pépin réseau.')
+      setSubmitting(false)
+    }
+  }
+
+  const handleClose = () => {
+    setOpen(false)
+    if (success) {
+      setSuccess(false)
+      setMessage('')
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        disabled={loadingMe}
+        className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-or px-6 py-3.5 text-[12px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:bg-or-light disabled:opacity-60"
+        aria-label={`Demander un devis à ${prestataireName}`}
+      >
+        ✨ Demander un devis
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="devis-modal-title"
+          className="fixed inset-0 z-50 flex items-end justify-center bg-vert/40 p-0 backdrop-blur-sm sm:items-center sm:p-6"
+          onClick={handleClose}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="relative w-full max-w-lg rounded-t-3xl bg-blanc p-6 shadow-2xl sm:rounded-3xl sm:p-8"
+          >
+            <button
+              type="button"
+              onClick={handleClose}
+              aria-label="Fermer"
+              className="absolute top-4 right-4 inline-flex h-9 w-9 items-center justify-center rounded-full text-texte-sec transition-colors hover:bg-creme-deep hover:text-vert"
+            >
+              ✕
+            </button>
+
+            {success ? (
+              <div className="text-center">
+                <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-or/15 text-or">
+                  ✓
+                </div>
+                <h2 id="devis-modal-title" className="font-serif text-2xl font-light text-vert">
+                  Demande envoyée.
+                </h2>
+                <p className="mt-3 text-[14px] leading-[1.6] text-texte-sec">
+                  {prestataireName} reçoit ta demande directement par email.
+                  Elle te répondra sous peu, en direct sur l&apos;email que tu
+                  as laissé.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  className="mt-6 inline-flex h-11 items-center justify-center rounded-full border border-or/40 px-6 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-colors hover:border-or hover:bg-creme-deep"
+                >
+                  Fermer
+                </button>
+              </div>
+            ) : (
+              <>
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-or/20 text-[12px] text-or">
+                    ✨
+                  </span>
+                  <span className="text-[10px] tracking-[0.28em] text-or uppercase">
+                    Devis Express · Cercle Pro
+                  </span>
+                </div>
+                <h2
+                  id="devis-modal-title"
+                  className="mt-3 font-serif text-2xl font-light text-vert"
+                >
+                  Demander un devis à {prestataireName}.
+                </h2>
+                <p className="mt-2 text-[13px] leading-[1.6] text-texte-sec">
+                  Quelques infos pour qu&apos;elle te recontacte avec une
+                  proposition adaptée. Pas de spam, ça part directement à la
+                  prestataire.
+                </p>
+
+                <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <label className="flex flex-col gap-1.5">
+                      <span className="text-[11px] tracking-[0.22em] text-or uppercase">
+                        Prénom
+                      </span>
+                      <input
+                        type="text"
+                        value={prenom}
+                        onChange={(e) => setPrenom(e.target.value)}
+                        required
+                        maxLength={80}
+                        className="border-b border-or/30 bg-transparent py-2 text-[15px] text-vert focus:border-or focus:outline-none"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1.5">
+                      <span className="text-[11px] tracking-[0.22em] text-or uppercase">
+                        Email
+                      </span>
+                      <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        required
+                        maxLength={200}
+                        className="border-b border-or/30 bg-transparent py-2 text-[15px] text-vert focus:border-or focus:outline-none"
+                      />
+                    </label>
+                  </div>
+                  <label className="flex flex-col gap-1.5">
+                    <span className="text-[11px] tracking-[0.22em] text-or uppercase">
+                      Téléphone (optionnel)
+                    </span>
+                    <input
+                      type="tel"
+                      value={telephone}
+                      onChange={(e) => setTelephone(e.target.value)}
+                      maxLength={50}
+                      placeholder="+33 6 ..."
+                      className="border-b border-or/30 bg-transparent py-2 text-[15px] text-vert placeholder:text-texte-sec/50 focus:border-or focus:outline-none"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1.5">
+                    <span className="text-[11px] tracking-[0.22em] text-or uppercase">
+                      Ton besoin
+                    </span>
+                    <textarea
+                      value={message}
+                      onChange={(e) => setMessage(e.target.value)}
+                      required
+                      minLength={5}
+                      maxLength={2000}
+                      rows={5}
+                      placeholder="Dis-lui ce que tu cherches : type de prestation, date approximative, budget, contraintes..."
+                      className="resize-none rounded-sm border border-or/20 bg-creme-soft p-3 font-serif text-[14px] italic leading-[1.55] text-vert placeholder:not-italic placeholder:font-sans placeholder:text-texte-sec/60 focus:border-or focus:outline-none"
+                    />
+                    <span className="text-[11px] text-texte-sec">
+                      {message.length} / 2000
+                    </span>
+                  </label>
+
+                  {error && (
+                    <p
+                      role="alert"
+                      className="rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[12px] text-red-900"
+                    >
+                      {error}
+                    </p>
+                  )}
+
+                  <div className="flex items-center justify-end gap-3 pt-2">
+                    <button
+                      type="button"
+                      onClick={handleClose}
+                      className="text-[11px] tracking-[0.22em] text-texte-sec uppercase hover:text-vert"
+                    >
+                      Annuler
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={submitting}
+                      className="inline-flex h-12 items-center gap-2 rounded-full bg-vert px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark disabled:opacity-60"
+                    >
+                      {submitting ? 'Envoi…' : 'Envoyer ma demande'}
+                      <span className="text-or-light" aria-hidden="true">
+                        →
+                      </span>
+                    </button>
+                  </div>
+                </form>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/lib/email/transactional.ts
+++ b/lib/email/transactional.ts
@@ -698,3 +698,52 @@ export async function sendStatsHebdoPrestataire({
     }),
   });
 }
+
+/**
+ * Devis Express (Cercle Pro · Phase 4) — email envoyé à la prestataire
+ * quand une utilisatrice soumet une demande de devis depuis sa fiche.
+ *
+ * Le contact (téléphone, email) de l'utilisatrice est inclus pour que
+ * la prestataire puisse répondre directement out-of-band. La trace
+ * en DB sert d'archive + dashboard.
+ */
+export async function sendDevisExpressEmail({
+  to,
+  prestaPrenom,
+  ficheNom,
+  utilisatricePrenom,
+  utilisatriceEmail,
+  utilisatriceTelephone,
+  message,
+  dashboardUrl,
+}: {
+  to: string;
+  prestaPrenom: string;
+  ficheNom: string;
+  utilisatricePrenom: string;
+  utilisatriceEmail: string;
+  utilisatriceTelephone?: string | null;
+  message: string;
+  dashboardUrl: string;
+}) {
+  const contactLines = [
+    `Email : ${utilisatriceEmail}`,
+    utilisatriceTelephone ? `Téléphone : ${utilisatriceTelephone}` : null,
+  ].filter(Boolean) as string[];
+
+  await sendEmail({
+    to,
+    subject: `Demande de devis — ${utilisatricePrenom} via Hilmy`,
+    html: buildRichLayout({
+      preview: `${utilisatricePrenom} te contacte pour un devis`,
+      title: `${prestaPrenom}, ${utilisatricePrenom} te demande un devis.`,
+      paragraphs: [
+        `Une copine vient de soumettre une demande de devis sur ta fiche ${ficheNom} via Hilmy. Voici son message :`,
+      ],
+      quote: message,
+      ctaLabel: "Voir mes demandes de devis",
+      ctaHref: dashboardUrl,
+      footer: `Pour répondre, écris-lui directement : ${contactLines.join(" · ")}. Tu peux marquer cette demande comme traitée depuis ton dashboard.`,
+    }),
+  });
+}

--- a/supabase/migrations/36_devis_requests.sql
+++ b/supabase/migrations/36_devis_requests.sql
@@ -1,0 +1,146 @@
+-- =====================================================================
+-- HILMY · 36 — Devis Express (Cercle Pro · Phase 4)
+-- Table devis_requests : demandes de devis envoyées par les utilisatrices
+-- aux prestataires Cercle Pro.
+-- Idempotent.
+--
+-- Modèle :
+--  - Chaque ligne = une demande envoyée par une utilisatrice (auth requise)
+--    à une prestataire spécifique
+--  - L'email envoyée à la prestataire est best-effort (pas de garantie
+--    de delivery → la table sert d'archive + dashboard)
+--  - La prestataire peut répondre directement à l'utilisatrice (out of
+--    band, hors Hilmy) → la table sert juste à archiver l'historique
+--    + permettre de marquer "traité" / "ignoré"
+--
+-- ATTENTION : ne pas exécuter en prod sans validation Jiji.
+-- Exécuter via : bash scripts/run-migration.sh 36_devis_requests.sql
+-- =====================================================================
+
+CREATE TABLE IF NOT EXISTS public.devis_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prestataire_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Infos contact saisies dans le formulaire (snapshot à l'envoi)
+  prenom TEXT NOT NULL,
+  email TEXT NOT NULL,
+  telephone TEXT,
+  message TEXT NOT NULL,
+
+  -- Statut traité côté prestataire
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'replied', 'ignored', 'archived')),
+
+  -- Trace email best-effort (null si l'envoi a raté)
+  email_sent_at TIMESTAMPTZ,
+  email_error TEXT,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS devis_requests_prestataire_created_idx
+  ON public.devis_requests (prestataire_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS devis_requests_user_idx
+  ON public.devis_requests (user_id);
+
+CREATE INDEX IF NOT EXISTS devis_requests_pending_idx
+  ON public.devis_requests (prestataire_id) WHERE status = 'pending';
+
+COMMENT ON TABLE public.devis_requests IS
+  'Demandes de devis envoyées par utilisatrices aux prestataires Cercle Pro (Phase 4).';
+COMMENT ON COLUMN public.devis_requests.status IS
+  'pending = en attente / replied = répondu / ignored = ignoré par prestataire / archived = archivé.';
+COMMENT ON COLUMN public.devis_requests.message IS
+  'Texte libre saisi par utilisatrice. Limite côté server action 2000 chars.';
+
+-- ─── Trigger updated_at ──────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.bump_devis_requests_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS devis_requests_updated_at_trg ON public.devis_requests;
+CREATE TRIGGER devis_requests_updated_at_trg
+  BEFORE UPDATE ON public.devis_requests
+  FOR EACH ROW EXECUTE FUNCTION public.bump_devis_requests_updated_at();
+
+-- ─── RLS ─────────────────────────────────────────────────────────────
+ALTER TABLE public.devis_requests ENABLE ROW LEVEL SECURITY;
+
+-- INSERT : utilisatrice authentifiée pour elle-même.
+-- La validation que la prestataire ciblée est bien Cercle Pro se fait
+-- côté server action (la policy SQL ne peut pas joindre profiles ici
+-- sans complexifier).
+DROP POLICY IF EXISTS "devis_requests_user_insert" ON public.devis_requests;
+CREATE POLICY "devis_requests_user_insert"
+  ON public.devis_requests
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+-- SELECT : 2 cas
+--  1) L'utilisatrice qui a envoyé le devis peut voir ses propres devis
+--  2) La prestataire (owner du profile cible) peut voir les devis reçus
+DROP POLICY IF EXISTS "devis_requests_user_select_own" ON public.devis_requests;
+CREATE POLICY "devis_requests_user_select_own"
+  ON public.devis_requests
+  FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "devis_requests_prestataire_select" ON public.devis_requests;
+CREATE POLICY "devis_requests_prestataire_select"
+  ON public.devis_requests
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = devis_requests.prestataire_id
+        AND p.user_id = auth.uid()
+    )
+  );
+
+-- UPDATE : seule la prestataire peut changer le statut (pending -> replied/ignored/archived)
+DROP POLICY IF EXISTS "devis_requests_prestataire_update_status" ON public.devis_requests;
+CREATE POLICY "devis_requests_prestataire_update_status"
+  ON public.devis_requests
+  FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = devis_requests.prestataire_id
+        AND p.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = devis_requests.prestataire_id
+        AND p.user_id = auth.uid()
+    )
+  );
+
+-- DELETE : aucune policy → personne ne peut supprimer (cleanup admin via service-role).
+
+-- ─── Reload PostgREST schema cache ───────────────────────────────────
+NOTIFY pgrst, 'reload schema';
+
+-- =====================================================================
+-- ROLLBACK
+-- =====================================================================
+-- DROP POLICY IF EXISTS "devis_requests_user_insert" ON public.devis_requests;
+-- DROP POLICY IF EXISTS "devis_requests_user_select_own" ON public.devis_requests;
+-- DROP POLICY IF EXISTS "devis_requests_prestataire_select" ON public.devis_requests;
+-- DROP POLICY IF EXISTS "devis_requests_prestataire_update_status" ON public.devis_requests;
+-- DROP TRIGGER IF EXISTS devis_requests_updated_at_trg ON public.devis_requests;
+-- DROP FUNCTION IF EXISTS public.bump_devis_requests_updated_at();
+-- DROP TABLE IF EXISTS public.devis_requests;
+-- =====================================================================


### PR DESCRIPTION
## Quoi
Implémente la promesse Cercle Pro \"Devis express\" end-to-end (migration SQL + RLS + API + UI fiche + dashboard).

## Architecture

### Migration 36 (à exécuter Jiji avant merge)
- Table \`devis_requests\` (prestataire_id, user_id, prenom, email, telephone, message, status, email_sent_at, email_error, timestamps)
- 3 indexes (prestataire+created DESC, user, partial pending)
- **RLS strict** :
  - INSERT : utilisatrice authentifiée pour elle-même
  - SELECT : 2 cas → utilisatrice voit ses devis OU prestataire owner voit les siens
  - UPDATE : seule la prestataire peut changer le statut
  - DELETE : aucune policy (cleanup admin via service-role)
- Trigger updated_at

### Template email \`sendDevisExpressEmail\`
Best-effort, contient contact utilisatrice (email + tel optionnel) + message en quote, signature Sara, lien dashboard prestataire.

### Route POST \`/api/devis-requests\`
- Auth obligatoire + rate limit 3 / 5min / utilisatrice (anti-spam)
- Validation : prénom 1-80, email format, message 5-2000 chars
- Vérifie prestataire \`palier='cercle_pro' AND status='approved'\`
- Insert via RLS (policy user_insert)
- Email best-effort + update \`email_sent_at\` / \`email_error\` en service-role

### UI fiche prestataire
- \`DevisExpressCTA\` rendu conditionnellement \`palier === 'cercle_pro' AND !isPreview\`
- Bouton or \"✨ Demander un devis\" sous le bloc contact
- Si non connectée : redirect \`/auth/signup\` avec retour fiche
- Modal mobile-first (full bottom sheet mobile, dialog centered desktop)
- Pré-fill prénom + email depuis user_profiles + auth

### Dashboard prestataire
- Layout : entrée sidebar \"Mes devis\" Cercle Pro uniquement, badge nombre pending
- Page \`/dashboard/prestataire/devis\` :
  - Garde Cercle Pro (redirect /abonnement sinon)
  - Liste pending + historique
  - DevisRow : expand pour voir message complet, CTAs actions changement statut (pending → replied/ignored, replied → archived), affiche email_sent_at / email_error

## ⚠️ Migration SQL requise avant merge
\`\`\`bash
bash scripts/run-migration.sh supabase/migrations/36_devis_requests.sql
\`\`\`

Vérification post-migration :
\`\`\`sql
SELECT polname, polcmd FROM pg_policies WHERE tablename='devis_requests';
SELECT count(*) FROM devis_requests;
\`\`\`

Tester un devis bout en bout :
1. Compte utilisatrice authentifiée → fiche prestataire Cercle Pro → bouton \"Demander un devis\" → modal → soumettre
2. Côté prestataire Cercle Pro → /dashboard/prestataire/devis → la demande apparaît en \"À traiter\"
3. Click \"Marquer répondu\" → bascule en \"Historique\"
4. Email Resend reçu côté prestataire avec contact utilisatrice

## Risques
- 🟡 **Migration SQL 36 requise avant merge** sinon insert et select planteront
- Layout dashboard fait un best-effort count sur devis_requests : sans la table, le badge sidebar reste à 0 mais ne crash pas (query échoue silencieusement)
- Service-role utilisé uniquement dans la route API (auth requise en amont)
- Build OK local

## Verdict
🟡 **À MERGER MANUELLEMENT par Jiji après exécution migration 36**

Closes part of #30 (Cercle Pro \"Devis express\").