### PR TITLE
fix(je-cherche): repositionnement TeamCherche public vs connected

### DIFF
--- a/app/accueil/page.tsx
+++ b/app/accueil/page.tsx
@@ -6,6 +6,7 @@ import { GoldLine } from '@/components/ui/GoldLine'
 import { FadeInSection } from '@/components/ui/FadeInSection'
 import { EvenementCard } from '@/components/v2/EvenementCard'
 import { HomeMap, type MapPoint } from '@/components/v2/HomeMap'
+import { TeamCherche } from '@/components/landing/TeamCherche'
 import {
   getCentroid,
   offsetPoint,
@@ -351,8 +352,13 @@ export default async function AccueilPage() {
 
   return (
     <PageShell navVariant="solid">
+      {/* Module Je cherche : variant connected (vraies demandes) */}
+      <div className="pt-24 md:pt-32">
+        <TeamCherche />
+      </div>
+
       {/* Hero mini */}
-      <section className="relative overflow-hidden bg-creme-soft pt-28 pb-14 md:pt-36 md:pb-20">
+      <section className="relative overflow-hidden bg-creme-soft pt-14 pb-14 md:pt-20 md:pb-20">
         <div className="absolute inset-0 bg-grain opacity-[0.06]" />
         <div className="relative mx-auto max-w-container px-6 md:px-20">
           <div className="flex items-center gap-4">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,7 @@ export default function HomePage() {
         <Manifesto />
         <ThreePromises />
         <ElleProfiles />
-        <TeamCherche />
+        <TeamCherche variant="public" />
         <PricingTeaser />
         <FAQ />
         <FinalCTA />

--- a/components/landing/TeamCherche.tsx
+++ b/components/landing/TeamCherche.tsx
@@ -22,11 +22,73 @@ function initial(prenom: string | null): string {
 }
 
 /**
- * Section home : carrousel horizontal "La team cherche…".
- * 4 demandes triées urgent > created_at, dernière card = CTA poster une demande.
- * Server Component.
+ * Cards démo statiques pour la home publique (variant="public").
+ * Aucune info perso (pas de prénom réel, pas d'avatar, pas de timestamp
+ * relatif) — juste un teaser pour donner envie de s'inscrire.
+ *
+ * Toutes les variantes "publiques" du composant pointent vers /auth/signup,
+ * pas vers les vraies demandes (fonctionnalité réservée aux inscrites).
  */
-export async function TeamCherche() {
+const DEMO_CARDS_PUBLIC: {
+  id: string
+  category: string
+  title: string
+  city: string
+}[] = [
+  {
+    id: 'demo-1',
+    category: 'maison',
+    title: 'Une copine cherche une décoratrice',
+    city: 'Genève',
+  },
+  {
+    id: 'demo-2',
+    category: 'evenementiel',
+    title: 'Une copine cherche un photographe mariage',
+    city: 'Lausanne',
+  },
+  {
+    id: 'demo-3',
+    category: 'beaute',
+    title: 'Une copine cherche un coiffeur curly',
+    city: 'Annemasse',
+  },
+  {
+    id: 'demo-4',
+    category: 'sport-nutrition',
+    title: 'Une copine cherche une coach sportive',
+    city: 'Fribourg',
+  },
+]
+
+interface TeamCherchePropsBase {
+  /**
+   * - "connected" (default) : fetch les vraies demandes via Supabase,
+   *   tous les CTAs pointent vers /je-cherche.
+   * - "public" : 4 cards démo statiques sans info perso, tous les CTAs
+   *   pointent vers /auth/signup. Aucun fetch Supabase.
+   */
+  variant?: 'connected' | 'public'
+}
+
+/**
+ * Section home : carrousel horizontal "La team cherche…".
+ *
+ * Mode "connected" : 4 demandes triées urgent > created_at, dernière card
+ * = CTA poster une demande. Affiche prénoms réels + villes.
+ *
+ * Mode "public" : 4 cards démo anonymisées + tous les CTAs vers /auth/signup
+ * (la fonctionnalité Je cherche est réservée aux inscrites).
+ */
+export async function TeamCherche({ variant = 'connected' }: TeamCherchePropsBase = {}) {
+  if (variant === 'public') return <TeamCherchePublic />
+  return <TeamCherchePrivate />
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+ * Variant "connected" — vraies données Supabase, CTAs vers /je-cherche
+ * ─────────────────────────────────────────────────────────────────── */
+async function TeamCherchePrivate() {
   const result = await getDemandesForHomeCarousel()
   const demandes: DemandeWithProfile[] = result.ok ? result.data : []
 
@@ -113,6 +175,106 @@ export async function TeamCherche() {
             <li className="w-[260px] shrink-0 snap-start sm:w-[280px]">
               <Link
                 href="/je-cherche/nouvelle"
+                className="group flex h-full flex-col items-center justify-center gap-4 rounded-sm bg-vert p-6 text-center text-creme transition-all duration-300 hover:-translate-y-0.5 hover:bg-vert-dark"
+              >
+                <span className="overline text-or">À toi</span>
+                <p className="font-serif text-[20px] font-light italic leading-tight text-creme">
+                  Demande à la team
+                </p>
+                <p className="text-[12px] leading-[1.55] text-creme/80">
+                  On a forcément l&apos;adresse.
+                </p>
+                <span className="mt-1 inline-flex items-center gap-2 rounded-full border border-or/40 px-4 py-2 text-[10px] font-medium tracking-[0.22em] text-or uppercase transition-all group-hover:bg-or group-hover:text-vert">
+                  + Poster ma demande
+                </span>
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+ * Variant "public" — cards démo statiques anonymisées, CTAs vers signup
+ * ─────────────────────────────────────────────────────────────────── */
+function TeamCherchePublic() {
+  const SIGNUP_HREF = '/auth/signup'
+
+  return (
+    <section className="bg-creme py-20 md:py-28">
+      <div className="mx-auto max-w-container px-6 md:px-20">
+        <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+          <div>
+            <div className="flex items-center gap-4">
+              <GoldLine width={48} />
+              <span className="overline text-or">Le feed des copines</span>
+            </div>
+            <h2 className="mt-5 font-serif text-h2 font-light leading-[1.05] text-vert">
+              La team{' '}
+              <em className="italic text-or">cherche</em>
+              <span className="text-or">…</span>
+            </h2>
+          </div>
+          <Link
+            href={SIGNUP_HREF}
+            className="group inline-flex items-center gap-2 self-start text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-colors hover:text-or md:self-auto"
+          >
+            Voir tout
+            <span className="text-or transition-transform group-hover:translate-x-0.5">
+              →
+            </span>
+          </Link>
+        </div>
+
+        <div className="mt-10 -mx-6 md:-mx-20">
+          <ul
+            className="flex snap-x snap-mandatory gap-4 overflow-x-auto px-6 pb-2 md:px-20 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            aria-label="Aperçu des demandes des copines"
+          >
+            {DEMO_CARDS_PUBLIC.map((d) => (
+              <li key={d.id} className="w-[260px] shrink-0 snap-start sm:w-[280px]">
+                <Link
+                  href={SIGNUP_HREF}
+                  className="group flex h-full flex-col rounded-sm border border-or/15 bg-blanc p-5 transition-all duration-300 hover:-translate-y-0.5 hover:border-or/40 hover:shadow-[0_16px_32px_-20px_rgba(15,61,46,0.25)]"
+                  aria-label="Rejoindre la team pour voir cette demande"
+                >
+                  <div className="flex items-start gap-2.5">
+                    <div
+                      className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full bg-creme-deep"
+                      aria-hidden="true"
+                    >
+                      <span className="flex h-full w-full items-center justify-center font-serif text-[14px] font-light text-or">
+                        ·
+                      </span>
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-[12px] font-medium text-vert">
+                        Une copine
+                      </p>
+                      <p className="truncate text-[10px] text-texte-sec">
+                        {d.city}
+                      </p>
+                    </div>
+                  </div>
+                  <p className="mt-3 text-[9px] tracking-[0.22em] text-or-deep uppercase">
+                    {CATEGORY_LABELS[d.category] ?? d.category}
+                  </p>
+                  <h3 className="mt-1.5 line-clamp-3 font-serif text-[16px] font-light leading-tight text-vert break-words">
+                    {d.title}
+                  </h3>
+                  <div className="mt-auto pt-4 text-[11px] font-medium text-or">
+                    Rejoindre pour voir →
+                  </div>
+                </Link>
+              </li>
+            ))}
+
+            {/* Card CTA finale : signup */}
+            <li className="w-[260px] shrink-0 snap-start sm:w-[280px]">
+              <Link
+                href={SIGNUP_HREF}
                 className="group flex h-full flex-col items-center justify-center gap-4 rounded-sm bg-vert p-6 text-center text-creme transition-all duration-300 hover:-translate-y-0.5 hover:bg-vert-dark"
               >
                 <span className="overline text-or">À toi</span>


### PR DESCRIPTION
## Quoi
Repositionnement du module Je cherche : variant 'public' (cards demo anonymisees + CTAs vers /auth/signup) sur la home publique, variant 'connected' (vraies donnees + CTAs vers /je-cherche) ajoute en haut de /accueil.

## Pourquoi
Avant : la home publique exposait les vraies demandes (prenom + ville + timestamp) -> fuite d'infos perso ET aucun sens d'afficher une fonctionnalite reservee aux inscrites. Le module manquait sur /accueil.

## Avant / Apres
- **Home publique (/)** : 4 cards reelles avec infos perso -> 4 cards demo anonymisees ("Une copine cherche une decoratrice / Geneve" etc.), tous les CTAs -> /auth/signup
- **/accueil** : pas de TeamCherche -> TeamCherche en haut (vraies donnees, CTAs vers /je-cherche)

## Verifie en preview
✅ / mobile : 4 cards demo, 4 villes, 100% des liens du bloc -> /auth/signup
✅ Aucune mention "il y a X min" / aucun avatar reel / aucun prenom reel sur la home publique
✅ /accueil redirige vers / sans session (auth-required, comportement attendu)
✅ Build OK

## Risques
- Pas de touche auth/Stripe/SQL/EMAIL_FROM
- Refactor TeamCherche en 2 sous-composants : retrocompat preservee (default 'connected')
- Pas de modification de la page /je-cherche elle-meme

## Verdict
🟢 SAFE - refactor visuel + securite des donnees. Merge auto.