### PR TITLE
feat(founders): app logic for is_founder access to Cercle Pro features

### DIFF
--- a/app/annuaire/AnnuaireClient.tsx
+++ b/app/annuaire/AnnuaireClient.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { motion, AnimatePresence } from 'framer-motion'
+import { PageShell } from '@/components/v2/PageShell'
+import { PageHero } from '@/components/v2/PageHero'
+import { FiltersBar } from '@/components/v2/FiltersBar'
+import { PrestataireCard } from '@/components/v2/PrestataireCard'
+import { LiveEmptyState } from '@/components/v2/LiveStates'
+import {
+  villesSuggestions,
+  categoriesPrestataires,
+  type Prestataire as MockPrestataire,
+} from '@/lib/mock-data'
+
+type Props = {
+  prestataires: MockPrestataire[]
+}
+
+export function AnnuaireClient({ prestataires }: Props) {
+  const [categorie, setCategorie] = useState('all')
+  const [ville, setVille] = useState('all')
+  const [note, setNote] = useState('all')
+
+  const dataSource = prestataires
+
+  const filtered = useMemo(() => {
+    return dataSource.filter((p) => {
+      if (categorie !== 'all' && p.categorie !== categorie) return false
+      if (ville !== 'all' && p.ville !== ville) return false
+      if (note === '45' && p.note < 4.5) return false
+      if (note === '48' && p.note < 4.8) return false
+      return true
+    })
+  }, [dataSource, categorie, ville, note])
+
+  const villesPresentes = Array.from(new Set(dataSource.map((p) => p.ville)))
+  const villesOptions = villesPresentes
+    .sort((a, b) => villesSuggestions.indexOf(a) - villesSuggestions.indexOf(b))
+    .map((v) => ({ value: v, label: v }))
+
+  const reset = () => {
+    setCategorie('all')
+    setVille('all')
+    setNote('all')
+  }
+
+  if (dataSource.length === 0) {
+    return (
+      <PageShell>
+        <PageHero
+          number="01"
+          kicker="L'annuaire"
+          titre={
+            <>
+              Les prestataires,
+              <br />
+              choisies une par une.
+            </>
+          }
+          lead={<>Le carnet commence à peine à s&apos;écrire.</>}
+        />
+        <LiveEmptyState
+          kicker="Premières copines"
+          titre="Les premières fiches arrivent bientôt."
+          pitch="On vérifie chaque profil à la main — quelques jours parfois. Reviens vite ou inscris-toi pour être prévenue."
+          ctaLabel="Créer ma fiche"
+          ctaHref="/onboarding/prestataire"
+          secondaryLabel="Être prévenue →"
+          secondaryHref="/inscription"
+        />
+      </PageShell>
+    )
+  }
+
+  return (
+    <PageShell>
+      <PageHero
+        number="01"
+        kicker="L'annuaire"
+        titre={
+          <>
+            Les prestataires,
+            <br />
+            choisies une par une.
+          </>
+        }
+        lead={
+          <>
+            Coachs, thérapeutes, coiffeuses, avocates… vérifiées à la main.
+            Zéro profil fake, zéro commission. Parcours l&apos;annuaire ou filtre selon ton
+            besoin.
+          </>
+        }
+      />
+
+      <FiltersBar
+        resultCount={filtered.length}
+        onReset={reset}
+        groups={[
+          {
+            id: 'categorie',
+            label: 'Catégorie',
+            value: categorie,
+            onChange: setCategorie,
+            options: [
+              { value: 'all', label: 'Toutes' },
+              ...categoriesPrestataires.map((c) => ({
+                value: c.slug,
+                label: c.label,
+              })),
+            ],
+          },
+          {
+            id: 'ville',
+            label: 'Ville',
+            value: ville,
+            onChange: setVille,
+            options: [{ value: 'all', label: 'Toutes' }, ...villesOptions],
+          },
+          {
+            id: 'note',
+            label: 'Note',
+            value: note,
+            onChange: setNote,
+            options: [
+              { value: 'all', label: 'Toutes' },
+              { value: '45', label: '4,5 +' },
+              { value: '48', label: '4,8 +' },
+            ],
+          },
+        ]}
+      />
+
+      <section className="py-10 sm:py-14 md:py-20">
+        <div className="mx-auto max-w-container px-4 sm:px-6 md:px-20">
+          <AnimatePresence mode="wait">
+            {filtered.length > 0 ? (
+              <motion.div
+                key="grid"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.3 }}
+                className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
+              >
+                {filtered.map((p, i) => (
+                  <PrestataireCard key={p.slug} p={p} index={i} />
+                ))}
+              </motion.div>
+            ) : (
+              <motion.div
+                key="empty"
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.4 }}
+                className="rounded-sm border border-dashed border-or/30 bg-blanc py-20 text-center"
+              >
+                <p className="font-serif text-3xl font-light text-vert">
+                  Pas encore de profil qui colle.
+                </p>
+                <p className="mt-3 text-[14px] leading-[1.7] text-texte-sec">
+                  Desserre un filtre, ou recommande-nous quelqu&apos;une qu&apos;on devrait connaître.
+                </p>
+                <div className="mt-6 flex flex-wrap items-center justify-center gap-4">
+                  <button
+                    type="button"
+                    onClick={reset}
+                    className="inline-flex h-11 items-center gap-2 rounded-full border border-or/40 px-6 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-or hover:bg-creme-deep"
+                  >
+                    Tout réinitialiser
+                  </button>
+                  <Link
+                    href="/onboarding/prestataire"
+                    className="inline-flex h-11 items-center gap-2 rounded-full bg-vert px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+                  >
+                    Recommander quelqu&apos;une
+                    <span className="text-or-light" aria-hidden="true">
+                      →
+                    </span>
+                  </Link>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </section>
+    </PageShell>
+  )
+}

--- a/app/annuaire/page.tsx
+++ b/app/annuaire/page.tsx
@@ -1,32 +1,23 @@
-'use client'
-
-import { useEffect, useMemo, useState } from 'react'
-import Link from 'next/link'
-import { motion, AnimatePresence } from 'framer-motion'
 import { PageShell } from '@/components/v2/PageShell'
 import { PageHero } from '@/components/v2/PageHero'
-import { FiltersBar } from '@/components/v2/FiltersBar'
-import { PrestataireCard } from '@/components/v2/PrestataireCard'
+import { LiveErrorState } from '@/components/v2/LiveStates'
 import {
-  SkeletonListGrid,
-  LiveErrorState,
-  LiveEmptyState,
-} from '@/components/v2/LiveStates'
-import {
-  villesSuggestions,
   categoriesPrestataires,
   type Prestataire as MockPrestataire,
 } from '@/lib/mock-data'
-import { createClient } from '@/lib/supabase/client'
+import { getAllPrestataires } from '@/lib/supabase/queries/prestataires'
 import type { Prestataire as DbPrestataire } from '@/lib/supabase/types'
+import { AnnuaireClient } from './AnnuaireClient'
 
 /**
  * Tri prioritaire annuaire (Cercle Pro 99€/mois — feature "Mise en avant prio").
  * Cercle Pro apparaît avant Premium qui apparaît avant Standard.
  * À tier égal, on conserve l'ordre serveur (approved_at desc, déterministe).
  *
- * Implémenté côté client après l'adaptation pour éviter une migration SQL
- * (Supabase ne supporte pas facilement ORDER BY CASE sans vue dédiée).
+ * Le palier reçu ici est déjà le palier EFFECTIF (founders mappées à
+ * cercle_pro côté server query helper) — donc les founders rankent
+ * automatiquement en tête sans logique supplémentaire.
+ *
  * Array.prototype.sort est stable en JS depuis ES2019 → tri secondaire
  * approved_at desc préservé naturellement.
  */
@@ -77,99 +68,12 @@ function adaptPrestataireFromDb(p: DbPrestataire): MockPrestataire {
   }
 }
 
-export default function AnnuairePage() {
-  const [categorie, setCategorie] = useState('all')
-  const [ville, setVille] = useState('all')
-  const [note, setNote] = useState('all')
+// SSR : on fetch côté serveur via getAllPrestataires() qui strippe is_founder
+// et retourne le palier effectif. Aucune donnée brute is_founder ne transite
+// dans le bundle ni dans la JSON envoyée au client.
+export default async function AnnuairePage() {
+  const { data, error } = await getAllPrestataires()
 
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [livePrestataires, setLivePrestataires] = useState<MockPrestataire[]>([])
-
-  useEffect(() => {
-    let cancelled = false
-
-    async function fetchData() {
-      try {
-        setLoading(true)
-        setError(null)
-        const supabase = createClient()
-        const { data, error: err } = await supabase
-          .from('profiles')
-          .select(
-            'id, user_id, nom, slug, categorie, ville, description, tagline, photos, galerie, services, prix_from, prix_gamme, devise, status, note_moyenne, nb_avis, nb_vues, approved_at, source_import, created_at, updated_at, admin_notes, whatsapp, instagram, tiktok, email, site_web, linkedin, palier'
-          )
-          .eq('status', 'approved')
-          .order('approved_at', { ascending: false, nullsFirst: false })
-
-        if (cancelled) return
-        if (err) {
-          setError(err.message)
-          setLoading(false)
-          return
-        }
-        const adapted = (data ?? []).map((row) =>
-          adaptPrestataireFromDb(row as unknown as DbPrestataire),
-        )
-        setLivePrestataires(sortByPalierThenServerOrder(adapted))
-        setLoading(false)
-      } catch (e) {
-        if (cancelled) return
-        setError(e instanceof Error ? e.message : String(e))
-        setLoading(false)
-      }
-    }
-
-    fetchData()
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-  const dataSource = livePrestataires
-
-  const filtered = useMemo(() => {
-    return dataSource.filter((p) => {
-      if (categorie !== 'all' && p.categorie !== categorie) return false
-      if (ville !== 'all' && p.ville !== ville) return false
-      if (note === '45' && p.note < 4.5) return false
-      if (note === '48' && p.note < 4.8) return false
-      return true
-    })
-  }, [dataSource, categorie, ville, note])
-
-  const villesPresentes = Array.from(new Set(dataSource.map((p) => p.ville)))
-  const villesOptions = villesPresentes
-    .sort((a, b) => villesSuggestions.indexOf(a) - villesSuggestions.indexOf(b))
-    .map((v) => ({ value: v, label: v }))
-
-  const reset = () => {
-    setCategorie('all')
-    setVille('all')
-    setNote('all')
-  }
-
-  // ── LIVE : skeleton pendant chargement ────────────────────────────
-  if (loading) {
-    return (
-      <PageShell>
-        <PageHero
-          number="01"
-          kicker="L'annuaire"
-          titre={
-            <>
-              Les prestataires,
-              <br />
-              choisies une par une.
-            </>
-          }
-        />
-        <SkeletonListGrid count={6} />
-      </PageShell>
-    )
-  }
-
-  // ── LIVE : erreur ─────────────────────────────────────────────────
   if (error) {
     return (
       <PageShell>
@@ -183,149 +87,8 @@ export default function AnnuairePage() {
     )
   }
 
-  // ── LIVE : DB vide ────────────────────────────────────────────────
-  if (dataSource.length === 0) {
-    return (
-      <PageShell>
-        <PageHero
-          number="01"
-          kicker="L'annuaire"
-          titre={
-            <>
-              Les prestataires,
-              <br />
-              choisies une par une.
-            </>
-          }
-          lead={<>Le carnet commence à peine à s&apos;écrire.</>}
-        />
-        <LiveEmptyState
-          kicker="Premières copines"
-          titre="Les premières fiches arrivent bientôt."
-          pitch="On vérifie chaque profil à la main — quelques jours parfois. Reviens vite ou inscris-toi pour être prévenue."
-          ctaLabel="Créer ma fiche"
-          ctaHref="/onboarding/prestataire"
-          secondaryLabel="Être prévenue →"
-          secondaryHref="/inscription"
-        />
-      </PageShell>
-    )
-  }
+  const adapted = (data ?? []).map(adaptPrestataireFromDb)
+  const sorted = sortByPalierThenServerOrder(adapted)
 
-  // ── LIVE : grille normale avec filtres ────────────────────────────
-  return (
-    <PageShell>
-      <PageHero
-        number="01"
-        kicker="L'annuaire"
-        titre={
-          <>
-            Les prestataires,
-            <br />
-            choisies une par une.
-          </>
-        }
-        lead={
-          <>
-            Coachs, thérapeutes, coiffeuses, avocates… vérifiées à la main.
-            Zéro profil fake, zéro commission. Parcours l&apos;annuaire ou filtre selon ton
-            besoin.
-          </>
-        }
-      />
-
-      <FiltersBar
-        resultCount={filtered.length}
-        onReset={reset}
-        groups={[
-          {
-            id: 'categorie',
-            label: 'Catégorie',
-            value: categorie,
-            onChange: setCategorie,
-            options: [
-              { value: 'all', label: 'Toutes' },
-              ...categoriesPrestataires.map((c) => ({
-                value: c.slug,
-                label: c.label,
-              })),
-            ],
-          },
-          {
-            id: 'ville',
-            label: 'Ville',
-            value: ville,
-            onChange: setVille,
-            options: [{ value: 'all', label: 'Toutes' }, ...villesOptions],
-          },
-          {
-            id: 'note',
-            label: 'Note',
-            value: note,
-            onChange: setNote,
-            options: [
-              { value: 'all', label: 'Toutes' },
-              { value: '45', label: '4,5 +' },
-              { value: '48', label: '4,8 +' },
-            ],
-          },
-        ]}
-      />
-
-      <section className="py-10 sm:py-14 md:py-20">
-        <div className="mx-auto max-w-container px-4 sm:px-6 md:px-20">
-          <AnimatePresence mode="wait">
-            {filtered.length > 0 ? (
-              <motion.div
-                key="grid"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.3 }}
-                className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
-              >
-                {filtered.map((p, i) => (
-                  <PrestataireCard key={p.slug} p={p} index={i} />
-                ))}
-              </motion.div>
-            ) : (
-              <motion.div
-                key="empty"
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.4 }}
-                className="rounded-sm border border-dashed border-or/30 bg-blanc py-20 text-center"
-              >
-                <p className="font-serif text-3xl font-light text-vert">
-                  Pas encore de profil qui colle.
-                </p>
-                <p className="mt-3 text-[14px] leading-[1.7] text-texte-sec">
-                  Desserre un filtre, ou recommande-nous quelqu&apos;une qu&apos;on devrait connaître.
-                </p>
-                <div className="mt-6 flex flex-wrap items-center justify-center gap-4">
-                  <button
-                    type="button"
-                    onClick={reset}
-                    className="inline-flex h-11 items-center gap-2 rounded-full border border-or/40 px-6 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-or hover:bg-creme-deep"
-                  >
-                    Tout réinitialiser
-                  </button>
-                  <Link
-                    href="/onboarding/prestataire"
-                    className="inline-flex h-11 items-center gap-2 rounded-full bg-vert px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
-                  >
-                    Recommander quelqu&apos;une
-                    <span className="text-or-light" aria-hidden="true">
-                      →
-                    </span>
-                  </Link>
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
-        </div>
-      </section>
-    </PageShell>
-  )
+  return <AnnuaireClient prestataires={sorted} />
 }

--- a/app/api/cron/stats-hebdo/route.ts
+++ b/app/api/cron/stats-hebdo/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { sendStatsHebdoPrestataire } from '@/lib/email/transactional'
 import { isAuthorizedCronRequest } from '@/lib/cron-auth'
+import { getEffectivePalier } from '@/lib/permissions'
 
 export const runtime = 'nodejs'
 // Pas de cache : appelé par Vercel Cron, doit toujours s'exécuter frais.
@@ -15,8 +16,9 @@ const PALIER_LABEL: Record<string, string> = {
 /**
  * Cron Vercel hebdomadaire (lundi 9h UTC, cf vercel.json).
  *
- * Pour chaque prestataire approved et payante (Premium / Cercle Pro)
- * qui n'a PAS opt-out (preferences.notifications.statsHebdoPrestataire !== false),
+ * Pour chaque prestataire approved et payante (Premium / Cercle Pro,
+ * incluant les founders qui bénéficient d'un Cercle Pro effectif) qui n'a
+ * PAS opt-out (preferences.notifications.statsHebdoPrestataire !== false),
  * envoie un email résumant les stats de la semaine.
  *
  * Utilise service-role pour bypasser RLS (cron interne, pas de session
@@ -37,11 +39,12 @@ export async function GET(request: Request) {
   const since7d = new Date(now.getTime() - 7 * 86_400_000).toISOString()
   const since14d = new Date(now.getTime() - 14 * 86_400_000).toISOString()
 
-  // 1. Liste des prestataires éligibles (Premium + Cercle Pro, approved)
+  // 1. Liste des prestataires éligibles (Premium + Cercle Pro, approved,
+  //    incluant les founders qui bénéficient d'un Cercle Pro effectif).
   const { data: prestataires, error: pErr } = await admin
     .from('profiles')
-    .select('id, user_id, nom, slug, palier')
-    .in('palier', ['premium', 'cercle_pro'])
+    .select('id, user_id, nom, slug, palier, is_founder')
+    .or('palier.in.(premium,cercle_pro),is_founder.eq.true')
     .eq('status', 'approved')
 
   if (pErr) {
@@ -117,6 +120,8 @@ export async function GET(request: Request) {
         p.nom.split(' ')[0] ??
         'Toi'
 
+      // Label affiché dans l'email = palier effectif (founders → Cercle Pro)
+      const effectivePalier = getEffectivePalier(p)
       await sendStatsHebdoPrestataire({
         to: email,
         prenom,
@@ -126,7 +131,7 @@ export async function GET(request: Request) {
         views7dPrev: views7dPrev ?? 0,
         contacts7d: contacts7d ?? 0,
         contacts7dPrev: contacts7dPrev ?? 0,
-        palierLabel: PALIER_LABEL[p.palier] ?? p.palier,
+        palierLabel: PALIER_LABEL[effectivePalier] ?? effectivePalier,
       })
       sent++
     } catch (err) {

--- a/app/api/devis-requests/route.ts
+++ b/app/api/devis-requests/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { sendDevisExpressEmail } from '@/lib/email/transactional'
 import { enforceRateLimit } from '@/lib/rate-limit'
+import { hasCerclePro } from '@/lib/permissions'
 
 export const runtime = 'nodejs'
 
@@ -16,7 +17,8 @@ export const runtime = 'nodejs'
  *
  * Validations :
  *  - Auth utilisatrice obligatoire
- *  - prestataire_id existe ET palier === 'cercle_pro' ET status === 'approved'
+ *  - prestataire_id existe ET palier effectif === 'cercle_pro' (incluant
+ *    les founders) ET status === 'approved'
  *  - prenom 1-80 / email format simple / message 5-2000 chars
  *  - Rate limit : max 3 soumissions / 5 min / utilisatrice (anti spam)
  *
@@ -87,7 +89,7 @@ export async function POST(request: Request) {
   // ─── Vérifie que la prestataire est bien Cercle Pro & approuvée ───
   const { data: presta, error: pErr } = await supabase
     .from('profiles')
-    .select('id, user_id, nom, palier, status')
+    .select('id, user_id, nom, palier, is_founder, status')
     .eq('id', prestataire_id)
     .maybeSingle()
 
@@ -97,7 +99,7 @@ export async function POST(request: Request) {
       { status: 404 },
     )
   }
-  if (presta.palier !== 'cercle_pro') {
+  if (!hasCerclePro(presta)) {
     return NextResponse.json(
       { error: 'Devis express réservé aux fiches Cercle Pro.' },
       { status: 403 },

--- a/app/dashboard/prestataire/devis/page.tsx
+++ b/app/dashboard/prestataire/devis/page.tsx
@@ -5,13 +5,14 @@ import { GoldLine } from '@/components/ui/GoldLine'
 import { EmptyState } from '@/components/dashboard/EmptyState'
 import { requirePrestataire } from '@/lib/supabase/session'
 import { createClient } from '@/lib/supabase/server'
+import { hasCerclePro } from '@/lib/permissions'
 import { DevisRow } from './_components/DevisRow'
 
 export default async function MesDevisPage() {
   const { prestataire } = await requirePrestataire()
 
-  // Garde Cercle Pro : si pas Cercle Pro, redirige vers tarifs
-  if (prestataire.palier !== 'cercle_pro') {
+  // Garde Cercle Pro : si pas Cercle Pro (et pas founder), redirige vers tarifs
+  if (!hasCerclePro(prestataire)) {
     redirect('/dashboard/prestataire/abonnement')
   }
 

--- a/app/dashboard/prestataire/fiche/page.tsx
+++ b/app/dashboard/prestataire/fiche/page.tsx
@@ -12,6 +12,7 @@ import {
   canUploadMorePhotos,
   photoCountLabel,
 } from '@/lib/palier-limits'
+import { getEffectivePalier } from '@/lib/permissions'
 import type { Palier } from '@/app/tarifs/_lib/pricing'
 
 type Service = { nom: string; prix: string; duree: string }
@@ -109,12 +110,13 @@ export default function MaFichePage() {
 
       setProfileId(data.id)
       setStatus(data.status)
+      // Palier effectif : founders → cercle_pro même si palier stocké = standard.
+      // Le helper applique la règle métier centralisée.
       setPalier(
-        data.palier === 'premium'
-          ? 'premium'
-          : data.palier === 'cercle_pro'
-            ? 'cercle_pro'
-            : 'standard',
+        getEffectivePalier({
+          palier: data.palier,
+          is_founder: data.is_founder === true,
+        }),
       )
       setNoteMoy(data.note_moyenne ?? 0)
       setNbAvis(data.nb_avis ?? 0)

--- a/app/dashboard/prestataire/layout.tsx
+++ b/app/dashboard/prestataire/layout.tsx
@@ -2,6 +2,7 @@ import { Sidebar, type SidebarItem } from '@/components/dashboard/Sidebar'
 import { requirePrestataire } from '@/lib/supabase/session'
 import { createClient } from '@/lib/supabase/server'
 import { CATEGORIES_MAP } from '@/lib/constants'
+import { hasCerclePro } from '@/lib/permissions'
 
 export default async function PrestataireLayout({
   children,
@@ -11,6 +12,7 @@ export default async function PrestataireLayout({
   const { user, prestataire } = await requirePrestataire()
   const isAdmin = Boolean(user.user_metadata?.is_admin)
   const supabase = await createClient()
+  const isCerclePro = hasCerclePro(prestataire)
 
   // Badge "nouveaux avis" = recommendations sans reponse_pro, publiées
   const { count: newReviewsCount } = await supabase
@@ -24,7 +26,7 @@ export default async function PrestataireLayout({
   // Badge "nouveaux devis" — Cercle Pro uniquement (best-effort, table peut
   // ne pas encore exister tant que migration 36 pas appliquée).
   let pendingDevisCount = 0
-  if (prestataire.palier === 'cercle_pro') {
+  if (isCerclePro) {
     const { count } = await supabase
       .from('devis_requests')
       .select('id', { count: 'exact', head: true })
@@ -51,7 +53,7 @@ export default async function PrestataireLayout({
       icon: '◇',
     },
     // Devis Express : entrée Cercle Pro uniquement
-    ...(prestataire.palier === 'cercle_pro'
+    ...(isCerclePro
       ? ([
           {
             href: '/dashboard/prestataire/devis',

--- a/app/dashboard/prestataire/page.tsx
+++ b/app/dashboard/prestataire/page.tsx
@@ -8,13 +8,20 @@ import { PalierBadge } from '@/components/v2/PalierBadge'
 import { PastilleSelectionHilmy } from '@/components/v2/PastilleSelectionHilmy'
 import { createClient } from '@/lib/supabase/server'
 import { requirePrestataire } from '@/lib/supabase/session'
+import {
+  getEffectivePalier,
+  hasCerclePro,
+  hasPremiumFeatures,
+} from '@/lib/permissions'
 
 export default async function PrestataireAccueilPage() {
   const { prestataire } = await requirePrestataire()
   const supabase = await createClient()
 
-  const palier = prestataire.palier ?? 'standard'
-  const isPremiumOrAbove = palier === 'premium' || palier === 'cercle_pro'
+  // Palier effectif : founders → cercle_pro même si palier stocké = standard.
+  const palier = getEffectivePalier(prestataire)
+  const isPremiumOrAbove = hasPremiumFeatures(prestataire)
+  const isCerclePro = hasCerclePro(prestataire)
 
   const since7d = new Date(Date.now() - 7 * 86_400_000).toISOString()
   const since30d = new Date(Date.now() - 30 * 86_400_000).toISOString()
@@ -99,7 +106,7 @@ export default async function PrestataireAccueilPage() {
         lead="Les chiffres depuis la création de ta fiche. Vues, contacts, avis."
         actions={
           <div className="flex flex-wrap items-center gap-3">
-            {palier === 'cercle_pro' && <PastilleSelectionHilmy />}
+            {isCerclePro && <PastilleSelectionHilmy />}
             <PalierBadge palier={palier} size="medium" />
             <Link
               href={`/prestataire-v2/${prestataire.slug}`}
@@ -141,11 +148,11 @@ export default async function PrestataireAccueilPage() {
         <div className="mb-8 flex items-center gap-4">
           <GoldLine width={40} />
           <span className="overline text-or">
-            {palier === 'standard' ? 'Mes chiffres' : 'Mes chiffres détaillés'}
+            {!isPremiumOrAbove ? 'Mes chiffres' : 'Mes chiffres détaillés'}
           </span>
         </div>
 
-        {palier === 'standard' ? (
+        {!isPremiumOrAbove ? (
           <div className="grid gap-4 md:grid-cols-2">
             <StatCard
               kicker="Vues totales"
@@ -193,7 +200,7 @@ export default async function PrestataireAccueilPage() {
         )}
 
         {/* Bandeau upsell Standard → Premium */}
-        {palier === 'standard' && (
+        {!isPremiumOrAbove && (
           <div className="mt-6 rounded-sm border border-or/30 bg-or/10 p-6 md:p-7">
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-6">
               <div>
@@ -218,7 +225,7 @@ export default async function PrestataireAccueilPage() {
         )}
 
         {/* Bandeau Stats avancées Cercle Pro — actif depuis Phase 4 */}
-        {palier === 'cercle_pro' && (
+        {isCerclePro && (
           <div className="mt-6 rounded-sm bg-vert p-6 text-creme md:p-7">
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-6">
               <div>

--- a/app/dashboard/prestataire/parametres/page.tsx
+++ b/app/dashboard/prestataire/parametres/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
 import { GoldLine } from '@/components/ui/GoldLine'
 import { createClient } from '@/lib/supabase/client'
+import { hasPremiumFeatures } from '@/lib/permissions'
 
 export default function ParametresPrestatairePage() {
   const router = useRouter()
@@ -22,6 +23,7 @@ export default function ParametresPrestatairePage() {
   const [palier, setPalier] = useState<'standard' | 'premium' | 'cercle_pro'>(
     'standard',
   )
+  const [isFounderState, setIsFounderState] = useState(false)
   const [statsHebdoOptIn, setStatsHebdoOptIn] = useState(true)
   const [statsHebdoSaving, setStatsHebdoSaving] = useState(false)
   const [userIdState, setUserIdState] = useState<string | null>(null)
@@ -43,7 +45,7 @@ export default function ParametresPrestatairePage() {
       const [profileRes, prefsRes] = await Promise.all([
         supabase
           .from('profiles')
-          .select('id, status, palier')
+          .select('id, status, palier, is_founder')
           .eq('user_id', user.id)
           .maybeSingle(),
         supabase
@@ -60,6 +62,7 @@ export default function ParametresPrestatairePage() {
         setPalier(
           p === 'premium' ? 'premium' : p === 'cercle_pro' ? 'cercle_pro' : 'standard',
         )
+        setIsFounderState(profileRes.data.is_founder === true)
       }
 
       // Opt-in stats hebdo : default true (active si pas opt-out explicite)
@@ -240,7 +243,7 @@ export default function ParametresPrestatairePage() {
               )}
             </SettingsGroup>
 
-            {(palier === 'premium' || palier === 'cercle_pro') && (
+            {hasPremiumFeatures({ palier, is_founder: isFounderState }) && (
               <SettingsGroup
                 kicker="Notifications"
                 titre="Ce qu'on t'envoie."

--- a/app/dashboard/prestataire/stats-avancees/page.tsx
+++ b/app/dashboard/prestataire/stats-avancees/page.tsx
@@ -10,6 +10,7 @@ import {
 import { requirePrestataire } from '@/lib/supabase/session'
 import { createClient } from '@/lib/supabase/server'
 import { CATEGORIES_MAP } from '@/lib/constants'
+import { hasCerclePro } from '@/lib/permissions'
 import {
   aggregateByVille,
   aggregateByHeure,
@@ -23,8 +24,8 @@ const SINCE_DAYS = 30
 export default async function StatsAvanceesPage() {
   const { prestataire } = await requirePrestataire()
 
-  // Garde Cercle Pro
-  if (prestataire.palier !== 'cercle_pro') {
+  // Garde Cercle Pro (founders incluses via hasCerclePro)
+  if (!hasCerclePro(prestataire)) {
     redirect('/dashboard/prestataire/abonnement')
   }
 
@@ -43,13 +44,14 @@ export default async function StatsAvanceesPage() {
   const myRows: VueRow[] = (myViewsRows ?? []) as VueRow[]
   const myViewsCount = myRows.length
 
-  // 2. Pairs : autres prestataires de même catégorie (Premium + Cercle Pro)
+  // 2. Pairs : autres prestataires de même catégorie (Premium + Cercle Pro,
+  //    incluant les founders qui bénéficient d'un Cercle Pro effectif).
   //    On count leurs vues 30j pour bench. On exclut soi-même.
   const { data: peers } = await supabase
     .from('profiles')
     .select('id')
     .eq('categorie', prestataire.categorie)
-    .in('palier', ['premium', 'cercle_pro'])
+    .or('palier.in.(premium,cercle_pro),is_founder.eq.true')
     .eq('status', 'approved')
     .neq('id', prestataire.id)
 

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -1,0 +1,44 @@
+/**
+ * Source de vérité pour le gating de features par palier prestataire.
+ *
+ * Règle métier (post-PR founders) :
+ *  - `is_founder = true` est strictement équivalent à `palier = 'cercle_pro'`,
+ *    quel que soit le palier stocké en DB.
+ *  - Les founders bénéficient d'un accès Cercle Pro à vie (gratuit), sans
+ *    abonnement Stripe associé.
+ *
+ * Tous les call-sites qui gatent une feature payante doivent passer par
+ * ces helpers plutôt que de lire `palier` directement.
+ */
+
+import type { Palier } from '@/app/tarifs/_lib/pricing'
+
+export type ProfileGatingFields = {
+  palier?: Palier | null
+  is_founder?: boolean | null
+}
+
+/**
+ * Palier effectif appliqué pour le gating.
+ * Founder → cercle_pro. Sinon palier stocké, fallback standard.
+ */
+export function getEffectivePalier(p: ProfileGatingFields): Palier {
+  if (p.is_founder === true) return 'cercle_pro'
+  return p.palier ?? 'standard'
+}
+
+/** Accès aux features Premium ou Cercle Pro (incluant founders). */
+export function hasPremiumFeatures(p: ProfileGatingFields): boolean {
+  const eff = getEffectivePalier(p)
+  return eff === 'premium' || eff === 'cercle_pro'
+}
+
+/** Accès aux features Cercle Pro (incluant founders). */
+export function hasCerclePro(p: ProfileGatingFields): boolean {
+  return getEffectivePalier(p) === 'cercle_pro'
+}
+
+/** Vrai si la prestataire est founder (accès Cercle Pro à vie). */
+export function isFounder(p: Pick<ProfileGatingFields, 'is_founder'>): boolean {
+  return p.is_founder === true
+}

--- a/lib/supabase/queries/prestataires.ts
+++ b/lib/supabase/queries/prestataires.ts
@@ -2,6 +2,13 @@
  * Queries prestataires (table : profiles).
  * Respecte les RLS : seules les fiches status='approved' sont visibles
  * publiquement. Pas de bypass admin côté client.
+ *
+ * ⚠️ Privacy is_founder : tous les helpers de ce fichier appliquent
+ * `toPublicPrestataire` qui strippe le champ `is_founder` et substitue
+ * `palier` par sa valeur effective (cercle_pro pour les founders).
+ * Le champ brut `is_founder` ne doit JAMAIS transiter via ces helpers
+ * vers un consumer SSR/CSR. Pour le code server-trusted (dashboard owner,
+ * API routes), utiliser `requirePrestataire` ou un select dédié.
  */
 
 import { createClient } from "@/lib/supabase/server";
@@ -10,6 +17,7 @@ import type {
   PrestataireCategorie,
   QueryResult,
 } from "@/lib/supabase/types";
+import { getEffectivePalier } from "@/lib/permissions";
 
 // ⚠️ On ne sélectionne que les colonnes qui existent vraiment dans la DB.
 // Les champs pays/region/code_postal/zone_intervention du type TS Prestataire
@@ -45,8 +53,26 @@ const PRESTATAIRE_SELECT = `
   note_moyenne,
   nb_avis,
   nb_vues,
-  palier
+  palier,
+  is_founder
 `;
+
+/**
+ * Projection publique d'une ligne `profiles` :
+ *  - strippe `is_founder` du résultat (donnée business interne, ne doit pas
+ *    transiter dans un bundle SSR/CSR public)
+ *  - remplace `palier` par sa valeur effective (founder → cercle_pro)
+ *
+ * Le consumer reçoit un `Prestataire` dont `palier` reflète directement le
+ * niveau d'accès appliqué — plus besoin d'appeler getEffectivePalier côté UI.
+ */
+function toPublicPrestataire(raw: Prestataire & { is_founder?: boolean }): Prestataire {
+  const { is_founder, palier, ...rest } = raw;
+  return {
+    ...rest,
+    palier: getEffectivePalier({ palier, is_founder }),
+  };
+}
 
 /**
  * Les N premières vraies inscrites (prestataires réelles, pas les seeds
@@ -67,7 +93,8 @@ export async function getPionnieres(
       .limit(limit);
 
     if (error) return { data: null, error: error.message };
-    return { data: (data ?? []) as unknown as Prestataire[], error: null };
+    const rows = (data ?? []) as unknown as (Prestataire & { is_founder?: boolean })[];
+    return { data: rows.map(toPublicPrestataire), error: null };
   } catch (err) {
     return { data: null, error: errorMessage(err) };
   }
@@ -84,7 +111,8 @@ export async function getAllPrestataires(): Promise<QueryResult<Prestataire[]>> 
       .order("approved_at", { ascending: false, nullsFirst: false });
 
     if (error) return { data: null, error: error.message };
-    return { data: (data ?? []) as unknown as Prestataire[], error: null };
+    const rows = (data ?? []) as unknown as (Prestataire & { is_founder?: boolean })[];
+    return { data: rows.map(toPublicPrestataire), error: null };
   } catch (err) {
     return { data: null, error: errorMessage(err) };
   }
@@ -104,7 +132,11 @@ export async function getPrestataireBySlug(
       .maybeSingle();
 
     if (error) return { data: null, error: error.message };
-    return { data: (data as unknown as Prestataire) ?? null, error: null };
+    if (!data) return { data: null, error: null };
+    return {
+      data: toPublicPrestataire(data as unknown as Prestataire & { is_founder?: boolean }),
+      error: null,
+    };
   } catch (err) {
     return { data: null, error: errorMessage(err) };
   }
@@ -114,6 +146,10 @@ export async function getPrestataireBySlug(
  * Récupère la fiche d'une prestataire par slug + user_id, sans filtre de statut.
  * Réservé à la prévisualisation owner-side (fiche en attente ou pausée).
  * Le double filtre slug + user_id garantit qu'on ne lit que sa propre fiche.
+ *
+ * Note : applique aussi `toPublicPrestataire` car le résultat alimente la
+ * même page publique en mode preview — l'owner doit voir sa fiche telle
+ * qu'elle apparaîtra publiquement (palier effectif, pas de is_founder).
  */
 export async function getPrestataireBySlugForOwner(
   slug: string,
@@ -129,7 +165,11 @@ export async function getPrestataireBySlugForOwner(
       .maybeSingle();
 
     if (error) return { data: null, error: error.message };
-    return { data: (data as unknown as Prestataire) ?? null, error: null };
+    if (!data) return { data: null, error: null };
+    return {
+      data: toPublicPrestataire(data as unknown as Prestataire & { is_founder?: boolean }),
+      error: null,
+    };
   } catch (err) {
     return { data: null, error: errorMessage(err) };
   }
@@ -149,7 +189,8 @@ export async function getPrestatairesByCategorie(
       .order("approved_at", { ascending: false, nullsFirst: false });
 
     if (error) return { data: null, error: error.message };
-    return { data: (data ?? []) as unknown as Prestataire[], error: null };
+    const rows = (data ?? []) as unknown as (Prestataire & { is_founder?: boolean })[];
+    return { data: rows.map(toPublicPrestataire), error: null };
   } catch (err) {
     return { data: null, error: errorMessage(err) };
   }
@@ -169,7 +210,8 @@ export async function getPrestatairesByVille(
       .order("approved_at", { ascending: false, nullsFirst: false });
 
     if (error) return { data: null, error: error.message };
-    return { data: (data ?? []) as unknown as Prestataire[], error: null };
+    const rows = (data ?? []) as unknown as (Prestataire & { is_founder?: boolean })[];
+    return { data: rows.map(toPublicPrestataire), error: null };
   } catch (err) {
     return { data: null, error: errorMessage(err) };
   }

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -102,6 +102,10 @@ export interface Prestataire {
 
   // Palier d'abonnement (display-only V1 — sera renommé `tier` au Chantier 3)
   palier?: "standard" | "premium" | "cercle_pro";
+
+  // Founder flag — accès Cercle Pro à vie (gratuit, sans abonnement Stripe).
+  // ⚠️ Ne JAMAIS exposer côté public : strippé via toPublicPrestataire().
+  is_founder?: boolean;
 }
 
 /* ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Quoi

Code applicatif qui donne **vie** au flag `profiles.is_founder` installé en BDD par PR #72 (migration 39). Désormais, partout où le code gate une feature payante via `palier === 'cercle_pro'`, les founders sont traitées strictement comme Cercle Pro, sans abonnement Stripe associé.

## Pourquoi

PR #72 (déjà mergée) a installé en prod :
- Colonne `profiles.is_founder` (boolean)
- Table `app_config` (`founders_window_open`, `stripe_live`)
- Trigger d'auto-flag des nouvelles approuvées tant que la fenêtre est ouverte
- 15 founders existantes flaggées en BDD

Mais en l'état actuel sur main, **aucune ligne de code ne lit `is_founder`**. Conséquence : les 15 founders flaggées en BDD reçoivent toujours l'UX « Standard », ne voient pas les stats Premium, ne peuvent pas accéder à `/dashboard/prestataire/devis` ni `/dashboard/prestataire/stats-avancees`. **Cette PR complète le binôme** et débloque l'accès Cercle Pro effectif aux founders.

## Comment c'est wired

### 1. Helper centralisé (source de vérité unique)

Nouveau fichier [lib/permissions.ts](lib/permissions.ts) :

```ts
getEffectivePalier(p)     // founder → 'cercle_pro', sinon p.palier ?? 'standard'
hasPremiumFeatures(p)     // true si effectivePalier ∈ {premium, cercle_pro}
hasCerclePro(p)           // true si effectivePalier === 'cercle_pro'
isFounder(p)              // true si p.is_founder === true
```

Tous les call-sites de gating utilisent ces helpers à la place de `palier === 'cercle_pro'` direct.

### 2. Privacy `is_founder` — jamais exposé côté public

`is_founder` est de la donnée business interne (qui paie / qui ne paie pas). Le mapper privé `toPublicPrestataire(raw)` dans [lib/supabase/queries/prestataires.ts](lib/supabase/queries/prestataires.ts) :
- strippe `is_founder` du résultat
- substitue `palier` par sa valeur effective (founder → `cercle_pro`)

**Tous les helpers publics** du fichier (`getAllPrestataires`, `getPrestataireBySlug`, `getPionnieres`, `getPrestatairesByCategorie`, `getPrestatairesByVille`, `getPrestataireBySlugForOwner`) appliquent le mapper avant retour. → **aucune donnée brute `is_founder` ne transite par un bundle SSR public ou une JSON response publique**.

Le code server-trusted (dashboard owner, API routes, cron) lit raw via `requirePrestataire` (`select("*")`) ou des selects dédiés, et utilise les helpers directement.

### 3. Annuaire converti CSR → RSC

[app/annuaire/page.tsx](app/annuaire/page.tsx) était `'use client'` avec un `useEffect` de fetch côté browser. Pour éviter que `is_founder` transite via la JSON wire vers le client (le tri par palier en avait besoin), conversion en **Server Component** :
- Server fetch via `getAllPrestataires()` (qui strippe)
- Tri par palier effectif côté serveur
- Passe les données à un nouveau Client Component [app/annuaire/AnnuaireClient.tsx](app/annuaire/AnnuaireClient.tsx) qui gère filtres + animations

### 4. Cohortes BDD via `.or()` PostgREST

Pour `/api/cron/stats-hebdo` (qui email Premium+ chaque lundi) et le benchmark catégorie de `/dashboard/prestataire/stats-avancees`, le filtre `.in('palier', ['premium', 'cercle_pro'])` est remplacé par `.or('palier.in.(premium,cercle_pro),is_founder.eq.true')` → les founders sont **incluses dans les cohortes du tier supérieur**.

## Fichiers modifiés (13 fichiers, +359 / -290)

### Nouveaux (2)
- `lib/permissions.ts` — helpers source de vérité
- `app/annuaire/AnnuaireClient.tsx` — client component (filtres + animations)

### Helpers serveur (3)
- `lib/supabase/types.ts` — ajoute `is_founder?: boolean` au type `Prestataire`
- `lib/supabase/queries/prestataires.ts` — `PRESTATAIRE_SELECT` inclut `is_founder` ; mapper `toPublicPrestataire` strippe + substitue palier ; appliqué aux 6 helpers publics

### Dashboard prestataire (6)
- `app/dashboard/prestataire/page.tsx` — `hasPremiumFeatures` / `hasCerclePro` au lieu de tests directs
- `app/dashboard/prestataire/parametres/page.tsx` — `select` inclut `is_founder` ; section Notifications via helper
- `app/dashboard/prestataire/layout.tsx` — sidebar item « Mes devis » + count query via `hasCerclePro`
- `app/dashboard/prestataire/fiche/page.tsx` — palier effectif passé à `canUploadMorePhotos` (founders → illimité)
- `app/dashboard/prestataire/stats-avancees/page.tsx` — garde Cercle Pro via helper + cohorte benchmark via `.or()`
- `app/dashboard/prestataire/devis/page.tsx` — garde Cercle Pro via helper

### API server-side (2)
- `app/api/devis-requests/route.ts` — `select` inclut `is_founder` + gate via helper
- `app/api/cron/stats-hebdo/route.ts` — `select` inclut `is_founder` + cohorte via `.or()` + label palier effectif dans email

## Décisions prises en autonomie (Q1–Q5 répondues en amont)

1. **DSN/init** N/A (côté web pas mobile)
2. **Annuaire** converti en RSC plutôt que rester CSR + filtrage de selects côté browser → le seul moyen de garantir « zéro `is_founder` côté wire publique »
3. **Privacy** : un seul mapper `toPublicPrestataire` au niveau lib (Option B refined) plutôt que deux selects séparés (Option A) — convention du repo, plus simple à maintenir
4. **Display** : badge / pastille / sort annuaire utilisent désormais le palier effectif → **founders affichées comme Cercle Pro partout** (badge, pastille, ranking)
5. **Hors scope explicite** : `/dashboard/prestataire/abonnement` reste **intouchée** (paywall-adjacent, à traiter dans une PR n°3 dédiée plus tard)

## Comment tester

### En local
```sh
git checkout claude/founders-app-logic
npm run dev
```

1. **Owner founder** (login avec un compte parmi les 15 UUIDs flaggés en migration 39) :
   - `/dashboard/prestataire` → bandeau « Stats avancées · disponibles » visible (réservé Cercle Pro)
   - `/dashboard/prestataire/devis` → page accessible (au lieu d'un redirect)
   - `/dashboard/prestataire/stats-avancees` → page accessible
   - `/dashboard/prestataire/fiche` → upload photo possible illimité
   - `/dashboard/prestataire/parametres` → section Notifications (stats hebdo opt-in) visible
2. **Public** :
   - `/annuaire` → la fiche du founder rank en tête (palier effectif = cercle_pro)
   - `/prestataire-v2/[slug-d-une-founder]` → badge Cercle Pro affiché côté public
   - **Ouvrir DevTools Network** sur `/annuaire` et `/prestataire-v2/[slug]` : la JSON response **ne contient PAS** le champ `is_founder` (privacy ✓)
3. **TypeScript** : `npx tsc --noEmit` — aucune erreur introduite (24 erreurs baseline pré-existantes inchangées)

### Vercel preview de cette PR
Tester les mêmes parcours sur l'URL preview que Vercel générera automatiquement.

## Risques

- **Mauvaise extension de cohorte BDD** : la nouvelle expression PostgREST `.or('palier.in.(premium,cercle_pro),is_founder.eq.true')` doit être validée par un essai concret sur prod (cron stats-hebdo). Mitigation : le cron est best-effort et un envoi raté n'arrête pas les autres ; la prochaine exécution lundi 9h UTC servira de validation. À surveiller dans les logs Vercel.
- **API `/api/devis-requests`** est gate-critique : un faux positif sur `hasCerclePro` autoriserait des soumissions de devis sur des fiches non-Cercle-Pro. Le helper est central (`lib/permissions.ts`) → bug = bug pour tout le monde, faible probabilité d'erreur subtile vs duplication ad-hoc.
- **Type `Prestataire`** rendu en `is_founder?: boolean` (optionnel) pour ne pas forcer toutes les couches à l'inclure. Les call-sites qui appellent les helpers passent volontairement un `Prestataire` complet ou un `Pick<Prestataire, 'palier' | 'is_founder'>`. Pas de risque TS.

## Sécurité

- Aucun secret committé.
- Aucune modif auth, paywall, Stripe, prix DB ou Stripe Price IDs.
- **Privacy `is_founder`** : strippé via mapper avant tout retour de fonction publique → ne transite pas dans le bundle SSR ni la JSON wire publique. Owner-side et server-trusted continuent de lire raw.
- Pas de référence Muslim/halal/Islam introduite.
- Voix Sara respectée (pas de « plateforme/communauté/membres »).

## À faire avant / après merge

- [x] **Migration 39** déjà mergée via PR #72 (DB columns + trigger + 15 founders flaggées) — prérequis de cette PR
- [ ] **Vercel preview** : tester les parcours owner-founder et public (cf. section Test)
- [ ] **Surveillance cron stats-hebdo** : vérifier les logs Vercel après la prochaine exécution lundi 9h UTC pour confirmer que les founders reçoivent bien leur email
- [ ] **PR n°3 future (hors scope)** : `/dashboard/prestataire/abonnement` à adapter pour les founders (vue « Tu es founder, accès Cercle Pro à vie offert »)
