### PR TITLE
fix(tarifs): remove obsolete '-10% pour les Copines' label from Premium

### DIFF
--- a/app/tarifs/_lib/pricing.ts
+++ b/app/tarifs/_lib/pricing.ts
@@ -79,7 +79,6 @@ export const PALIER_INFO: Record<Palier, PalierInfo> = {
       'Dashboard détaillé',
       'Tap-to-contact tracé',
       '20 photos · 1 vidéo 60s (dès cette semaine)',
-      '-10% pour les Copines',
       'Stats hebdo (dès lundi prochain)',
       'Story trimestrielle (dès Q3 2026)',
       '2 boosts par an (dès mai 2026)',


### PR DESCRIPTION
## Quoi

Suppression de la ligne `'-10% pour les Copines'` dans `PALIER_INFO.premium.features` ([app/tarifs/_lib/pricing.ts:82](app/tarifs/_lib/pricing.ts)).

## Pourquoi

Le code promo `COPINE10` a été désactivé en BDD le **2026-05-08** via [migration 40](supabase/migrations/40_disable_copine10.sql) (`active = false`). Le label restait pourtant listé dans la feature list Premium.

Aujourd'hui, l'incohérence est masquée parce que `NEXT_PUBLIC_PROMO_LANCEMENT=true` cache le champ "code copine" du wizard. Mais dès que la promo lancement se termine, n'importe quelle copine qui tape `COPINE10` aura un message d'erreur "Ce code n'existe pas". Le label promet quelque chose qu'on ne livre plus.

**Décision Jiji (2026-05-09)** : retirer le label définitivement. Le rabais Copines ne fait plus partie du modèle économique.

## Comment tester

- [ ] Ouvrir [/tarifs](https://hilmy.io/tarifs), avancer le wizard jusqu'au palier Premium → la liste de features ne mentionne plus "-10% pour les Copines"
- [ ] Ouvrir [/dashboard/prestataire/abonnement](https://hilmy.io/dashboard/prestataire/abonnement) sur un compte Premium → la liste "Inclus dans ton palier" (qui lit aussi `PALIER_INFO`) ne mentionne plus le rabais
- [ ] `npm run build` passe (✓)
- [ ] Le helper `validatePromoCode` continue de fonctionner pour de futurs codes — le système promo générique reste en place

## Risques

- **Très faible.** Une seule ligne supprimée d'un tableau de strings éditoriaux. Pas de modif de logique, pas de modif BDD, pas de modif d'API.

## Ce qui n'est PAS touché (volontaire)

- ✅ [supabase/migrations/35_promo_codes.sql](supabase/migrations/35_promo_codes.sql) + [supabase/migrations/40_disable_copine10.sql](supabase/migrations/40_disable_copine10.sql) → source of truth BDD, audit trail
- ✅ [lib/stripe-promo.ts](lib/stripe-promo.ts) → gère `LANCEMENT50` (-50%), pas `COPINE10`. Inchangé.
- ✅ [lib/promo-codes.ts](lib/promo-codes.ts) → helper de validation générique, réutilisable pour de futurs codes. Inchangé.
- ✅ Le champ "code copine" du wizard ([WizardSection.tsx:529](app/tarifs/_components/WizardSection.tsx)) → toujours câblé, prêt à accueillir un futur code promo sans re-coder l'UI.
- ⏸️ `docs/audit-promesses-vs-realite-2026-05-03.md`, `docs/session-phase-4-codables-2026-05-04.md`, `docs/migrations-phase-4-2026-05-04.md`, `docs/session-phase-1-quick-wins-2026-05-04.md`, `docs/discovery-app-native-hilmy-2026-05-05.md` → **historique de sessions, audit trail**. Pas modifiés. Si tu veux les nettoyer (ou archiver), dis-moi et je le fais en PR séparée.

## Sécurité

Aucun impact sécurité.

## Refs

- Audit complet : `audit-features-tarifs.md` (bug ⚠️ #2, recommandation P2)
- Désactivation BDD : [migration 40](supabase/migrations/40_disable_copine10.sql), commit 67b1ac0