### PR TITLE
feat(stats): Stats avancées Cercle Pro (carte villes + pics horaires + benchmark)

### DIFF
--- a/app/dashboard/prestataire/page.tsx
+++ b/app/dashboard/prestataire/page.tsx
@@ -217,24 +217,27 @@ export default async function PrestataireAccueilPage() {
           </div>
         )}
 
-        {/* Bandeau "stats avancées coming soon" Cercle Pro */}
+        {/* Bandeau Stats avancées Cercle Pro — actif depuis Phase 4 */}
         {palier === 'cercle_pro' && (
           <div className="mt-6 rounded-sm bg-vert p-6 text-creme md:p-7">
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-6">
               <div>
-                <p className="overline text-or">Stats avancées · à venir</p>
+                <p className="overline text-or">Stats avancées · disponibles</p>
                 <p className="mt-2 font-serif text-[18px] italic leading-[1.4] text-creme md:text-[20px]">
                   Carte des villes, pics horaires, benchmark catégorie.
                 </p>
                 <p className="mt-2 text-[13px] leading-[1.6] text-creme/75">
-                  Tu fais partie du Cercle Pro : ces vues plus fines
-                  arrivent dans la V1.2. On te prévient dès qu&apos;elles
-                  sont prêtes.
+                  Tu fais partie du Cercle Pro — voici la vue 30 jours
+                  glissants pour piloter ton audience en profondeur.
                 </p>
               </div>
-              <span className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full border border-or/40 px-4 text-[11px] font-medium tracking-[0.22em] text-or-light uppercase">
-                Bientôt
-              </span>
+              <Link
+                href="/dashboard/prestataire/stats-avancees"
+                className="inline-flex h-11 shrink-0 items-center gap-2 rounded-full bg-or px-5 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:bg-or-light"
+              >
+                Voir mes stats avancées
+                <span aria-hidden="true">→</span>
+              </Link>
             </div>
           </div>
         )}

--- a/app/dashboard/prestataire/stats-avancees/page.tsx
+++ b/app/dashboard/prestataire/stats-avancees/page.tsx
@@ -1,0 +1,221 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
+import { GoldLine } from '@/components/ui/GoldLine'
+import { StatCard } from '@/components/dashboard/StatCard'
+import {
+  VillesBarChart,
+  HeuresBarChart,
+} from '@/components/dashboard/AdvancedCharts'
+import { requirePrestataire } from '@/lib/supabase/session'
+import { createClient } from '@/lib/supabase/server'
+import { CATEGORIES_MAP } from '@/lib/constants'
+import {
+  aggregateByVille,
+  aggregateByHeure,
+  computeCategoryPercentile,
+  benchmarkWording,
+  type VueRow,
+} from '@/lib/stats/aggregations'
+
+const SINCE_DAYS = 30
+
+export default async function StatsAvanceesPage() {
+  const { prestataire } = await requirePrestataire()
+
+  // Garde Cercle Pro
+  if (prestataire.palier !== 'cercle_pro') {
+    redirect('/dashboard/prestataire/abonnement')
+  }
+
+  const supabase = await createClient()
+  const since = new Date(
+    Date.now() - SINCE_DAYS * 86_400_000,
+  ).toISOString()
+
+  // 1. Mes vues sur 30j (avec ville pour la carte)
+  const { data: myViewsRows } = await supabase
+    .from('profile_views')
+    .select('viewed_at, city')
+    .eq('profile_id', prestataire.id)
+    .gte('viewed_at', since)
+
+  const myRows: VueRow[] = (myViewsRows ?? []) as VueRow[]
+  const myViewsCount = myRows.length
+
+  // 2. Pairs : autres prestataires de même catégorie (Premium + Cercle Pro)
+  //    On count leurs vues 30j pour bench. On exclut soi-même.
+  const { data: peers } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('categorie', prestataire.categorie)
+    .in('palier', ['premium', 'cercle_pro'])
+    .eq('status', 'approved')
+    .neq('id', prestataire.id)
+
+  const peerIds = (peers ?? []).map((p) => p.id)
+
+  // Pour chaque peer, count vues 30j en parallèle (limit pour éviter
+  // une vague de requêtes — top 50 pairs suffisent pour un percentile fiable)
+  const peerSubset = peerIds.slice(0, 50)
+  const peerCounts: number[] = await Promise.all(
+    peerSubset.map(async (pid) => {
+      const { count } = await supabase
+        .from('profile_views')
+        .select('id', { count: 'exact', head: true })
+        .eq('profile_id', pid)
+        .gte('viewed_at', since)
+      return count ?? 0
+    }),
+  )
+
+  // 3. Agrégations
+  const villes = aggregateByVille(myRows, 8)
+  const heures = aggregateByHeure(myRows)
+  const percentile = computeCategoryPercentile(myViewsCount, peerCounts)
+  const wording = benchmarkWording(percentile)
+
+  // 4. Top heure (pour StatCard)
+  const topHeure = heures.reduce(
+    (best, cur) => (cur.vues > best.vues ? cur : best),
+    { heure: '—', vues: 0 },
+  )
+  const topVille = villes[0]
+
+  const categorieLabel =
+    CATEGORIES_MAP[prestataire.categorie] ?? prestataire.categorie
+
+  return (
+    <>
+      <DashboardHeader
+        kicker="Stats avancées"
+        titre={
+          <>
+            Ton audience,{' '}
+            <em className="font-serif italic text-or">en profondeur.</em>
+          </>
+        }
+        lead={`Carte des villes, pics horaires, benchmark catégorie. Sur les ${SINCE_DAYS} derniers jours.`}
+        actions={
+          <Link
+            href="/dashboard/prestataire"
+            className="inline-flex h-11 items-center gap-2 rounded-full border border-or/40 px-5 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-or hover:bg-blanc"
+          >
+            ← Retour au dashboard
+          </Link>
+        }
+      />
+
+      {/* KPIs résumé */}
+      <section className="px-6 py-10 md:px-12 md:py-14">
+        <div className="mb-8 flex items-center gap-4">
+          <GoldLine width={40} />
+          <span className="overline text-or">Vue d&apos;ensemble · {SINCE_DAYS}j</span>
+        </div>
+        <div className="grid gap-4 md:grid-cols-3">
+          <StatCard
+            kicker="Vues totales 30j"
+            value={myViewsCount.toLocaleString('fr-FR')}
+            hint="Visiteuses uniques de ta fiche"
+            index={0}
+          />
+          <StatCard
+            kicker="Top ville"
+            value={topVille ? topVille.ville : '—'}
+            hint={topVille ? `${topVille.vues} vues` : 'Pas encore de données'}
+            variant="or"
+            index={1}
+          />
+          <StatCard
+            kicker="Pic horaire"
+            value={topHeure.vues > 0 ? topHeure.heure : '—'}
+            hint={
+              topHeure.vues > 0
+                ? `${topHeure.vues} vues à ${topHeure.heure} (UTC)`
+                : 'Pas encore de pic identifiable'
+            }
+            variant="vert"
+            index={2}
+          />
+        </div>
+      </section>
+
+      {/* Carte des villes */}
+      <section className="bg-blanc px-6 py-12 md:px-12 md:py-16">
+        <div className="rounded-sm border border-or/15 bg-creme-soft p-6 md:p-8">
+          <div className="mb-4 flex items-start justify-between gap-4">
+            <div>
+              <p className="overline text-or">Carte des villes</p>
+              <h2 className="mt-2 font-serif text-2xl font-light text-vert">
+                D&apos;où viennent tes copines.
+              </h2>
+              <p className="mt-1 text-[12px] italic text-texte-sec">
+                Top 8 villes par nombre de vues sur 30j.
+              </p>
+            </div>
+          </div>
+          <VillesBarChart data={villes} />
+        </div>
+      </section>
+
+      {/* Pics horaires */}
+      <section className="px-6 py-12 md:px-12 md:py-16">
+        <div className="rounded-sm border border-or/15 bg-creme-soft p-6 md:p-8">
+          <div className="mb-4 flex items-start justify-between gap-4">
+            <div>
+              <p className="overline text-or">Pics horaires</p>
+              <h2 className="mt-2 font-serif text-2xl font-light text-vert">
+                Quand on te regarde.
+              </h2>
+              <p className="mt-1 text-[12px] italic text-texte-sec">
+                Distribution des vues par heure de la journée (UTC) sur 30j.
+                Idéal pour caler tes posts Insta ou tes annonces d&apos;événements.
+              </p>
+            </div>
+          </div>
+          <HeuresBarChart data={heures} />
+        </div>
+      </section>
+
+      {/* Benchmark catégorie */}
+      <section className="bg-vert px-6 py-12 text-creme md:px-12 md:py-16">
+        <div className="mx-auto max-w-3xl">
+          <div className="flex items-center gap-4">
+            <GoldLine width={40} />
+            <span className="overline text-or">Benchmark catégorie</span>
+          </div>
+          <h2 className="mt-4 font-serif text-3xl font-light text-creme md:text-4xl">
+            Où tu te situes en{' '}
+            <em className="italic text-or">{categorieLabel}</em>.
+          </h2>
+
+          {percentile !== null && (
+            <div className="mt-8 rounded-sm border border-or/30 bg-vert-dark/40 p-6 md:p-8">
+              <p className="font-serif text-[64px] font-light leading-none text-or md:text-[80px]">
+                {percentile}
+              </p>
+              <p className="mt-1 text-[11px] tracking-[0.28em] text-or-light uppercase">
+                Percentile dans ta catégorie
+              </p>
+            </div>
+          )}
+
+          <p className="mt-6 text-[15px] leading-[1.7] text-creme/85">
+            {wording}
+          </p>
+
+          <p className="mt-6 text-[11px] italic text-creme/55">
+            Comparaison vs les autres prestataires Premium et Cercle Pro de la
+            catégorie {categorieLabel} sur la même fenêtre 30j (échantillon
+            de {peerCounts.length} prestataires).
+          </p>
+        </div>
+      </section>
+
+      {/* Footer reassurance */}
+      <p className="px-6 pb-12 pt-8 text-center font-sans text-[12px] italic text-texte-sec">
+        Stats avancées · Cercle Pro · données agrégées 30j glissants
+      </p>
+    </>
+  )
+}

--- a/components/dashboard/AdvancedCharts.tsx
+++ b/components/dashboard/AdvancedCharts.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts'
+
+const axisTick = {
+  fontSize: 10,
+  fontFamily: 'var(--font-dm-sans)',
+  fill: '#6B5D54',
+  letterSpacing: '0.12em',
+  textTransform: 'uppercase' as const,
+}
+
+const tooltipStyle = {
+  background: '#FDFBF7',
+  border: '1px solid #C9A961',
+  borderRadius: '2px',
+  fontSize: '12px',
+  color: '#2A1F1A',
+  padding: '8px 12px',
+  boxShadow: '0 20px 40px -20px rgba(15,61,46,0.25)',
+}
+
+const orPalette = ['#C9A961', '#B8924A', '#0F3D2E', '#1a4a3a', '#D4C5B0']
+
+/**
+ * Carte des villes : barres horizontales.
+ * Top N villes (default 8) avec compteur vues sur la fenêtre fournie.
+ */
+export function VillesBarChart({
+  data,
+}: {
+  data: { ville: string; vues: number }[]
+}) {
+  if (data.length === 0) {
+    return (
+      <p className="px-4 py-12 text-center text-[13px] italic text-texte-sec">
+        Pas encore assez de données géo. Reviens d&apos;ici une semaine ou deux.
+      </p>
+    )
+  }
+  return (
+    <div className="h-80 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          data={data}
+          layout="vertical"
+          margin={{ top: 10, right: 20, left: 80, bottom: 10 }}
+        >
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="#C9A961"
+            strokeOpacity={0.15}
+            horizontal={false}
+          />
+          <XAxis type="number" tick={axisTick} axisLine={false} tickLine={false} />
+          <YAxis
+            type="category"
+            dataKey="ville"
+            tick={axisTick}
+            axisLine={false}
+            tickLine={false}
+            width={120}
+          />
+          <Tooltip
+            contentStyle={tooltipStyle}
+            cursor={{ fill: '#C9A961', fillOpacity: 0.08 }}
+            formatter={(v: number) => [`${v} vues`, 'Vues']}
+          />
+          <Bar dataKey="vues" barSize={20} radius={[2, 2, 2, 2]}>
+            {data.map((_, i) => (
+              <Cell key={i} fill={orPalette[i % orPalette.length]} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+/**
+ * Pics horaires : barres verticales 24h.
+ */
+export function HeuresBarChart({
+  data,
+}: {
+  data: { heure: string; vues: number }[]
+}) {
+  if (data.every((d) => d.vues === 0)) {
+    return (
+      <p className="px-4 py-12 text-center text-[13px] italic text-texte-sec">
+        Aucune visite enregistrée sur cette fenêtre. Patience, ça vient.
+      </p>
+    )
+  }
+  return (
+    <div className="h-72 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 10, right: 10, left: -10, bottom: 10 }}>
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="#C9A961"
+            strokeOpacity={0.15}
+            vertical={false}
+          />
+          <XAxis
+            dataKey="heure"
+            tick={axisTick}
+            axisLine={{ stroke: '#C9A961', strokeOpacity: 0.3 }}
+            tickLine={false}
+            interval={2}
+          />
+          <YAxis
+            tick={axisTick}
+            axisLine={false}
+            tickLine={false}
+            width={30}
+          />
+          <Tooltip
+            contentStyle={tooltipStyle}
+            cursor={{ fill: '#C9A961', fillOpacity: 0.08 }}
+            formatter={(v: number) => [`${v} vues`, 'Vues']}
+          />
+          <Bar dataKey="vues" barSize={14} radius={[3, 3, 0, 0]} fill="#C9A961" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/lib/stats/aggregations.ts
+++ b/lib/stats/aggregations.ts
@@ -1,0 +1,104 @@
+/**
+ * Agrégations stats avancées Cercle Pro.
+ * Pures fonctions JS sur des arrays de timestamps / villes / lignes.
+ *
+ * Volume cible : un Cercle Pro très visible peut atteindre quelques k vues
+ * sur 30 jours → agrégation client-side acceptable. Si on dépasse 50k, on
+ * passera en RPC SQL.
+ */
+
+export interface VueRow {
+  viewed_at: string
+  city: string | null
+}
+
+/**
+ * Top N villes par nombre de vues sur la fenêtre fournie.
+ * Filtre les city null/empty. Tri DESC par compteur.
+ */
+export function aggregateByVille(
+  rows: VueRow[],
+  topN: number = 8,
+): { ville: string; vues: number }[] {
+  const counts = new Map<string, number>()
+  for (const r of rows) {
+    const city = r.city?.trim()
+    if (!city) continue
+    counts.set(city, (counts.get(city) ?? 0) + 1)
+  }
+  return Array.from(counts.entries())
+    .map(([ville, vues]) => ({ ville, vues }))
+    .sort((a, b) => b.vues - a.vues)
+    .slice(0, topN)
+}
+
+/**
+ * Pics horaires : 24 buckets (00h → 23h) sur la fenêtre.
+ * Heure dérivée du timestamp viewed_at en local time UTC (Vercel server).
+ * Convention : 00h = minuit, 12h = midi.
+ */
+export function aggregateByHeure(
+  rows: VueRow[],
+): { heure: string; vues: number }[] {
+  const buckets: number[] = new Array(24).fill(0)
+  for (const r of rows) {
+    const d = new Date(r.viewed_at)
+    if (Number.isNaN(d.getTime())) continue
+    const h = d.getUTCHours() // UTC -> simple, agrégat statistique
+    buckets[h]++
+  }
+  return buckets.map((vues, h) => ({
+    heure: `${h.toString().padStart(2, '0')}h`,
+    vues,
+  }))
+}
+
+/**
+ * Benchmark catégorie : retourne le percentile dans lequel se situe
+ * le prestataire par rapport à ses pairs (autres Premium/Cercle Pro
+ * de la même catégorie sur la même fenêtre).
+ *
+ * Exemple : percentile=80 → "tu es dans le top 20%".
+ *
+ * @param myViews Nombre de vues du prestataire sur la fenêtre
+ * @param peerViews Liste des vues de chaque pair (un nombre par pair)
+ * @returns null si pas assez de pairs pour calculer un benchmark fiable
+ */
+export function computeCategoryPercentile(
+  myViews: number,
+  peerViews: number[],
+): number | null {
+  if (peerViews.length < 3) return null // pas assez de signal
+  const all = [...peerViews, myViews].sort((a, b) => a - b)
+  // Position du prestataire (index dernière occurrence pour gérer ex-aequo)
+  let pos = -1
+  for (let i = all.length - 1; i >= 0; i--) {
+    if (all[i] === myViews) {
+      pos = i
+      break
+    }
+  }
+  if (pos === -1) return null
+  // Percentile = % de pairs en dessous (inclus le prestataire lui-même)
+  return Math.round(((pos + 1) / all.length) * 100)
+}
+
+/**
+ * Wording UX du benchmark selon le percentile.
+ * Voix Sara : tutoiement, encourageant, jamais culpabilisant.
+ */
+export function benchmarkWording(percentile: number | null): string {
+  if (percentile === null) {
+    return "Pas encore assez de prestataires comparables dans ta catégorie pour te situer. Reviens dans quelques semaines."
+  }
+  if (percentile >= 80) {
+    return `Tu es dans le top ${100 - percentile}% de ta catégorie. Tu rayonnes — continue comme ça.`
+  }
+  if (percentile >= 50) {
+    return `Tu es au-dessus de la moyenne de ta catégorie (top ${100 - percentile}%). Tu construis quelque chose de solide.`
+  }
+  if (percentile >= 25) {
+    return `Tu es dans la moyenne basse de ta catégorie. Quelques boosts ou un événement bien placé peuvent t'aider à monter.`
+  }
+  return `Ta visibilité est plus discrète que celle de la majorité de ta catégorie. C'est normal au début — pousse ta fiche, demande des avis aux premières clientes, propose un événement.`
+}


### PR DESCRIPTION
## Quoi
Implémente la promesse Cercle Pro \"Stats avancées\" qui était explicitement marquée \"à venir V1.2\" dans le dashboard.

## Architecture (zéro migration SQL, agrégations sur tables existantes)

### Helpers \`lib/stats/aggregations.ts\` (pures fonctions JS testables)
- \`aggregateByVille(rows, topN=8)\` : top N villes par compteur
- \`aggregateByHeure(rows)\` : 24 buckets 00h-23h en UTC
- \`computeCategoryPercentile(myViews, peerViews[])\` : percentile dans la distribution. Null si <3 pairs (pas assez de signal)
- \`benchmarkWording(percentile)\` : voix Sara, jamais culpabilisant, conseil contextuel par tranche

### Charts \`components/dashboard/AdvancedCharts.tsx\` (use client, Recharts)
- \`VillesBarChart\` : barres horizontales palette or
- \`HeuresBarChart\` : barres verticales 24h
- Style cohérent avec \`Charts.tsx\` existant

### Page \`/dashboard/prestataire/stats-avancees\`
- **Garde Cercle Pro stricte** (redirect /abonnement sinon)
- Query : profile_views 30j + liste pairs catégorie (Premium+Cercle Pro, status approved, exclude self) + counts vues 30j de chaque pair en parallèle (limit top 50)
- 4 sections : KPIs (vues totales, top ville, pic horaire), carte villes, pics horaires, benchmark catégorie avec percentile en gros + wording adapté

### Modification \`dashboard/prestataire/page.tsx\`
- Bandeau Cercle Pro \"Stats avancées · à venir V1.2\" → \"Stats avancées · disponibles\" + CTA or vers la nouvelle page
- Plus aucune mention \"Bientôt\" / \"V1.2\" — feature livrée

## Comment tester
1. Connexion compte prestataire \`palier === 'cercle_pro'\` avec quelques vues sur sa fiche
2. \`/dashboard/prestataire\` → bandeau Cercle Pro affiche maintenant \"Voir mes stats avancées →\"
3. Click → \`/dashboard/prestataire/stats-avancees\` :
   - 3 KPIs en haut (vues 30j, top ville, pic horaire)
   - Carte villes : barres horizontales top 8
   - Pics horaires : 24 barres verticales
   - Benchmark catégorie : percentile en gros + wording

Pour palier Standard/Premium : la page redirige vers /abonnement (garde stricte).

## Risques
- **Zéro migration SQL** : utilise tables existantes (profile_views, profiles)
- Volume cible OK : Cercle Pro très visible = quelques k vues/30j → agrégation client-side rapide
- Si on dépasse 50k vues/30j → passer en RPC SQL (pas le cas avant longtemps)
- Limit pairs à 50 pour ne pas faire 200+ requêtes Supabase si grosse catégorie
- Build OK local
- Page protégée par auth + garde Cercle Pro

## Verdict
🟢 **SAFE** — pas de SQL, agrégations sur tables existantes, garde Cercle Pro stricte. Merge auto.

Closes part of #30 (Cercle Pro \"Stats avancées\").