### PR TITLE
feat(lieux): Sélection Hilmy foundations — migration 41 + helpers

### DIFF
--- a/lib/event-types.ts
+++ b/lib/event-types.ts
@@ -1,0 +1,214 @@
+/**
+ * Taxonomie events pour l'auto-boost lieu (Phase 2A · PR-D).
+ *
+ * ⚠️ NE PAS CONFONDRE avec `events.event_type` (free-text affiché par
+ * eventTypeLabel() dans lib/constants.ts — toujours en place pour la
+ * home, le dashboard utilisatrice, l'admin). Ces 25 slugs alimentent
+ * UNIQUEMENT la nouvelle colonne `events.boost_event_type` ajoutée par
+ * la migration 41, qui drive le système d'auto-mise-en-avant des fiches
+ * lieux Sélection Hilmy.
+ *
+ * Source de vérité : la liste DOIT rester strictement alignée avec :
+ *   - le CHECK constraint `events_boost_event_type_check`
+ *     (supabase/migrations/41_selection_hilmy_foundations.sql, section 3)
+ *   - le CHECK constraint `events_config_admin_event_type_check`
+ *     (idem migration 41, section 7)
+ *   - le seed initial de events_config_admin (idem, section 7)
+ *
+ * Ajouter un slug = migration BDD nouvelle (CHECK + seed). Renommer un
+ * slug = migration de données. Ne pas modifier en TS sans synchroniser.
+ */
+
+export type EventType =
+  // Restauration / convivialité
+  | 'brunch_copines'
+  | 'diner_thematique'
+  | 'soiree_iftar_ramadan'
+  | 'apero_afterwork'
+  // Beauté / bien-être
+  | 'atelier_decouverte'
+  | 'journee_portes_ouvertes'
+  | 'masterclass_beaute'
+  | 'retraite_bien_etre'
+  // Shopping / créatrices
+  | 'pop_up_ephemere'
+  | 'vente_privee_copines'
+  | 'lancement_collection'
+  | 'marche_creatrices'
+  // Religieux / culturel
+  | 'preparation_aid'
+  | 'soiree_henne'
+  // Saisonnier laïque
+  | 'saint_valentin'
+  | 'fete_des_meres'
+  | 'ete_vacances'
+  | 'rentree'
+  | 'black_friday'
+  | 'fetes_fin_annee'
+  // Lifestyle / pro
+  | 'soiree_privee_copines'
+  | 'atelier_creatif'
+  | 'conference_talk'
+  | 'workshop_business'
+  // Fallback
+  | 'autre'
+
+/** Catégories pour le grouping UI (form select dropdown PR-D). */
+export type EventTypeCategory =
+  | 'restauration'
+  | 'beaute'
+  | 'shopping'
+  | 'religieux_culturel'
+  | 'saisonnier_laic'
+  | 'lifestyle'
+  | 'autre'
+
+/**
+ * Mapping slug → catégorie. Utilisé par PR-D pour grouper les options
+ * du select "Type d'event" dans le form de création/édition d'event lieu.
+ */
+export const EVENT_TYPE_CATEGORIES: Record<EventType, EventTypeCategory> = {
+  // Restauration / convivialité
+  brunch_copines: 'restauration',
+  diner_thematique: 'restauration',
+  soiree_iftar_ramadan: 'restauration',
+  apero_afterwork: 'restauration',
+  // Beauté / bien-être
+  atelier_decouverte: 'beaute',
+  journee_portes_ouvertes: 'beaute',
+  masterclass_beaute: 'beaute',
+  retraite_bien_etre: 'beaute',
+  // Shopping / créatrices
+  pop_up_ephemere: 'shopping',
+  vente_privee_copines: 'shopping',
+  lancement_collection: 'shopping',
+  marche_creatrices: 'shopping',
+  // Religieux / culturel
+  preparation_aid: 'religieux_culturel',
+  soiree_henne: 'religieux_culturel',
+  // Saisonnier laïque
+  saint_valentin: 'saisonnier_laic',
+  fete_des_meres: 'saisonnier_laic',
+  ete_vacances: 'saisonnier_laic',
+  rentree: 'saisonnier_laic',
+  black_friday: 'saisonnier_laic',
+  fetes_fin_annee: 'saisonnier_laic',
+  // Lifestyle / pro
+  soiree_privee_copines: 'lifestyle',
+  atelier_creatif: 'lifestyle',
+  conference_talk: 'lifestyle',
+  workshop_business: 'lifestyle',
+  // Fallback
+  autre: 'autre',
+}
+
+/**
+ * Labels FR voix Sara (tutoiement, ton copine, pas corporate).
+ * Affiché côté form (dropdown) et côté admin (page /admin/events-config).
+ */
+export const EVENT_TYPE_LABELS: Record<EventType, string> = {
+  // Restauration / convivialité
+  brunch_copines: 'Brunch copines',
+  diner_thematique: 'Dîner thématique',
+  soiree_iftar_ramadan: 'Soirée iftar (Ramadan)',
+  apero_afterwork: 'Apéro afterwork',
+  // Beauté / bien-être
+  atelier_decouverte: 'Atelier découverte',
+  journee_portes_ouvertes: 'Journée portes ouvertes',
+  masterclass_beaute: 'Masterclass beauté',
+  retraite_bien_etre: 'Retraite bien-être',
+  // Shopping / créatrices
+  pop_up_ephemere: 'Pop-up éphémère',
+  vente_privee_copines: 'Vente privée copines',
+  lancement_collection: 'Lancement de collection',
+  marche_creatrices: 'Marché de créatrices',
+  // Religieux / culturel
+  preparation_aid: 'Préparation Aïd',
+  soiree_henne: 'Soirée henné',
+  // Saisonnier laïque
+  saint_valentin: 'Saint-Valentin',
+  fete_des_meres: 'Fête des mères',
+  ete_vacances: 'Été / vacances',
+  rentree: 'Rentrée',
+  black_friday: 'Black Friday',
+  fetes_fin_annee: 'Fêtes de fin d’année',
+  // Lifestyle / pro
+  soiree_privee_copines: 'Soirée privée copines',
+  atelier_creatif: 'Atelier créatif',
+  conference_talk: 'Conférence / talk',
+  workshop_business: 'Workshop business',
+  // Fallback
+  autre: 'Autre',
+}
+
+/** Labels FR pour les groupes de catégories (header optgroup form). */
+export const EVENT_TYPE_CATEGORY_LABELS: Record<EventTypeCategory, string> = {
+  restauration: 'Restauration & convivialité',
+  beaute: 'Beauté & bien-être',
+  shopping: 'Shopping & créatrices',
+  religieux_culturel: 'Religieux & culturel',
+  saisonnier_laic: 'Saisonnier',
+  lifestyle: 'Lifestyle & pro',
+  autre: 'Autre',
+}
+
+/** Tous les slugs, pour itération (form select, validation Zod, etc.). */
+export const EVENT_TYPES: readonly EventType[] = [
+  'brunch_copines',
+  'diner_thematique',
+  'soiree_iftar_ramadan',
+  'apero_afterwork',
+  'atelier_decouverte',
+  'journee_portes_ouvertes',
+  'masterclass_beaute',
+  'retraite_bien_etre',
+  'pop_up_ephemere',
+  'vente_privee_copines',
+  'lancement_collection',
+  'marche_creatrices',
+  'preparation_aid',
+  'soiree_henne',
+  'saint_valentin',
+  'fete_des_meres',
+  'ete_vacances',
+  'rentree',
+  'black_friday',
+  'fetes_fin_annee',
+  'soiree_privee_copines',
+  'atelier_creatif',
+  'conference_talk',
+  'workshop_business',
+  'autre',
+] as const
+
+/** Type guard runtime — utile pour valider un payload form/API. */
+export function isEventType(value: unknown): value is EventType {
+  return typeof value === 'string' && (EVENT_TYPES as readonly string[]).includes(value)
+}
+
+/**
+ * Liste groupée par catégorie, dans l'ordre d'affichage du form select.
+ * Ordre des catégories aligné sur le brief Phase 2A (restauration en
+ * premier, "autre" en dernier).
+ */
+export const EVENT_TYPES_BY_CATEGORY: {
+  category: EventTypeCategory
+  label: string
+  types: { value: EventType; label: string }[]
+}[] = (
+  [
+    'restauration',
+    'beaute',
+    'shopping',
+    'religieux_culturel',
+    'saisonnier_laic',
+    'lifestyle',
+    'autre',
+  ] as EventTypeCategory[]
+).map((category) => ({
+  category,
+  label: EVENT_TYPE_CATEGORY_LABELS[category],
+  types: EVENT_TYPES.filter((t) => EVENT_TYPE_CATEGORIES[t] === category).map(
+    (t) => ({ value: t, label: EVENT_TYPE_LABELS[t] }),
+  ),
+}))

--- a/lib/permissions-lieux.ts
+++ b/lib/permissions-lieux.ts
@@ -1,0 +1,50 @@
+/**
+ * Source de vérité pour le gating de features par palier lieu.
+ *
+ * Mirror de lib/permissions.ts (prestataires) mais simplifié :
+ *  - Pas de système founder côté lieux pour l'instant
+ *  - 2 paliers seulement : 'aucun' (gratuit/communautaire) et
+ *    'selection_hilmy' (39€/mois, pastille + tri prio + stats + photos
+ *    illimitées + auto-boost événementiel)
+ *
+ * Tous les call-sites qui gatent une feature payante lieu doivent passer
+ * par ces helpers plutôt que de lire `palier` directement (cohérence avec
+ * la convention prestataires : cf bug ⚠️ #3 de l'audit du 2026-05-09 où
+ * une lecture brute avait laissé passer le mauvais palier sur /abonnement).
+ *
+ * BDD : colonne `places.palier` ajoutée par migration 41.
+ */
+
+export type LieuPalier = 'aucun' | 'selection_hilmy'
+
+export type PlaceGatingFields = {
+  palier?: LieuPalier | null
+}
+
+/**
+ * Palier effectif appliqué pour le gating.
+ * Pas de mapping founder côté lieux → on retourne le palier stocké,
+ * fallback 'aucun' si NULL/undefined (lieu créé avant migration 41 ou
+ * sans palier configuré).
+ *
+ * Existe pour symétrie avec getEffectivePalier() côté prestataires :
+ * si on introduit un système founder/legacy/grandfathered côté lieux
+ * plus tard, on l'ajoute ici sans toucher aux call-sites.
+ */
+export function getEffectivePalierLieu(p: PlaceGatingFields): LieuPalier {
+  return p.palier ?? 'aucun'
+}
+
+/** Accès aux features Sélection Hilmy (pastille, tri prio, stats, etc.). */
+export function hasSelectionHilmy(p: PlaceGatingFields): boolean {
+  return getEffectivePalierLieu(p) === 'selection_hilmy'
+}
+
+/**
+ * Alias plus lisible de hasSelectionHilmy() — quand le code de lecture
+ * exprime "ce lieu EST Sélection Hilmy" plutôt que "ce lieu A accès aux
+ * features Sélection Hilmy". Sémantiquement identique.
+ */
+export function isSelectionHilmy(p: PlaceGatingFields): boolean {
+  return hasSelectionHilmy(p)
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -144,9 +144,25 @@ export interface Place {
   main_photo_url: string | null;
   photos: string[];
 
+  // Tracking créateur (mig 28). NULL pour les fiches anté-Phase 1.
+  created_by_user_id?: string | null;
+
+  // Sélection Hilmy (mig 41) — gating produit payant 39€/mois.
+  // Default 'aucun'. Lecture via getEffectivePalierLieu / hasSelectionHilmy
+  // (lib/permissions-lieux.ts) — ne PAS lire palier brut côté UI.
+  palier?: LieuPalier;
+
+  // Compteur cumulé des vues (mig 41), bumpé atomiquement par trigger
+  // sur place_views. Default 0.
+  nb_vues?: number;
+
   created_at: string;
   updated_at: string;
 }
+
+/* Type re-export aligné avec lib/permissions-lieux.ts. Source unique
+ * du set de valeurs : `LieuPalier` côté permissions-lieux. */
+export type LieuPalier = 'aucun' | 'selection_hilmy';
 
 /* ─────────────────────────────────────────────────────────────
    events
@@ -162,11 +178,21 @@ export interface HilmyEvent {
   id: string;
   user_id: string;
   prestataire_id: string | null;
+  // FK vers places(id) — mig 41. NULL pour les events historiques ou
+  // ceux non rattachés à un lieu. Un event peut être tied à un presta
+  // ET/OU à un lieu (pas de XOR).
+  place_id?: string | null;
 
   title: string;
   slug: string | null;
   description: string;
+  /** Free-text, affiché par eventTypeLabel() — préservé pour back-compat
+   *  UI (home, dashboard, admin). Voir aussi boost_event_type. */
   event_type: string;
+  /** Slug taxonomique (25 valeurs, mig 41) pour l'auto-boost lieu PR-D.
+   *  NULL si event antérieur à mig 41 ou sans rattachement Sélection Hilmy.
+   *  Type strict importé depuis lib/event-types.ts pour éviter dérive. */
+  boost_event_type?: import('@/lib/event-types').EventType | null;
   format: EventFormat;
   visibility: EventVisibility;
 
@@ -339,6 +365,72 @@ export interface VoixPublicReco {
   profile_nom: string | null;
   profile_ville: string | null;
   profile_slug: string | null;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   place_views (tracking pageview lieu — mig 41)
+   ───────────────────────────────────────────────────────────── */
+
+/** Une ligne = une visite de fiche lieu. Anonyme OK (viewer_id NULL).
+ *  Mirror de profile_views (mig 15). */
+export interface PlaceView {
+  id: string;
+  place_id: string;
+  viewer_id: string | null;
+  viewed_at: string;
+  country: string | null;
+  region: string | null;
+  city: string | null;
+  referer: string | null;
+  user_agent_hash: string | null;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   place_contacts (tracking tap-to-contact lieu — mig 41)
+   ───────────────────────────────────────────────────────────── */
+
+export type PlaceContactType =
+  | 'phone'
+  | 'website'
+  | 'email'
+  | 'instagram'
+  | 'tiktok'
+  | 'facebook'
+  | 'youtube'
+  | 'google_maps'
+  | 'whatsapp';
+
+/** Une ligne = un clic sur un canal contact d'une fiche lieu.
+ *  Mirror profile_contacts (mig 15). */
+export interface PlaceContact {
+  id: string;
+  place_id: string;
+  clicker_id: string | null;
+  contact_type: PlaceContactType;
+  clicked_at: string;
+  country: string | null;
+  region: string | null;
+  city: string | null;
+  referer: string | null;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   events_config_admin (config auto-boost par catégorie — mig 41)
+   ───────────────────────────────────────────────────────────── */
+
+/** Ligne par event_type (les 25 slugs). Modifiable côté admin via
+ *  /admin/events-config (PR-D). Lue par is_lieu_boosted (PR-D). */
+export interface EventsConfigAdmin {
+  id: string;
+  /** L'un des 25 slugs — type strict importé depuis lib/event-types.ts. */
+  event_type: import('@/lib/event-types').EventType;
+  boost_enabled: boolean;
+  /** Nombre de jours avant l'event où la fiche lieu est mise en avant. */
+  boost_days_before: number;
+  /** Si true, la mise en avant se prolonge jusqu'à end_date (ou +1j si NULL). */
+  boost_until_event_end: boolean;
+  created_at: string;
+  updated_at: string;
 }
 
 /* ─────────────────────────────────────────────────────────────

--- a/supabase/migrations/41_selection_hilmy_foundations.sql
+++ b/supabase/migrations/41_selection_hilmy_foundations.sql
@@ -1,0 +1,461 @@
+-- =====================================================================
+-- HILMY · 41 — Sélection Hilmy foundations (lieux)
+--
+-- Phase 2A · PR-A. Migration unique qui pose tout le schéma nécessaire
+-- au produit "Sélection Hilmy" (39€/mois pour les LIEUX) :
+--
+--   1. places.palier              ('aucun' | 'selection_hilmy')
+--   2. places.nb_vues             compteur agrégé (mirror profiles.nb_vues)
+--   3. events.boost_event_type    25 slugs pour l'auto-boost (PR-D)
+--   4. events.place_id            FK lieu organisateur (PR-D)
+--   5. place_views                tracking pageview (mirror profile_views)
+--   6. place_contacts             tracking tap-to-contact (mirror profile_contacts)
+--   7. events_config_admin        config flexible boost par catégorie
+--
+-- Décisions Jiji (2026-05-09) :
+--   - Conflit 1 (events.event_type déjà free-text en usage) → A1 :
+--     nouvelle colonne `boost_event_type` séparée, contrainte CHECK 25 slugs.
+--     `event_type` (free-text) reste intacte pour l'UI publique existante.
+--   - Conflit 2 (pas de FK event ↔ lieu) → B1 : ajout `events.place_id`.
+--   - Conflit 3 (pas de tracking lieu) → migration 41 unique (pas 41+42).
+--
+-- Idempotente. Voir bas de fichier pour le rollback.
+-- ⚠️ Application en prod : SUR DEMANDE EXPLICITE de Jiji uniquement.
+-- =====================================================================
+
+
+-- =====================================================================
+-- 1. places.palier  (Sélection Hilmy gating)
+-- =====================================================================
+
+alter table public.places
+  add column if not exists palier text not null default 'aucun';
+
+alter table public.places drop constraint if exists places_palier_check;
+alter table public.places add constraint places_palier_check
+  check (palier in ('aucun', 'selection_hilmy'));
+
+-- Index utilisé pour le tri du feed (Sélection Hilmy d'abord) et pour
+-- le filtrage admin "lieux payants" / cron de stats.
+create index if not exists places_palier_idx on public.places (palier);
+
+comment on column public.places.palier is
+  'Palier d''abonnement du lieu. ''aucun'' = lieu gratuit/communautaire, '
+  '''selection_hilmy'' = lieu payant 39€/mois (pastille, tri prio, stats).';
+
+
+-- =====================================================================
+-- 2. places.nb_vues  (compteur agrégé maintenu par trigger)
+-- =====================================================================
+-- Mirror du pattern profiles.nb_vues (cf migration 15). Le compteur est
+-- bumpé par le trigger sur place_views (cf section 5 de cette migration).
+
+alter table public.places
+  add column if not exists nb_vues integer not null default 0;
+
+alter table public.places drop constraint if exists places_nb_vues_positive;
+alter table public.places add constraint places_nb_vues_positive
+  check (nb_vues >= 0);
+
+comment on column public.places.nb_vues is
+  'Compteur cumulé des vues de la fiche lieu (toutes époques). Maintenu '
+  'atomiquement par trigger sur place_views (UPDATE ... SET nb_vues = '
+  'nb_vues + 1, pas de SELECT-then-UPDATE pour éviter race condition).';
+
+
+-- =====================================================================
+-- 3. events.boost_event_type  (25 catégories pour l'auto-boost lieu)
+-- =====================================================================
+-- ⚠️ Colonne SÉPARÉE de events.event_type (free-text déjà en usage par
+-- la home, dashboard utilisatrice, admin, etc.). Décision A1 du brief.
+--
+-- Cette colonne est nullable :
+--   - NULL pour les events historiques (avant cette migration)
+--   - NULL pour les events qui n'ont pas vocation à boost (event sans
+--     lieu lié, ou lieu non Sélection Hilmy)
+--   - 1 des 25 slugs pour les events de lieux Sélection Hilmy
+--
+-- L'obligation "boost_event_type non-NULL si lieu Sélection Hilmy" est
+-- enforcée côté form UI + API server (cf PR-D). PAS via CHECK BDD :
+-- impossible de joindre places.palier au moment de l'INSERT event.
+
+alter table public.events
+  add column if not exists boost_event_type text;
+
+alter table public.events drop constraint if exists events_boost_event_type_check;
+alter table public.events add constraint events_boost_event_type_check
+  check (boost_event_type is null or boost_event_type in (
+    -- Restauration / convivialité
+    'brunch_copines',
+    'diner_thematique',
+    'soiree_iftar_ramadan',
+    'apero_afterwork',
+    -- Beauté / bien-être
+    'atelier_decouverte',
+    'journee_portes_ouvertes',
+    'masterclass_beaute',
+    'retraite_bien_etre',
+    -- Shopping / créatrices
+    'pop_up_ephemere',
+    'vente_privee_copines',
+    'lancement_collection',
+    'marche_creatrices',
+    -- Religieux / culturel
+    'preparation_aid',
+    'soiree_henne',
+    -- Saisonnier laïque
+    'saint_valentin',
+    'fete_des_meres',
+    'ete_vacances',
+    'rentree',
+    'black_friday',
+    'fetes_fin_annee',
+    -- Lifestyle / pro
+    'soiree_privee_copines',
+    'atelier_creatif',
+    'conference_talk',
+    'workshop_business',
+    -- Fallback
+    'autre'
+  ));
+
+create index if not exists events_boost_event_type_idx
+  on public.events (boost_event_type)
+  where boost_event_type is not null;
+
+comment on column public.events.boost_event_type is
+  'Catégorie taxonomique (25 slugs) pour le système d''auto-boost lieu '
+  '(PR-D). Distinct de event_type (free-text UI publique). NULL si event '
+  'antérieur à mig 41 ou sans lien lieu Sélection Hilmy. Obligatoire côté '
+  'form/API si l''event est créé par un lieu palier=''selection_hilmy''.';
+
+
+-- =====================================================================
+-- 4. events.place_id  (FK lieu organisateur)
+-- =====================================================================
+-- Un event peut être lié à un prestataire (events.prestataire_id, mig 03)
+-- et/ou à un lieu (events.place_id, ici). Les deux peuvent être NULL
+-- (event organisé par une copine sans rattachement business). Ce n'est
+-- ni l'un ni l'autre exclusivement — pas de XOR constraint.
+-- ON DELETE SET NULL : si le lieu disparaît, l'event reste mais perd
+-- son rattachement (idem pattern prestataire_id).
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'events'
+      and column_name = 'place_id'
+  ) then
+    alter table public.events
+      add column place_id uuid
+      references public.places(id) on delete set null;
+  end if;
+end $$;
+
+create index if not exists events_place_id_idx
+  on public.events (place_id)
+  where place_id is not null;
+
+comment on column public.events.place_id is
+  'FK vers places(id) du lieu organisateur. Optionnel — un event peut '
+  'être organisé par un prestataire (prestataire_id), un lieu (place_id), '
+  'les deux, ou ni l''un ni l''autre. Utilisé par le système d''auto-boost '
+  'lieu (PR-D) pour identifier quel lieu mettre en avant.';
+
+
+-- =====================================================================
+-- 5. place_views  (tracking pageview lieu, mirror profile_views)
+-- =====================================================================
+-- Pattern aligné sur la migration 15 (profile_views). Anonymous OK
+-- (viewer_id NULL). Le client est responsable du debounce 1/session/lieu
+-- côté <TrackPlaceView /> (pattern futur en PR-B).
+
+create table if not exists public.place_views (
+  id uuid primary key default gen_random_uuid(),
+  place_id uuid not null references public.places(id) on delete cascade,
+  viewer_id uuid references auth.users(id) on delete set null,
+  viewed_at timestamptz not null default now(),
+  country text,                 -- ISO-2 depuis x-vercel-ip-country
+  region text,
+  city text,
+  referer text,
+  user_agent_hash text          -- sha256 anti-fingerprint, dedupe
+);
+
+create index if not exists place_views_place_viewed_idx
+  on public.place_views (place_id, viewed_at desc);
+create index if not exists place_views_viewer_idx
+  on public.place_views (viewer_id) where viewer_id is not null;
+create index if not exists place_views_viewed_at_idx
+  on public.place_views (viewed_at desc);
+
+comment on table public.place_views is
+  'Une ligne = une visite de fiche lieu. Anonyme OK. Mirror de profile_views.';
+
+
+-- ─── Trigger atomique : nb_vues++ après INSERT view ─────────────────
+-- Utilise UPDATE ... SET nb_vues = nb_vues + 1 (verrou row-level postgres
+-- atomique, pas de SELECT-then-UPDATE qui créerait une race condition).
+create or replace function public.bump_place_nb_vues() returns trigger as $$
+begin
+  update public.places
+     set nb_vues = nb_vues + 1
+   where id = new.place_id;
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists place_views_bump_nb_vues on public.place_views;
+create trigger place_views_bump_nb_vues
+  after insert on public.place_views
+  for each row execute function public.bump_place_nb_vues();
+
+
+-- ─── RLS place_views ────────────────────────────────────────────────
+alter table public.place_views enable row level security;
+
+-- INSERT : public. En pratique le client passera par /api/lieux/track-view
+-- (service-role) en PR-B, mais on laisse l'insert direct ouvert pour
+-- futur flexibility (mirror du choix migration 15 sur profile_views).
+drop policy if exists "Anyone can insert a place view" on public.place_views;
+create policy "Anyone can insert a place view"
+  on public.place_views
+  for insert
+  with check (true);
+
+-- SELECT : owner du lieu (places.created_by_user_id, mig 28) OU admin.
+-- Note : pas de notion d'"owner-prestataire" pour les places — c'est la
+-- créatrice de la fiche (mig 28). Si on a besoin d'un autre owner type
+-- en PR-B/C, on ajustera. Admin via JWT user_metadata.is_admin (pattern
+-- établi mig 06, 15).
+drop policy if exists "Owner reads own place views" on public.place_views;
+create policy "Owner reads own place views"
+  on public.place_views
+  for select
+  using (
+    exists (
+      select 1 from public.places p
+      where p.id = place_views.place_id
+        and p.created_by_user_id = auth.uid()
+    )
+    or coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+-- Pas de policy UPDATE/DELETE : historique immutable.
+
+
+-- =====================================================================
+-- 6. place_contacts  (tracking tap-to-contact lieu, mirror profile_contacts)
+-- =====================================================================
+-- Mirror profile_contacts (mig 15). Les lieux n'ont pas tous les mêmes
+-- canaux que les prestataires (pas de WhatsApp en général, mais site web
+-- + téléphone Google Places + Instagram parfois). On garde un CHECK
+-- ouvert pour permettre d'ajouter des canaux sans nouvelle migration.
+
+create table if not exists public.place_contacts (
+  id uuid primary key default gen_random_uuid(),
+  place_id uuid not null references public.places(id) on delete cascade,
+  clicker_id uuid references auth.users(id) on delete set null,
+  contact_type text not null,
+  clicked_at timestamptz not null default now(),
+  country text,
+  region text,
+  city text,
+  referer text
+);
+
+alter table public.place_contacts drop constraint if exists place_contacts_type_check;
+alter table public.place_contacts add constraint place_contacts_type_check
+  check (contact_type in (
+    'phone', 'website', 'email',
+    'instagram', 'tiktok', 'facebook', 'youtube',
+    'google_maps', 'whatsapp'
+  ));
+
+create index if not exists place_contacts_place_clicked_idx
+  on public.place_contacts (place_id, clicked_at desc);
+create index if not exists place_contacts_type_idx
+  on public.place_contacts (place_id, contact_type);
+
+comment on table public.place_contacts is
+  'Une ligne = un clic sur un canal contact d''une fiche lieu. Mirror '
+  'profile_contacts. Tracking universel (toutes places), affichage stats '
+  'gated palier=''selection_hilmy'' côté UI dashboard.';
+
+
+-- ─── RLS place_contacts ─────────────────────────────────────────────
+alter table public.place_contacts enable row level security;
+
+drop policy if exists "Anyone can insert a place contact click" on public.place_contacts;
+create policy "Anyone can insert a place contact click"
+  on public.place_contacts
+  for insert
+  with check (true);
+
+drop policy if exists "Owner reads own place contacts" on public.place_contacts;
+create policy "Owner reads own place contacts"
+  on public.place_contacts
+  for select
+  using (
+    exists (
+      select 1 from public.places p
+      where p.id = place_contacts.place_id
+        and p.created_by_user_id = auth.uid()
+    )
+    or coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+
+-- =====================================================================
+-- 7. events_config_admin  (config flexible auto-boost par catégorie)
+-- =====================================================================
+-- Une ligne par event_type (les 25 slugs). Modifiable côté admin via
+-- /admin/events-config (PR-D). Lue par la fonction is_lieu_boosted (PR-D).
+
+create table if not exists public.events_config_admin (
+  id uuid primary key default gen_random_uuid(),
+  event_type text not null unique,
+  boost_enabled boolean not null default true,
+  boost_days_before integer not null default 7,
+  boost_until_event_end boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint events_config_admin_event_type_check check (event_type in (
+    'brunch_copines', 'diner_thematique', 'soiree_iftar_ramadan', 'apero_afterwork',
+    'atelier_decouverte', 'journee_portes_ouvertes', 'masterclass_beaute', 'retraite_bien_etre',
+    'pop_up_ephemere', 'vente_privee_copines', 'lancement_collection', 'marche_creatrices',
+    'preparation_aid', 'soiree_henne',
+    'saint_valentin', 'fete_des_meres', 'ete_vacances', 'rentree', 'black_friday', 'fetes_fin_annee',
+    'soiree_privee_copines', 'atelier_creatif', 'conference_talk', 'workshop_business',
+    'autre'
+  )),
+  constraint events_config_admin_days_before_positive
+    check (boost_days_before >= 0 and boost_days_before <= 365)
+);
+
+create index if not exists events_config_admin_event_type_idx
+  on public.events_config_admin (event_type);
+
+-- Trigger updated_at (idempotent, fonction réutilisée si elle existe déjà)
+create or replace function public.bump_events_config_admin_updated_at()
+returns trigger as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists events_config_admin_updated_at_trg on public.events_config_admin;
+create trigger events_config_admin_updated_at_trg
+  before update on public.events_config_admin
+  for each row execute function public.bump_events_config_admin_updated_at();
+
+
+-- ─── RLS events_config_admin ────────────────────────────────────────
+-- SELECT : public (le client en a besoin pour calculer is_currently_boosted).
+-- INSERT/UPDATE/DELETE : admin uniquement (pattern is_admin via JWT).
+
+alter table public.events_config_admin enable row level security;
+
+drop policy if exists "events_config_admin_public_read" on public.events_config_admin;
+create policy "events_config_admin_public_read"
+  on public.events_config_admin
+  for select
+  using (true);
+
+drop policy if exists "events_config_admin_admin_write" on public.events_config_admin;
+create policy "events_config_admin_admin_write"
+  on public.events_config_admin
+  for all
+  using (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  )
+  with check (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+
+-- ─── Seed initial : 25 catégories ───────────────────────────────────
+-- Toutes activées par défaut (boost_enabled=true) sauf 'autre' (laissée
+-- désactivée pour éviter qu'un event mal catégorisé déclenche un boost).
+-- ON CONFLICT DO NOTHING : idempotent en cas de replay.
+
+insert into public.events_config_admin (event_type, boost_enabled, boost_days_before, boost_until_event_end) values
+  ('brunch_copines',         true, 7, true),
+  ('diner_thematique',       true, 7, true),
+  ('soiree_iftar_ramadan',   true, 7, true),
+  ('apero_afterwork',        true, 7, true),
+  ('atelier_decouverte',     true, 7, true),
+  ('journee_portes_ouvertes',true, 7, true),
+  ('masterclass_beaute',     true, 7, true),
+  ('retraite_bien_etre',     true, 7, true),
+  ('pop_up_ephemere',        true, 7, true),
+  ('vente_privee_copines',   true, 7, true),
+  ('lancement_collection',   true, 7, true),
+  ('marche_creatrices',      true, 7, true),
+  ('preparation_aid',        true, 7, true),
+  ('soiree_henne',           true, 7, true),
+  ('saint_valentin',         true, 7, true),
+  ('fete_des_meres',         true, 7, true),
+  ('ete_vacances',           true, 7, true),
+  ('rentree',                true, 7, true),
+  ('black_friday',           true, 7, true),
+  ('fetes_fin_annee',        true, 7, true),
+  ('soiree_privee_copines',  true, 7, true),
+  ('atelier_creatif',        true, 7, true),
+  ('conference_talk',        true, 7, true),
+  ('workshop_business',      true, 7, true),
+  ('autre',                  false, 7, true)
+on conflict (event_type) do nothing;
+
+
+-- =====================================================================
+-- Reload PostgREST schema cache (sinon les nouveaux columns/tables sont
+-- invisibles au client supabase-js jusqu'au prochain redémarrage).
+-- =====================================================================
+notify pgrst, 'reload schema';
+
+
+-- =====================================================================
+-- ROLLBACK (à exécuter manuellement si besoin de revert)
+-- =====================================================================
+-- -- 7. events_config_admin
+-- drop policy if exists "events_config_admin_admin_write" on public.events_config_admin;
+-- drop policy if exists "events_config_admin_public_read" on public.events_config_admin;
+-- drop trigger if exists events_config_admin_updated_at_trg on public.events_config_admin;
+-- drop function if exists public.bump_events_config_admin_updated_at();
+-- drop table if exists public.events_config_admin;
+--
+-- -- 6. place_contacts
+-- drop policy if exists "Owner reads own place contacts" on public.place_contacts;
+-- drop policy if exists "Anyone can insert a place contact click" on public.place_contacts;
+-- drop table if exists public.place_contacts;
+--
+-- -- 5. place_views
+-- drop policy if exists "Owner reads own place views" on public.place_views;
+-- drop policy if exists "Anyone can insert a place view" on public.place_views;
+-- drop trigger if exists place_views_bump_nb_vues on public.place_views;
+-- drop function if exists public.bump_place_nb_vues();
+-- drop table if exists public.place_views;
+--
+-- -- 4. events.place_id
+-- drop index if exists events_place_id_idx;
+-- alter table public.events drop column if exists place_id;
+--
+-- -- 3. events.boost_event_type
+-- drop index if exists events_boost_event_type_idx;
+-- alter table public.events drop constraint if exists events_boost_event_type_check;
+-- alter table public.events drop column if exists boost_event_type;
+--
+-- -- 2. places.nb_vues
+-- alter table public.places drop constraint if exists places_nb_vues_positive;
+-- alter table public.places drop column if exists nb_vues;
+--
+-- -- 1. places.palier
+-- drop index if exists places_palier_idx;
+-- alter table public.places drop constraint if exists places_palier_check;
+-- alter table public.places drop column if exists palier;
+-- =====================================================================


### PR DESCRIPTION
**PR-A of Phase 2A.** Foundation layer for the new "Sélection Hilmy" product (39€/month for places). PR-B (owner dashboard), PR-C (public UI), PR-D (event-driven auto-boost) will consume this. **No user-facing change yet** — pure plumbing.

## Symptôme audité

`audit-features-tarifs.md` (Phase 1) a identifié que le palier Sélection Hilmy lieux est listé sur [/tarifs](app/tarifs) à 39€/mois mais que **0/5 features promises** sont implémentées. Aucune colonne `palier` sur `places`, aucun tracking lieu (vues/clics), aucun lien entre events et places, aucune pastille rendue.

## Root cause

Le schéma BDD pour les lieux n'a jamais dépassé le stade "annuaire communautaire gratuit" (mig 01-40). La table `places` n'a aujourd'hui ni gating commercial ni infra de stats — alors que la fiche prestataire (mig 15) a tout ça depuis 6 mois.

## Fix : migration 41 + helpers TS

### DB migration 41 (idempotente, voir [le fichier](supabase/migrations/41_selection_hilmy_foundations.sql) pour le détail)

| # | Élément | Détail |
|---|---|---|
| 1 | `places.palier` | text NOT NULL DEFAULT 'aucun', CHECK (`'aucun'` \| `'selection_hilmy'`) + index pour tri du feed |
| 2 | `places.nb_vues` | integer NOT NULL DEFAULT 0, bumpé atomiquement par trigger (`UPDATE … SET nb_vues = nb_vues + 1`, pas de race condition) |
| 3 | `events.boost_event_type` | **NOUVELLE colonne** séparée de `event_type` (free-text préservé pour back-compat UI). CHECK sur les 25 slugs validés |
| 4 | `events.place_id` | uuid FK vers `places(id)` ON DELETE SET NULL — n'existait pas avant cette migration |
| 5 | `place_views` | tracking pageview lieu, mirror `profile_views` (mig 15). Trigger bumps `places.nb_vues`. RLS owner via `places.created_by_user_id` (mig 28) ou admin |
| 6 | `place_contacts` | tracking tap-to-contact, CHECK sur 9 canaux (`phone`, `website`, `email`, `instagram`, `tiktok`, `facebook`, `youtube`, `google_maps`, `whatsapp`) |
| 7 | `events_config_admin` | 1 ligne par event_type, controls `boost_enabled` / `boost_days_before` / `boost_until_event_end`. Seed des 25 lignes, `'autre'` désactivé par défaut. RLS public-SELECT + admin-write |

### TypeScript helpers

- **`lib/permissions-lieux.ts`** — `getEffectivePalierLieu`, `hasSelectionHilmy`, `isSelectionHilmy`. Mirror de `lib/permissions.ts` (prestataires), simplifié : pas de système founder côté lieux pour l'instant.
- **`lib/event-types.ts`** — Type strict `EventType` (25 slugs), `EVENT_TYPE_LABELS` (FR voix Sara, tutoiement), `EVENT_TYPE_CATEGORIES` (groupage en 7 catégories), `EVENT_TYPES_BY_CATEGORY` (pré-groupé pour le form select PR-D), `isEventType()` runtime guard.
- **`lib/supabase/types.ts`** — `Place` gagne `palier` + `nb_vues` + `created_by_user_id` (optionnels). `HilmyEvent` gagne `place_id` + `boost_event_type` (optionnels). Nouveaux types : `PlaceView`, `PlaceContact`, `PlaceContactType`, `EventsConfigAdmin`, `LieuPalier`.

## Décisions clés (validées Jiji 2026-05-09)

- **A1** : `events.event_type` reste free-text intacte (10+ call sites en prod) ; `boost_event_type` est une colonne **séparée**.
- **B1** : `events.place_id` ajoutée. Pas de XOR avec `prestataire_id` (un event peut être tied aux deux : atelier prestataire dans lieu partenaire).
- **Migration 41 unique** (pas split 41 + 42) — toute l'infra Sélection Hilmy en une transaction.

## Tests manuels validés

- [x] `npm run build` vert (aucune erreur TS, seul warning préexistant turbopack)
- [x] Sanity-check SQL line-by-line :
  - Triggers (BEFORE/AFTER, FOR EACH ROW, language plpgsql) ✓
  - Toutes les colonnes référencées existent ✓
  - Tous les FK targets existent (`places.id`, `auth.users.id`) ✓
  - 25 slugs identiques aux 3 endroits (events CHECK, events_config_admin CHECK, seed) ✓
  - RLS lue mentalement : owner peut lire ses stats, admin peut éditer events_config_admin, public ne peut pas lire les stats d'un autre lieu ✓
  - Aucune collision de nom (function/trigger/table/index) avec les migrations 01-40 ✓
- [x] Pattern admin (`auth.jwt() -> 'user_metadata' ->> 'is_admin'`) confirmé cohérent avec migrations 06 et 15
- [x] Trigger sécurité : aligné sur `bump_profile_nb_vues` (mig 15) qui tourne en prod depuis 6 mois sans `SECURITY DEFINER`

## Tests manuels à faire après merge + apply prod

- [ ] `SELECT count(*) FROM events_config_admin;` → 25
- [ ] `SELECT event_type, boost_enabled FROM events_config_admin WHERE event_type = 'autre';` → `('autre', false)`
- [ ] Manual `INSERT INTO place_views (place_id) VALUES ('<some place id>');` → `places.nb_vues` incrémenté de 1
- [ ] `INSERT INTO events_config_admin (event_type) VALUES ('typo_invalide');` → erreur CHECK constraint
- [ ] `INSERT INTO place_contacts (place_id, contact_type) VALUES ('<id>', 'fax');` → erreur CHECK constraint

## Risques

- **Faible.** Migration 100% non-destructive : que des `ADD COLUMN ... DEFAULT`, des `CREATE TABLE`, des seeds idempotents (`ON CONFLICT DO NOTHING`). Aucune row existante ne change de valeur (sauf défaut implicite : `places.palier='aucun'` et `places.nb_vues=0`, mais ces colonnes n'existaient pas avant).
- **Idempotente** : peut être rejouée sans dégât.
- **Rollback documenté** en commentaires bas de fichier (drop dans l'ordre inverse, à exécuter manuellement si besoin).
- **Aucun tier local Supabase** dans ce repo (pas de `config.toml`, pas de Docker requis) — application en prod via [scripts/run-migration.sh](scripts/run-migration.sh) après backup manuel **sur GO explicite Jiji**.

## Sécurité

- ✅ RLS activée sur les 3 nouvelles tables (`place_views`, `place_contacts`, `events_config_admin`)
- ✅ Pattern admin via JWT `user_metadata.is_admin` (cohérent migrations 06 + 15)
- ✅ Pas d'`UPDATE`/`DELETE` policies sur `place_views`/`place_contacts` → historique immuable
- ✅ Aucune lecture de PII dans les triggers
- ✅ Aucun `service_role` côté client

## Out of scope (PR-B/C/D)

- API routes `/api/lieux/[id]/track-view`, `/api/lieux/[id]/track-contact-click` → PR-B
- Dashboard owner lieu (`/dashboard/lieu/page.tsx`) → PR-B
- Pastille publique + tri prio + photos illimitées → PR-C
- Form select `boost_event_type` + admin `/admin/events-config` + fonction `is_lieu_boosted` → PR-D

## Refs

- Audit complet : `audit-features-tarifs.md` (P0 — Sélection Hilmy lieux 0/5 features)
- Brief Phase 2A — sprint Sélection Hilmy lieux
- Mig 15 (pattern tracking prestataires), mig 28 (places.created_by_user_id)