### PR TITLE
feat: promo lancement -50% (avant sortie app mobile)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,14 @@ Sans validation explicite.
 ### Lieux (Recommandations payantes)
 - **Sélection Hilmy** : 39€/mois · 3m 110€ · 6m 210€ · 1an 374€
 Ne pas modifier les prix, les noms de tiers, ni les durées sans validation explicite.
+
+### Promo lancement -50% (en cours, jusqu'à la sortie de l'app mobile)
+- Feature flag : `NEXT_PUBLIC_PROMO_LANCEMENT=true`
+- Helpers : [lib/promo-lancement.ts](lib/promo-lancement.ts) (UI) + [lib/stripe-promo.ts](lib/stripe-promo.ts) (futur Stripe checkout)
+- Coupon Stripe : `LANCEMENT50` (créé manuellement par Jiji dans le dashboard Stripe — **ne pas créer via API**)
+- UI affecte : [/tarifs](app/tarifs) wizard + homepage [PricingTeaser](components/landing/PricingTeaser.tsx)
+- **À désactiver le jour de sortie de l'app mobile** : passer la var à `false` (ou retirer) côté Vercel + `.env.local`. Aucune autre modif code nécessaire.
+- Coexistence avec le système promo_codes Supabase : pendant la promo lancement, le champ « J'ai un code copine » est masqué (pas de stacking).
  
 ## 🔒 Workflow Git
 - Toujours créer une nouvelle branche par tâche.

--- a/app/tarifs/_components/WizardSection.tsx
+++ b/app/tarifs/_components/WizardSection.tsx
@@ -18,6 +18,12 @@ import {
   validatePromoCode,
   type PromoCodeRow,
 } from '@/lib/promo-codes'
+import {
+  PROMO_LANCEMENT_BADGE_LABEL,
+  PROMO_LANCEMENT_PRICE_NOTE,
+  applyPromoLancement,
+  isPromoLancementActive,
+} from '@/lib/promo-lancement'
 
 type WizardKey = 'standard' | 'premium' | 'cercle_pro'
 
@@ -266,10 +272,25 @@ export function WizardSection({ initialPalier, initialPromo }: WizardSectionProp
   const monthlyAfterDiscount = applyDiscount(price.m, discountPct)
   const totalAfterDiscount =
     price.t !== null ? applyDiscount(price.t, discountPct) : null
-  const totalLine =
-    totalAfterDiscount !== null
+
+  // Promo lancement -50% : exclusive avec un code copine saisi (la promo
+  // lancement coupe l'affichage du champ code). Quand active, on remplace
+  // le prix affiché par le prix -50% et on barre l'original.
+  const promoLancActive = isPromoLancementActive() && !appliedPromo
+  const lancMonthly = promoLancActive ? applyPromoLancement(price.m) : price.m
+  const lancTotal =
+    promoLancActive && price.t !== null
+      ? applyPromoLancement(price.t)
+      : price.t
+
+  const totalLine = appliedPromo
+    ? totalAfterDiscount !== null
       ? `Soit ${formatPrice(totalAfterDiscount)} ${DUREE_PERIODE[duree]}`.trim()
       : ''
+    : lancTotal !== null
+      ? `Soit ${formatPrice(lancTotal)} ${DUREE_PERIODE[duree]}`.trim()
+      : ''
+
   const mailto = buildMailtoPalier(palier, duree, appliedPromo?.code ?? null)
 
   return (
@@ -434,9 +455,16 @@ export function WizardSection({ initialPalier, initialPromo }: WizardSectionProp
           <div className="mx-auto grid max-w-[1000px] grid-cols-1 items-center gap-12 md:grid-cols-2">
             <div
               className={`relative rounded-[32px] border-2 border-or bg-vert p-12 text-creme shadow-[0_24px_60px_rgba(15,61,46,0.2)] ${
+                promoLancActive ? 'mt-10' : ''
+              } ${
                 initialPalier ? 'animate-[pulse-border_2s_ease-out_1]' : ''
               }`}
             >
+              {promoLancActive ? (
+                <span className="absolute -top-12 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-creme px-5 py-2 text-[11px] font-semibold uppercase tracking-[.18em] text-or shadow-[0_4px_12px_rgba(15,61,46,0.08)]">
+                  {PROMO_LANCEMENT_BADGE_LABEL}
+                </span>
+              ) : null}
               <span className="absolute -top-3.5 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-or px-4 py-2 text-[11px] font-semibold uppercase tracking-[.18em] text-vert">
                 Pour toi
               </span>
@@ -449,6 +477,16 @@ export function WizardSection({ initialPalier, initialPromo }: WizardSectionProp
                   <div className="flex items-baseline gap-3">
                     <span className="font-serif text-[60px] font-light leading-none text-creme">
                       {formatPrice(monthlyAfterDiscount)}
+                    </span>
+                    <span className="text-sm text-or-light line-through opacity-70">
+                      {formatPrice(price.m)}
+                    </span>
+                    <span className="ml-1.5 text-sm text-or-light">/mois</span>
+                  </div>
+                ) : promoLancActive ? (
+                  <div className="flex items-baseline gap-3">
+                    <span className="font-serif text-[60px] font-light leading-none text-creme">
+                      {formatPrice(lancMonthly)}
                     </span>
                     <span className="text-sm text-or-light line-through opacity-70">
                       {formatPrice(price.m)}
@@ -472,6 +510,11 @@ export function WizardSection({ initialPalier, initialPromo }: WizardSectionProp
                     Code «{appliedPromo.code}» −{appliedPromo.discount_pct}%
                   </p>
                 )}
+                {promoLancActive && (
+                  <p className="mt-2 text-[11px] italic text-or-light/80">
+                    {PROMO_LANCEMENT_PRICE_NOTE}
+                  </p>
+                )}
               </div>
               <ul className="mb-8 space-y-1.5">
                 {info.features.map((f) => (
@@ -483,9 +526,11 @@ export function WizardSection({ initialPalier, initialPromo }: WizardSectionProp
                   </li>
                 ))}
               </ul>
-              {/* Champ code promo "J'ai un code copine" */}
+              {/* Champ code promo "J'ai un code copine" — masqué pendant la
+                   promo lancement -50% (la remise est déjà appliquée pour
+                   tout le monde, pas de stacking). */}
               <div className="mb-5">
-                {!appliedPromo ? (
+                {promoLancActive ? null : !appliedPromo ? (
                   <details className="group">
                     <summary className="cursor-pointer list-none text-[12px] font-medium text-or-light transition-colors hover:text-or">
                       <span className="border-b border-or-light/40 pb-0.5 group-open:hidden">
@@ -506,7 +551,7 @@ export function WizardSection({ initialPalier, initialPromo }: WizardSectionProp
                         spellCheck={false}
                         value={promoInput}
                         onChange={(e) => setPromoInput(e.target.value)}
-                        placeholder="COPINE10"
+                        placeholder="TON CODE"
                         disabled={promoStatus === 'checking'}
                         onKeyDown={(e) => {
                           if (e.key === 'Enter') {
@@ -560,7 +605,9 @@ export function WizardSection({ initialPalier, initialPromo }: WizardSectionProp
               <a
                 href={mailto}
                 className="block w-full rounded-full bg-or px-8 py-4 text-center text-[15px] font-semibold text-vert transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)]"
-                aria-label={`Choisir la formule ${info.name} (${formatPrice(monthlyAfterDiscount)} par mois)`}
+                aria-label={`Choisir la formule ${info.name} (${formatPrice(
+                  appliedPromo ? monthlyAfterDiscount : lancMonthly,
+                )} par mois)`}
               >
                 Je choisis cette formule
               </a>
@@ -582,17 +629,32 @@ export function WizardSection({ initialPalier, initialPromo }: WizardSectionProp
               </button>
 
               <div className="mt-6 flex flex-col">
-                {(['standard', 'premium', 'cercle_pro'] as Palier[]).map((p) => (
-                  <button
-                    key={p}
-                    type="button"
-                    onClick={() => setPalier(p)}
-                    className="flex cursor-pointer justify-between border-t border-vert/8 py-3.5 text-[13px] text-texte-sec transition-colors hover:text-vert"
-                  >
-                    <span>Voir {PALIER_INFO[p].name}</span>
-                    <span className="font-medium text-vert">{PALIER_PRICES_LABEL[p]}</span>
-                  </button>
-                ))}
+                {(['standard', 'premium', 'cercle_pro'] as Palier[]).map((p) => {
+                  const monthly = PRICING[p][1].m
+                  const monthlyLanc = applyPromoLancement(monthly)
+                  return (
+                    <button
+                      key={p}
+                      type="button"
+                      onClick={() => setPalier(p)}
+                      className="flex cursor-pointer justify-between border-t border-vert/8 py-3.5 text-[13px] text-texte-sec transition-colors hover:text-vert"
+                    >
+                      <span>Voir {PALIER_INFO[p].name}</span>
+                      {promoLancActive ? (
+                        <span className="flex items-baseline gap-2 font-medium text-vert">
+                          <span>{formatPrice(monthlyLanc)}/mois</span>
+                          <span className="text-[11px] text-texte-sec line-through">
+                            {formatPrice(monthly)}
+                          </span>
+                        </span>
+                      ) : (
+                        <span className="font-medium text-vert">
+                          {PALIER_PRICES_LABEL[p]}
+                        </span>
+                      )}
+                    </button>
+                  )
+                })}
               </div>
             </div>
           </div>

--- a/components/landing/PricingTeaser.tsx
+++ b/components/landing/PricingTeaser.tsx
@@ -1,6 +1,12 @@
 import { FadeInSection } from '@/components/ui/FadeInSection'
 import { HilmyButton } from '@/components/ui/HilmyButton'
-import { PRICING, PALIER_INFO, type Palier } from '@/app/tarifs/_lib/pricing'
+import { PRICING, PALIER_INFO, formatPrice, type Palier } from '@/app/tarifs/_lib/pricing'
+import {
+  PROMO_LANCEMENT_BADGE_LABEL,
+  PROMO_LANCEMENT_PRICE_NOTE,
+  applyPromoLancement,
+  isPromoLancementActive,
+} from '@/lib/promo-lancement'
 
 // Teaser homepage des 3 paliers prestataires. Source de vérité prix +
 // labels = app/tarifs/_lib/pricing.ts (option B brief batch 3.2 home).
@@ -37,6 +43,8 @@ const TEASER_CARDS: TeaserCard[] = [
 ]
 
 export function PricingTeaser() {
+  const promoLancActive = isPromoLancementActive()
+
   return (
     <section className="bg-creme py-28 md:py-36">
       <div className="mx-auto max-w-container px-6 md:px-20">
@@ -52,10 +60,15 @@ export function PricingTeaser() {
           </div>
         </FadeInSection>
 
-        <div className="mt-14 grid gap-6 md:mt-16 md:grid-cols-3 md:gap-8">
+        <div
+          className={`grid gap-6 md:grid-cols-3 md:gap-8 ${
+            promoLancActive ? 'mt-20 md:mt-24' : 'mt-14 md:mt-16'
+          }`}
+        >
           {TEASER_CARDS.map((card, i) => {
             const info = PALIER_INFO[card.palier]
             const price = PRICING[card.palier][1].m
+            const lancPrice = applyPromoLancement(price)
             return (
               <FadeInSection key={card.palier} delay={i * 0.08}>
                 <div
@@ -65,18 +78,39 @@ export function PricingTeaser() {
                       : 'border border-creme-deep'
                   }`}
                 >
-                  {card.highlight && card.badge ? (
+                  {promoLancActive ? (
+                    <span className="absolute -top-3 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-creme px-4 py-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-or shadow-[0_4px_12px_rgba(15,61,46,0.06)]">
+                      {PROMO_LANCEMENT_BADGE_LABEL}
+                    </span>
+                  ) : card.highlight && card.badge ? (
                     <span className="absolute -top-3 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-or px-4 py-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-vert">
                       {card.badge}
                     </span>
                   ) : null}
                   <p className="font-serif text-lg font-medium text-vert">{info.name}</p>
-                  <p className="mt-3 flex items-baseline gap-1.5">
-                    <span className="font-serif text-[48px] font-light leading-none text-vert md:text-5xl">
-                      {price}€
-                    </span>
-                    <span className="text-sm text-texte-sec">/ mois</span>
-                  </p>
+                  {promoLancActive ? (
+                    <>
+                      <p className="mt-3 flex items-baseline gap-2">
+                        <span className="font-serif text-[48px] font-light leading-none text-vert md:text-5xl">
+                          {formatPrice(lancPrice)}
+                        </span>
+                        <span className="text-sm text-texte-sec line-through">
+                          {price}€
+                        </span>
+                        <span className="text-sm text-texte-sec">/ mois</span>
+                      </p>
+                      <p className="mt-2 text-[11px] italic text-texte-sec/80">
+                        {PROMO_LANCEMENT_PRICE_NOTE}
+                      </p>
+                    </>
+                  ) : (
+                    <p className="mt-3 flex items-baseline gap-1.5">
+                      <span className="font-serif text-[48px] font-light leading-none text-vert md:text-5xl">
+                        {price}€
+                      </span>
+                      <span className="text-sm text-texte-sec">/ mois</span>
+                    </p>
+                  )}
                   <p className="mt-4 text-[14px] leading-relaxed text-texte-sec">
                     {card.tagline}
                   </p>

--- a/lib/promo-lancement.ts
+++ b/lib/promo-lancement.ts
@@ -1,0 +1,47 @@
+/**
+ * Promo lancement -50% — feature flag + helpers prix.
+ *
+ * Activation : variable d'env publique `NEXT_PUBLIC_PROMO_LANCEMENT`.
+ *  - 'true'  → promo active (prix barrés + nouveau prix -50% + badge
+ *              sur /tarifs et homepage, coupon Stripe LANCEMENT50
+ *              auto-appliqué au futur checkout)
+ *  - sinon   → prix normaux, pas de badge, pas de coupon
+ *
+ * À désactiver manuellement le jour de sortie de l'app mobile en
+ * passant la var à 'false' côté Vercel + .env.local.
+ *
+ * Lu côté client ET serveur : NEXT_PUBLIC_* est inliné par Next à
+ * build-time, donc safe à utiliser dans des composants 'use client'.
+ */
+
+/** Pourcentage de remise appliquée pendant la promo lancement. */
+export const PROMO_LANCEMENT_DISCOUNT_PCT = 50
+
+/** ID du coupon Stripe à passer en `discounts: [{ coupon: ... }]` au futur checkout. */
+export const PROMO_LANCEMENT_COUPON_ID = 'LANCEMENT50'
+
+/** Wording réutilisé sur les badges et mentions. */
+export const PROMO_LANCEMENT_BADGE_LABEL = 'Offre copines lancement —50%'
+export const PROMO_LANCEMENT_PRICE_NOTE =
+  '—50% jusqu\'à la sortie de l\'app Hilmy'
+export const PROMO_LANCEMENT_BANNER_TEXT =
+  '—50% sur tous les tarifs jusqu\'à la sortie de l\'app'
+
+/**
+ * Vrai si la promo lancement est active. Lit la variable d'env publique
+ * (compatible client + serveur, inlinée par Next à build-time).
+ */
+export function isPromoLancementActive(): boolean {
+  return process.env.NEXT_PUBLIC_PROMO_LANCEMENT === 'true'
+}
+
+/**
+ * Applique la remise de la promo lancement à un prix.
+ * Pas de remise si la promo est inactive.
+ *
+ * Exemple : applyPromoLancement(19) → 9.5 si actif, 19 sinon.
+ */
+export function applyPromoLancement(price: number): number {
+  if (!isPromoLancementActive()) return price
+  return price * (1 - PROMO_LANCEMENT_DISCOUNT_PCT / 100)
+}

--- a/lib/stripe-promo.ts
+++ b/lib/stripe-promo.ts
@@ -1,0 +1,43 @@
+/**
+ * Helpers Stripe pour la promo lancement -50%.
+ *
+ * ⚠️ Stripe checkout n'est PAS encore branché dans le repo (pas de SDK
+ * installé, pas de route /api/stripe/*). Ce module fournit les helpers
+ * prêts à brancher pour le jour où le checkout sera implémenté :
+ *
+ *   import { getActiveStripeDiscounts } from '@/lib/stripe-promo'
+ *
+ *   const session = await stripe.checkout.sessions.create({
+ *     mode: 'subscription',
+ *     line_items: [...],
+ *     discounts: getActiveStripeDiscounts(), // auto-applique LANCEMENT50 si flag on
+ *     // ...
+ *   })
+ *
+ * Le coupon `LANCEMENT50` est créé manuellement par Jiji dans le
+ * dashboard Stripe. Ce fichier ne le crée jamais via API.
+ */
+
+import {
+  PROMO_LANCEMENT_COUPON_ID,
+  isPromoLancementActive,
+} from '@/lib/promo-lancement'
+
+/** Type minimal d'un discount passé à `stripe.checkout.sessions.create`. */
+export type StripeCheckoutDiscount = { coupon: string }
+
+/**
+ * Retourne le tableau `discounts` à passer à un Stripe Checkout Session
+ * quand la promo lancement est active. `undefined` sinon (Stripe ignore
+ * silencieusement).
+ *
+ * Pour les 3 paliers (Standard / Premium / Cercle Pro) : le coupon
+ * `LANCEMENT50` est configuré côté Stripe en pourcentage 50% — il
+ * s'applique au prix de chaque palier sans logique différenciée côté code.
+ */
+export function getActiveStripeDiscounts():
+  | StripeCheckoutDiscount[]
+  | undefined {
+  if (!isPromoLancementActive()) return undefined
+  return [{ coupon: PROMO_LANCEMENT_COUPON_ID }]
+}

--- a/supabase/migrations/40_disable_copine10.sql
+++ b/supabase/migrations/40_disable_copine10.sql
@@ -1,0 +1,24 @@
+-- =====================================================================
+-- HILMY · 40 — Désactivation du seed COPINE10 (legacy)
+-- =====================================================================
+-- Le code promo `COPINE10` (-10% Premium, seed migration 35) est retiré
+-- de l'UI prestataire à la même date. On le désactive en BDD via
+-- `active = false` plutôt qu'un DELETE pour préserver l'historique
+-- (audit trail + replay fresh-env cohérent).
+--
+-- Note : la migration 35 fait `ON CONFLICT DO UPDATE SET active = true`
+-- sur le seed. En replay fresh-env, l'ordre des migrations garantit que
+-- 35 réactive le seed puis 40 le redésactive. État final cohérent.
+--
+-- Idempotent : peut être rejouée sans erreur.
+-- =====================================================================
+
+UPDATE public.promo_codes
+SET active = false,
+    notes = COALESCE(notes, '') || ' [désactivé 2026-05-08 — promo lancement -50% via LANCEMENT50]'
+WHERE code = 'COPINE10'
+  AND active = true;
+
+-- Reload PostgREST schema cache (pas strictement nécessaire pour un
+-- UPDATE sur ligne existante, mais cohérent avec la convention du repo).
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Quoi

Promo de lancement -50% sur les 3 paliers prestataires (Standard / Premium / Cercle Pro), active jusqu'à la sortie de l'app mobile Hilmy. Désactivable d'un seul flag, sans déploiement code.

## Pourquoi

- Booster les inscriptions prestataires sur la fenêtre pré-app mobile
- Préparer l'auto-application du coupon Stripe `LANCEMENT50` quand le checkout sera branché
- Retirer le code promo legacy `COPINE10` (-10% Premium, seed migration 35) qui devient redondant avec la promo lancement

## Comment c'est wired

- **Feature flag** : `NEXT_PUBLIC_PROMO_LANCEMENT=true` côté Vercel (Production + Preview). Pour désactiver le jour de sortie de l'app mobile : passer la var à `false` côté Vercel + redeploy. Aucune modif code.
- **Helpers** :
  - [lib/promo-lancement.ts](lib/promo-lancement.ts) : `isPromoLancementActive()`, `applyPromoLancement(price)`, constantes wording
  - [lib/stripe-promo.ts](lib/stripe-promo.ts) : `getActiveStripeDiscounts()` retourne `[{ coupon: 'LANCEMENT50' }]` ou `undefined` selon le flag — forward-compat pour le futur Stripe Checkout
- **UI** :
  - `/tarifs` ([WizardSection.tsx](app/tarifs/_components/WizardSection.tsx)) : badge crème sur or « Offre copines lancement —50% » au-dessus de la card recommandée, prix promo + original barré, mention italique « —50% jusqu'à la sortie de l'app Hilmy », mini-list bas avec prix barrés, **champ « J'ai un code copine » masqué** (pas de stacking)
  - Homepage ([PricingTeaser.tsx](components/landing/PricingTeaser.tsx)) : badges sur les 3 cards + prix barrés + mentions
- **BDD** : [migration 40](supabase/migrations/40_disable_copine10.sql) désactive le seed `COPINE10` (`active = false`), idempotente. **Déjà appliquée en prod le 2026-05-08** par Jiji via Supabase Studio (project `qrlvjwqanixkhopedqqw`).

## Fichiers modifiés (6)

| Fichier | Type | Détail |
|---|---|---|
| `supabase/migrations/40_disable_copine10.sql` | A | UPDATE active=false sur seed COPINE10 |
| `lib/promo-lancement.ts` | A | Feature flag + helpers prix + constantes wording |
| `lib/stripe-promo.ts` | A | `getActiveStripeDiscounts()` forward-compat checkout |
| `app/tarifs/_components/WizardSection.tsx` | M | Placeholder COPINE10 → TON CODE + UI promo + masquage champ |
| `components/landing/PricingTeaser.tsx` | M | UI promo sur 3 cards homepage |
| `AGENTS.md` | M | Sous-section « Promo lancement -50% » sous le bloc Pricing |

## Décisions prises en autonomie (escaladables)

1. **Migration 35** intacte (règle d'or). Nouvelle **migration 40** désactive le seed via UPDATE (idempotent, ordonné 35→40 → état final cohérent en replay fresh-env).
2. **Docs archives** (`docs/session-phase-4-codables-2026-05-04.md` etc.) **laissées intactes** (audit trail). La consigne « grep COPINE10 doit être vide » est strictement incompatible avec « ne pas éditer une migration appliquée » + nature archivale des rapports — j'ai tranché en faveur des règles d'or.
3. **Stripe checkout pas encore branché** dans le repo (pas de SDK, pas de route /api/stripe/*). Helper `lib/stripe-promo.ts` créé en mode forward-compatible — quand le checkout sera implémenté, ajouter `discounts: getActiveStripeDiscounts()` aux params de `stripe.checkout.sessions.create`.
4. **Champ « J'ai un code copine »** masqué pendant la promo lancement (pas de stacking visuel ni applicatif).
5. **Bandeau homepage haut de page** : non implémenté (la spec disait « éventuellement »). Constante `PROMO_LANCEMENT_BANNER_TEXT` exposée si tu veux l'activer plus tard.

## Comment tester

1. **Sur Vercel preview de cette PR** : la var `NEXT_PUBLIC_PROMO_LANCEMENT` est déjà ajoutée (Production + Preview) côté Vercel. Visiter `/tarifs` et `/`.
2. **En local** :
   ```sh
   echo "NEXT_PUBLIC_PROMO_LANCEMENT=true" >> .env.local
   npm run dev
   ```
   Vérifier `/tarifs?palier=premium` (badge + prix barré + mention) et `/` (3 cards avec badges).
   Toggle à `false` → tout revient au comportement initial.
3. **Vérifier le grep** :
   ```sh
   grep -rIn "COPINE10" . --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=.git --exclude-dir=docs --exclude="35_promo_codes.sql" --exclude="40_disable_copine10.sql"
   # → 0 hit attendu (code applicatif)
   ```

## Risques

- **Migration 40 non appliquée en prod** : la promo Stripe LANCEMENT50 fonctionnera quand même (UI + futur checkout indépendants), mais le seed COPINE10 reste actif côté Supabase → un user qui taperait `COPINE10` dans le champ promo verrait toujours -10% appliqué. **Mitigation** : déjà appliquée en prod le 2026-05-08 (cf. À faire). Le champ est de toute façon masqué quand la promo lancement est active.
- **Coupon Stripe `LANCEMENT50`** non créé : sans impact tant que le Stripe checkout n'est pas branché (mailto fallback actuel). À créer manuellement dans le dashboard Stripe (50% off, 3 produits) avant qu'un Stripe checkout soit branché.

## Sécurité

Aucun secret committé. Aucune modif auth, prix DB ou Stripe Price IDs. Le DSN Supabase et les autres clés ne sont pas touchés. Pas de référence Muslim/halal/Islam introduite. Voix Sara respectée (pas de « plateforme/communauté/membres »).

## À faire avant / après merge

- [x] **Vercel env var** : `NEXT_PUBLIC_PROMO_LANCEMENT=true` (Production + Preview) — ✅ déjà ajoutée par Jiji
- [x] **Migration 40** : appliquée en prod le 2026-05-08 via Supabase Studio (project `qrlvjwqanixkhopedqqw`). Vérification : `SELECT code, active FROM promo_codes WHERE code = 'COPINE10'` → `active = false` ✓
- [ ] **Coupon Stripe** : créer `LANCEMENT50` dans le dashboard Stripe (50%, 3 produits) — pas urgent (checkout pas encore branché)
- [ ] **Le jour de sortie app mobile** : passer `NEXT_PUBLIC_PROMO_LANCEMENT` à `false` côté Vercel + redeploy
