### PR TITLE
fix(founders): show effective palier on /dashboard/prestataire/abonnement

### DIFF
--- a/app/dashboard/prestataire/abonnement/page.tsx
+++ b/app/dashboard/prestataire/abonnement/page.tsx
@@ -3,6 +3,7 @@ import { GoldLine } from '@/components/ui/GoldLine'
 import { PalierBadge } from '@/components/v2/PalierBadge'
 import { PastilleSelectionHilmy } from '@/components/v2/PastilleSelectionHilmy'
 import { requirePrestataire } from '@/lib/supabase/session'
+import { getEffectivePalier, isFounder } from '@/lib/permissions'
 import {
   PALIER_INFO,
   PRICING,
@@ -18,12 +19,14 @@ const NEXT_PALIER: Record<Palier, Palier | null> = {
 export default async function AbonnementPage() {
   const { prestataire } = await requirePrestataire()
 
-  const palier: Palier =
-    prestataire.palier === 'premium'
-      ? 'premium'
-      : prestataire.palier === 'cercle_pro'
-        ? 'cercle_pro'
-        : 'standard'
+  // Source de vérité unique pour le palier affiché : `getEffectivePalier`
+  // mappe les founders (is_founder = true) vers cercle_pro même si la colonne
+  // `palier` en BDD vaut 'standard'. Lire `prestataire.palier` directement
+  // ferait apparaître la mauvaise formule pour les founders.
+  const palier: Palier = getEffectivePalier(prestataire)
+  // Founder = accès Cercle Pro à vie sans abonnement Stripe. On adapte la
+  // copie (prix, CTAs) en conséquence — pas d'upsell, pas de "résiliation".
+  const isFounderUser = isFounder(prestataire)
 
   const info = PALIER_INFO[palier]
   const monthlyPrice = PRICING[palier][1].m
@@ -82,17 +85,33 @@ export default async function AbonnementPage() {
         <div className="rounded-sm border border-or/20 bg-creme-soft p-8 md:p-10">
           <div className="flex items-center gap-4">
             <GoldLine width={40} />
-            <span className="overline text-or">Ce que tu paies</span>
-          </div>
-          <p className="mt-4 flex items-baseline gap-1.5">
-            <span className="font-serif text-[48px] font-light leading-none text-vert md:text-[56px]">
-              {monthlyPrice}€
+            <span className="overline text-or">
+              {isFounderUser ? 'Ton statut' : 'Ce que tu paies'}
             </span>
-            <span className="text-sm text-texte-sec">/ mois</span>
-          </p>
-          <p className="mt-2 text-[12px] italic text-texte-sec">
-            Sans engagement de durée. Tu peux résilier à tout moment.
-          </p>
+          </div>
+          {isFounderUser ? (
+            <>
+              <p className="mt-4 font-serif text-[40px] font-light leading-[1.05] text-vert md:text-[48px]">
+                Cercle Pro à vie
+              </p>
+              <p className="mt-2 text-[12px] italic text-texte-sec">
+                En tant que founder Hilmy, tu accèdes à toutes les fonctionnalités
+                Cercle Pro gratuitement, sans limite de durée. 💚
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="mt-4 flex items-baseline gap-1.5">
+                <span className="font-serif text-[48px] font-light leading-none text-vert md:text-[56px]">
+                  {monthlyPrice}€
+                </span>
+                <span className="text-sm text-texte-sec">/ mois</span>
+              </p>
+              <p className="mt-2 text-[12px] italic text-texte-sec">
+                Sans engagement de durée. Tu peux résilier à tout moment.
+              </p>
+            </>
+          )}
 
           <h2 className="mt-8 font-serif text-xl font-light text-vert">
             Inclus dans ton palier&nbsp;:
@@ -112,8 +131,36 @@ export default async function AbonnementPage() {
           </ul>
         </div>
 
-        {/* Card 2 — Upsell ou message Cercle Pro */}
-        {upsell && upsellInfo && upsellPrice !== null ? (
+        {/* Card 2 — Upsell, message founder, ou message Cercle Pro */}
+        {/* Note : pour les founders, `palier` vaut toujours 'cercle_pro' via
+            getEffectivePalier → la branche upsell ne se déclenche pas, on
+            tombe directement sur le bloc founder/sommet. */}
+        {isFounderUser ? (
+          <div className="relative overflow-hidden rounded-sm bg-vert p-8 text-creme md:p-10">
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute -top-20 -right-20 h-60 w-60 rounded-full bg-or/15 blur-3xl"
+            />
+            <div className="relative">
+              <div className="flex items-center gap-4">
+                <GoldLine width={40} />
+                <span className="overline text-or">Founder Hilmy</span>
+              </div>
+              <h2 className="mt-4 font-serif text-2xl font-light italic text-or">
+                Tu as Cercle Pro à vie en tant que founder Hilmy 💚
+              </h2>
+              <p className="mt-3 text-[14px] leading-[1.65] text-creme/85">
+                Toutes les fonctionnalités Cercle Pro, sans abonnement, sans
+                date de fin. C&apos;est notre façon de remercier celles qui
+                nous ont fait confiance les premières.
+              </p>
+              <p className="mt-4 text-[13px] leading-[1.6] text-creme/75">
+                Les nouvelles fonctionnalités te sont ajoutées en priorité,
+                sans surcoût.
+              </p>
+            </div>
+          </div>
+        ) : upsell && upsellInfo && upsellPrice !== null ? (
           <div className="relative overflow-hidden rounded-sm bg-vert p-8 text-creme md:p-10">
             <div
               aria-hidden="true"
@@ -193,33 +240,51 @@ export default async function AbonnementPage() {
           )}
         </div>
         <h2 className="mt-4 font-serif text-2xl font-light text-vert">
-          Tu veux changer ou résilier&nbsp;?
+          {isFounderUser ? 'Une question, un besoin ?' : 'Tu veux changer ou résilier ?'}
         </h2>
-        <p className="mt-4 max-w-2xl text-[14px] leading-[1.7] text-texte">
-          Tu peux changer de palier ou arrêter ton abonnement à tout moment, en
-          écrivant à{' '}
-          <a
-            href={supportMailto}
-            className="text-or-deep underline-offset-4 hover:text-or hover:underline"
-          >
-            hilmy.io@hotmail.com
-          </a>
-          . La résiliation prend effet à la fin de ta période en cours, sans
-          remboursement prorata. Aucune commission n&apos;est prélevée sur tes
-          prestations — seul l&apos;abonnement plat te lie à Hilmy.
-        </p>
-        <p className="mt-4 max-w-2xl text-[12px] italic leading-[1.65] text-texte-sec">
-          La gestion en self-service depuis le dashboard arrive bientôt. En
-          attendant, {supportSla}.
-        </p>
+        {isFounderUser ? (
+          <p className="mt-4 max-w-2xl text-[14px] leading-[1.7] text-texte">
+            Ton accès Cercle Pro est offert à vie — pas d&apos;abonnement à
+            gérer ni à résilier. Pour toute question, écris à{' '}
+            <a
+              href={supportMailto}
+              className="text-or-deep underline-offset-4 hover:text-or hover:underline"
+            >
+              hilmy.io@hotmail.com
+            </a>
+            , {supportSla}.
+          </p>
+        ) : (
+          <>
+            <p className="mt-4 max-w-2xl text-[14px] leading-[1.7] text-texte">
+              Tu peux changer de palier ou arrêter ton abonnement à tout moment, en
+              écrivant à{' '}
+              <a
+                href={supportMailto}
+                className="text-or-deep underline-offset-4 hover:text-or hover:underline"
+              >
+                hilmy.io@hotmail.com
+              </a>
+              . La résiliation prend effet à la fin de ta période en cours, sans
+              remboursement prorata. Aucune commission n&apos;est prélevée sur tes
+              prestations — seul l&apos;abonnement plat te lie à Hilmy.
+            </p>
+            <p className="mt-4 max-w-2xl text-[12px] italic leading-[1.65] text-texte-sec">
+              La gestion en self-service depuis le dashboard arrive bientôt. En
+              attendant, {supportSla}.
+            </p>
+          </>
+        )}
         <div className="mt-7 flex flex-wrap gap-3">
-          <Link
-            href="/tarifs"
-            className="inline-flex h-11 items-center gap-2 rounded-full bg-vert px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
-          >
-            Comparer les paliers
-            <span className="text-or-light" aria-hidden="true">→</span>
-          </Link>
+          {!isFounderUser && (
+            <Link
+              href="/tarifs"
+              className="inline-flex h-11 items-center gap-2 rounded-full bg-vert px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+            >
+              Comparer les paliers
+              <span className="text-or-light" aria-hidden="true">→</span>
+            </Link>
+          )}
           <a
             href={supportMailto}
             className="inline-flex h-11 items-center gap-2 rounded-full border border-or/40 px-6 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-or hover:bg-creme-deep"
@@ -232,8 +297,9 @@ export default async function AbonnementPage() {
 
       {/* Footer reassurance */}
       <p className="mt-12 text-center font-sans text-[12px] italic text-texte-sec">
-        Pas de commission sur tes prestations · Sans engagement minimum ·
-        Résiliation libre
+        {isFounderUser
+          ? 'Founder Hilmy · Cercle Pro à vie · Pas de commission sur tes prestations'
+          : 'Pas de commission sur tes prestations · Sans engagement minimum · Résiliation libre'}
       </p>
     </section>
   )


### PR DESCRIPTION
## Symptôme

Une founder (`is_founder = true` mais `palier = 'standard'` en BDD) qui ouvrait `/dashboard/prestataire/abonnement` voyait :

- la formule **Standard 19€/mois** au lieu de Cercle Pro
- le badge `PalierBadge` "Standard" au lieu de "Cercle Pro"
- pas de `PastilleSelectionHilmy` (gated `palier === 'cercle_pro'`)
- une carte upsell **Premium** (au lieu du message "tu es au sommet")
- un CTA "Comparer les paliers" + une copy "résilier ton abonnement" qui n'a aucun sens pour quelqu'un qui n'a pas d'abonnement Stripe

Pourtant, partout ailleurs dans le dashboard (accueil, fiche, devis, stats avancées), les founders ont bien leur accès Cercle Pro effectif via `hasCerclePro()` / `getEffectivePalier()`.

## Root cause

Le fichier `app/dashboard/prestataire/abonnement/page.tsx` lisait `prestataire.palier` **directement** au lieu de passer par `getEffectivePalier(prestataire)` — le helper qui mappe `is_founder = true` vers `cercle_pro` (logique métier centralisée dans `lib/permissions.ts`, introduite par #73).

C'était la **seule** page du dashboard prestataire à faire cette lecture brute. Confirmé par `grep -rn "prestataire\.palier\|profile\.palier" app/dashboard/`.

## Fix

- Import `getEffectivePalier` + `isFounder` depuis `lib/permissions.ts`
- `palier` calculé via `getEffectivePalier(prestataire)` — source de vérité unique, alignée avec le reste du dashboard
- Nouveau flag `isFounderUser = isFounder(prestataire)` pour adapter la copie founder-specific
- Card prix : "Cercle Pro à vie" (au lieu de `99€/mois`) + message 💚 quand founder
- Card upsell/cercle_pro : nouveau bloc "Founder Hilmy" avec message "Tu as Cercle Pro à vie en tant que founder Hilmy 💚" quand founder (la branche upsell ne se déclenche pas car `palier=cercle_pro` effectif)
- Section Gestion : "Une question, un besoin ?" remplace "Tu veux changer ou résilier ?" pour les founders, copy ajustée, CTA "Comparer les paliers" masqué
- Footer reassurance : ligne dédiée "Founder Hilmy · Cercle Pro à vie · Pas de commission"

Commentaires ajoutés au-dessus de chaque usage de `getEffectivePalier` / `isFounder` pour éviter qu'une régression future ne refasse le même raccourci.

## Tests manuels à valider

- [ ] **Founder** (`is_founder=true`, `palier='standard'`) sur `/dashboard/prestataire/abonnement` → voit "Cercle Pro à vie", PastilleSelectionHilmy, badge Cercle Pro, message founder, pas de CTA upgrade
- [ ] **Non-founder palier=standard** → voit toujours "Standard 19€/mois", badge Standard, upsell Premium
- [ ] **Non-founder palier=premium** → voit toujours "Premium 49€/mois", badge Premium, upsell Cercle Pro
- [ ] **Non-founder palier=cercle_pro** (cas hypothétique post-Stripe) → voit "Cercle Pro 99€/mois", PastilleSelectionHilmy, message "Tu es au sommet"
- [ ] La fiche publique de la founder (`/prestataire-v2/[slug]`) continue d'afficher le palier Cercle Pro effectif (déjà géré par `toPublicPrestataire`, pas touché ici)
- [ ] `npm run build` passe (✓)

## Risques

- **Faible.** Changement isolé à un seul fichier server component, pas de modif BDD, pas de modif logique métier (le helper `getEffectivePalier` existe et est testé en prod via #73 depuis hier).
- Aucun changement pour les non-founders : tous tombent dans la branche `else` qui préserve l'UI existante à l'identique.

## Sécurité

Pas d'impact sécurité. Aucune nouvelle exposition de `is_founder` côté client public — la page est server component owner-only via `requirePrestataire()`.

## Refs

- Audit complet : `audit-features-tarifs.md` (bug ⚠️ #3, recommandation P1)
- Système founders : #73