### PR TITLE
fix(je-cherche): refonte UX card TeamCherche connected (intro + titre split + CTA)

### DIFF
--- a/app/je-cherche/nouvelle/_components/NouvelleDemandeForm.tsx
+++ b/app/je-cherche/nouvelle/_components/NouvelleDemandeForm.tsx
@@ -127,7 +127,7 @@ export function NouvelleDemandeForm({ defaultCountry, defaultCity }: Props) {
         {/* Titre */}
         <label className="flex flex-col gap-1.5">
           <span className="text-[11px] tracking-[0.22em] text-or uppercase">
-            Titre
+            Tu cherches quoi&nbsp;?
           </span>
           <input
             type="text"
@@ -136,10 +136,16 @@ export function NouvelleDemandeForm({ defaultCountry, defaultCity }: Props) {
             required
             minLength={5}
             maxLength={120}
-            placeholder="Ostéo enceinte sur Lausanne"
+            placeholder="Une décoratrice, un photographe, un coach…"
             className="border-b border-or/30 bg-transparent py-2 text-[16px] text-vert placeholder:text-texte-sec/50 focus:border-or focus:outline-none"
             aria-required="true"
           />
+          {/* Helper : cadre la copine sur l'objet seul. Le préfixe "Cherche"
+              est ajouté en display sur les cards (cf TeamCherche.tsx variant
+              connected). Convention V1 : titre = juste l'objet, pas de phrase. */}
+          <span className="text-[11px] italic text-texte-sec">
+            Juste l&apos;essentiel — pas besoin d&apos;écrire «&nbsp;je cherche&nbsp;», on s&apos;en occupe.
+          </span>
           <span className="text-[11px] text-texte-sec">
             {title.trim().length} / 120
           </span>

--- a/components/landing/TeamCherche.tsx
+++ b/components/landing/TeamCherche.tsx
@@ -106,6 +106,10 @@ async function TeamCherchePrivate() {
               <em className="italic text-or">cherche</em>
               <span className="text-or">…</span>
             </h2>
+            {/* Intro module : explique en une ligne ce qu'on peut faire ici. */}
+            <p className="mt-4 text-[14px] leading-[1.55] text-vert/70 md:text-[15px]">
+              Tu cherches une adresse&nbsp;? Demande à la team.
+            </p>
           </div>
           <Link
             href="/je-cherche"
@@ -119,18 +123,24 @@ async function TeamCherchePrivate() {
         </div>
 
         {/* Carrousel scroll-snap */}
-        <div className="mt-10 -mx-6 md:-mx-20">
+        <div className="mt-8 -mx-6 md:-mx-20">
           <ul
             className="flex snap-x snap-mandatory gap-4 overflow-x-auto px-6 pb-2 md:px-20 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
             aria-label="Demandes récentes des copines"
           >
             {demandes.map((d) => {
               const isUrgent = d.urgency === 'urgent' && d.status === 'open'
+              const ctaLabel =
+                d.response_count > 0
+                  ? `${d.response_count} réponse${d.response_count > 1 ? 's' : ''} · Réponds aussi →`
+                  : `Réponds à ${d.prenom ?? 'la copine'} →`
+              const ctaIsOutline = d.response_count > 0
               return (
                 <li key={d.id} className="w-[260px] shrink-0 snap-start sm:w-[280px]">
                   <Link
                     href={`/je-cherche/${d.id}`}
                     className="group flex h-full flex-col rounded-sm border border-or/15 bg-blanc p-5 transition-all duration-300 hover:-translate-y-0.5 hover:border-or/40 hover:shadow-[0_16px_32px_-20px_rgba(15,61,46,0.25)]"
+                    aria-label={`Demande de ${d.prenom ?? 'une copine'} — ${d.title}. Cliquer pour répondre.`}
                   >
                     <div className="flex items-start gap-2.5">
                       <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full bg-creme-deep">
@@ -160,18 +170,38 @@ async function TeamCherchePrivate() {
                     <p className="mt-3 text-[9px] tracking-[0.22em] text-or-deep uppercase">
                       {CATEGORY_LABELS[d.category] ?? d.category}
                     </p>
-                    <h3 className="mt-1.5 line-clamp-3 font-serif text-[16px] font-light leading-tight text-vert break-words">
-                      {d.title}
+                    {/* Titre rime visuelle avec le H2 : "Cherche" italique or +
+                        objet de la demande en vert. Convention V1 : le champ
+                        title BDD contient juste l'objet ("Décoratrice", "Coach
+                        sportive"…) — le préfixe "Cherche " est ajouté ici en
+                        display. Le form /je-cherche/nouvelle cadre la copine
+                        avec label "Tu cherches quoi ?" + placeholder "Une
+                        décoratrice…" pour respecter cette convention. */}
+                    <h3 className="mt-1.5 font-serif text-[20px] font-light leading-tight md:text-[22px]">
+                      <em className="not-italic italic font-light text-or">
+                        Cherche{' '}
+                      </em>
+                      <span className="text-vert break-words line-clamp-2">
+                        {d.title}
+                      </span>
                     </h3>
-                    <div className="mt-auto pt-4 text-[11px] font-medium text-texte-sec">
-                      {d.response_count} reco{d.response_count > 1 ? 's' : ''}
+                    <div className="mt-auto pt-4">
+                      <span
+                        className={`flex w-full items-center justify-center rounded-full px-4 py-2.5 text-[12px] font-medium transition-colors ${
+                          ctaIsOutline
+                            ? 'border border-vert text-vert group-hover:bg-vert group-hover:text-creme'
+                            : 'bg-vert text-creme group-hover:bg-vert-dark'
+                        }`}
+                      >
+                        {ctaLabel}
+                      </span>
                     </div>
                   </Link>
                 </li>
               )
             })}
 
-            {/* Card CTA finale : poster une demande */}
+            {/* Card CTA finale : poster une demande (intacte vs spec) */}
             <li className="w-[260px] shrink-0 snap-start sm:w-[280px]">
               <Link
                 href="/je-cherche/nouvelle"


### PR DESCRIPTION
## Quoi
Refonte UX du carrousel TeamCherche en mode connected pour qu'on comprenne en 2 sec qu'une copine CHERCHE quelque chose (vs avoir une fiche annuaire), et que le tap = répondre à la copine.

## Avant / Apres
**Card actuelle** : eyebrow + titre seul ("Décoratrice" -> ambigu) + "0 reco" mort
**Card refondue** : eyebrow + "Cherche" (italique or) + objet (vert break-words) + bouton CTA contextuel

## Changements (3)
1. Intro sous H2 : "Tu cherches une adresse ? Demande à la team." (vert/70)
2. Titre card split : préfixe "Cherche" italique or + valeur BDD vert (rime visuelle avec H2)
3. CTA contextuel :
   - 0 réponse → bouton plein vert "Réponds à {prenom} →"
   - ≥1 réponse → bouton outline "{X} réponses · Réponds aussi →"

## Form /je-cherche/nouvelle (cohérence convention)
- Label "Titre" → "Tu cherches quoi ?"
- Placeholder → "Une décoratrice, un photographe, un coach…"
- Helper italique → "Juste l'essentiel — pas besoin d'écrire « je cherche », on s'en occupe."

## Capture preview mobile 375px
Vérifié sur preview locale (page temp _preview-teamcherche supprimée avant commit, dossier renommé en preview-teamcherche-tmp car Next App Router exclut les dossiers `_` préfixés du routing).
- ✅ "Cherche" en italique or visible
- ✅ Objet "Une décoratrice" en vert
- ✅ Bouton plein "Réponds à Jij →" pour 0 réponse
- ✅ Bouton outline "1 réponse · Réponds aussi →" pour ≥1
- ✅ Card finale "À TOI / Demande à la team / + POSTER MA DEMANDE" intacte

## Risques
- variant="public" (PR #63) intact — TeamCherchePublic non modifié
- card finale "À TOI" intacte
- H2 + eyebrow intacts
- Pas de touche auth / EMAIL_FROM / Stripe
- Build OK local 67/67 pages

## Verdict
🟢 SAFE — refonte UI seule sur sous-composant connected. Merge auto.