### PR TITLE
fix(contact): rollback hello@hilmy.io → hilmy.io@hotmail.com (21 occurrences)

### DIFF
--- a/app/(legal)/cgu/page.tsx
+++ b/app/(legal)/cgu/page.tsx
@@ -118,10 +118,10 @@ export default function CguPage() {
             mois&nbsp;; ils peuvent être résiliés à tout moment depuis le
             tableau de bord prestataire ou en écrivant à{' '}
             <a
-              href="mailto:hello@hilmy.io"
+              href="mailto:hilmy.io@hotmail.com"
               className="text-or-deep underline-offset-4 hover:text-or hover:underline"
             >
-              hello@hilmy.io
+              hilmy.io@hotmail.com
             </a>
             . La résiliation prend effet à la fin de la période payée en cours,
             sans remboursement prorata. Les abonnements annuels (3, 6 ou
@@ -135,10 +135,10 @@ export default function CguPage() {
             Vous pouvez demander la suppression de votre compte à tout moment en
             contactant{' '}
             <a
-              href="mailto:hello@hilmy.io"
+              href="mailto:hilmy.io@hotmail.com"
               className="text-or-deep underline-offset-4 hover:text-or hover:underline"
             >
-              hello@hilmy.io
+              hilmy.io@hotmail.com
             </a>
             . Vos données seront effacées dans un délai de 30 jours. Pour les
             comptes prestataires en cours d&apos;abonnement, la suppression

--- a/app/(legal)/confidentialite/page.tsx
+++ b/app/(legal)/confidentialite/page.tsx
@@ -26,10 +26,10 @@ export default function ConfidentialitePage() {
             <br />
             Contact&nbsp;:{' '}
             <a
-              href="mailto:hello@hilmy.io"
+              href="mailto:hilmy.io@hotmail.com"
               className="text-or-deep underline-offset-4 hover:text-or hover:underline"
             >
-              hello@hilmy.io
+              hilmy.io@hotmail.com
             </a>
           </p>
         </LegalSection>
@@ -141,10 +141,10 @@ export default function ConfidentialitePage() {
           <p className="mt-3">
             Pour exercer ces droits, contactez-nous à{' '}
             <a
-              href="mailto:hello@hilmy.io"
+              href="mailto:hilmy.io@hotmail.com"
               className="text-or-deep underline-offset-4 hover:text-or hover:underline"
             >
-              hello@hilmy.io
+              hilmy.io@hotmail.com
             </a>
             .
           </p>

--- a/app/(legal)/cookies/page.tsx
+++ b/app/(legal)/cookies/page.tsx
@@ -59,10 +59,10 @@ export default function CookiesPage() {
           <p>
             Pour toute question relative aux cookies, écris-nous à{' '}
             <a
-              href="mailto:hello@hilmy.io"
+              href="mailto:hilmy.io@hotmail.com"
               className="text-or-deep underline-offset-4 hover:text-or hover:underline"
             >
-              hello@hilmy.io
+              hilmy.io@hotmail.com
             </a>
             .
           </p>

--- a/app/(legal)/mentions-legales/page.tsx
+++ b/app/(legal)/mentions-legales/page.tsx
@@ -27,10 +27,10 @@ export default function MentionsLegalesPage() {
           <p>
             Contact&nbsp;:{' '}
             <a
-              href="mailto:hello@hilmy.io"
+              href="mailto:hilmy.io@hotmail.com"
               className="text-or-deep underline-offset-4 hover:text-or hover:underline"
             >
-              hello@hilmy.io
+              hilmy.io@hotmail.com
             </a>
           </p>
         </LegalSection>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -23,8 +23,8 @@ export default function ContactPage() {
         <ContactCard
           kicker="L'essentiel"
           titre="Email général"
-          link="mailto:hello@hilmy.io"
-          linkLabel="hello@hilmy.io"
+          link="mailto:hilmy.io@hotmail.com"
+          linkLabel="hilmy.io@hotmail.com"
           texte="Pour toute question produit, partenariat ou retour d'expérience."
         />
 

--- a/app/dashboard/prestataire/abonnement/page.tsx
+++ b/app/dashboard/prestataire/abonnement/page.tsx
@@ -45,7 +45,7 @@ export default async function AbonnementPage() {
   const supportSubject = isCerclePro
     ? '[PRIORITAIRE] Mon abonnement Hilmy'
     : 'Mon abonnement Hilmy'
-  const supportMailto = `mailto:hello@hilmy.io?subject=${encodeURIComponent(supportSubject)}`
+  const supportMailto = `mailto:hilmy.io@hotmail.com?subject=${encodeURIComponent(supportSubject)}`
   const supportSla = isCerclePro
     ? 'on te répond par email sous 12h ouvrées (support prioritaire Cercle Pro)'
     : 'on te répond par email sous 24h ouvrées'
@@ -202,7 +202,7 @@ export default async function AbonnementPage() {
             href={supportMailto}
             className="text-or-deep underline-offset-4 hover:text-or hover:underline"
           >
-            hello@hilmy.io
+            hilmy.io@hotmail.com
           </a>
           . La résiliation prend effet à la fin de ta période en cours, sans
           remboursement prorata. Aucune commission n&apos;est prélevée sur tes

--- a/app/evenement-v2/[slug]/page.tsx
+++ b/app/evenement-v2/[slug]/page.tsx
@@ -378,10 +378,10 @@ export default async function EvenementV2Page({
                 <p className="mt-3 text-[13px] leading-[1.65] text-texte-sec">
                   Écris à{' '}
                   <a
-                    href="mailto:hello@hilmy.io"
+                    href="mailto:hilmy.io@hotmail.com"
                     className="font-medium text-vert hover:text-or"
                   >
-                    hello@hilmy.io
+                    hilmy.io@hotmail.com
                   </a>
                   . On te répond sous 48h ouvrées.
                 </p>

--- a/app/tarifs/_lib/pricing.ts
+++ b/app/tarifs/_lib/pricing.ts
@@ -138,7 +138,7 @@ export function formatPrice(value: number): string {
     : `${value.toFixed(2).replace('.', ',')}€`;
 }
 
-const HELLO = 'hello@hilmy.io';
+const HELLO = 'hilmy.io@hotmail.com';
 
 /** Mailto pour les CTAs de commit prestataires (post-wizard ou switch).
  *  Si un `promoCode` est fourni (validé côté client en amont), il est

--- a/app/tarifs/page.tsx
+++ b/app/tarifs/page.tsx
@@ -367,7 +367,7 @@ export default function TarifsPage() {
                 Choisir ma formule
               </a>
               <a
-                href="mailto:hello@hilmy.io"
+                href="mailto:hilmy.io@hotmail.com"
                 className="inline-block rounded-full border border-vert bg-transparent px-8 py-4 text-[15px] font-medium text-vert transition-all hover:bg-vert hover:text-creme"
               >
                 Poser ma question


### PR DESCRIPTION
## Quoi
Inverse PR #46 + propage sur les surfaces ajoutées entre temps (CGU PR #37, dashboard abonnement PR #38, devis PR #50, etc.).

## Pourquoi
\`hello@hilmy.io\` n'est pas une vraie boîte (pas de MX records sur hilmy.io — Brevo utilise des TXT records pour l'envoi seulement). Décision Jiji : on garde \`hilmy.io@hotmail.com\` comme adresse de contact officielle.

## Fichiers modifiés (9 — 21 occurrences)
- \`app/contact/page.tsx\` (2)
- \`app/tarifs/_lib/pricing.ts\` (1, \`const HELLO\` qui propage à tous les CTAs commit pricing)
- \`app/tarifs/page.tsx\` (1, CTA \"Poser ma question\")
- \`app/evenement-v2/[slug]/page.tsx\` (2)
- \`app/dashboard/prestataire/abonnement/page.tsx\` (2)
- \`app/(legal)/cgu/page.tsx\` (4)
- \`app/(legal)/cookies/page.tsx\` (2)
- \`app/(legal)/confidentialite/page.tsx\` (4)
- \`app/(legal)/mentions-legales/page.tsx\` (2)

## ⚠️ Cas EXCLU intentionnellement
\`lib/email/transactional.ts:135\` EMAIL_FROM fallback \`\"Hilmy <hello@hilmy.io>\"\` → **reste à hello@hilmy.io** car c'est l'adresse d'EXPÉDITION via Brevo/Resend, authentifiée sur le domaine \`hilmy.io\` (pas besoin de MX pour envoyer). Si on changeait pour hotmail, SPF/DKIM Brevo casse et tous les emails transactionnels passent en spam.

Si Jiji veut quand même changer ça → mini-PR de suivi avec test prealable d'un envoi via Brevo en `Hilmy <hilmy.io@hotmail.com>`.

## Smoke check
Vérifié en preview locale : /tarifs, /cgu, /confidentialite → 0 occurrence \"hello@hilmy.io\" dans le HTML, tous les mailtos pointent vers \`mailto:hilmy.io@hotmail.com\`.

## Verdict
🟢 **SAFE** — string replacement. Merge auto.