### PR TITLE
feat(lieux): tracking infra + FavoriteButton wired (3 itemTypes)

### DIFF
--- a/app/api/track/place-contact/route.ts
+++ b/app/api/track/place-contact/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { enforceRateLimit } from '@/lib/rate-limit'
+import {
+  extractTrackingMeta,
+  isValidPlaceContactType,
+  isValidUuid,
+} from '@/lib/tracking'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/track/place-contact
+ * Body : { place_id: uuid, contact_type: PlaceContactType }
+ * Réponse : 204 No Content si OK, 400 sinon.
+ *
+ * Mirror de /api/track/contact pour les fiches lieux. Tracking universel
+ * (toutes les places, peu importe le palier). L'affichage gated palier
+ * 'selection_hilmy' se fait côté dashboard owner (PR-B2).
+ *
+ * Appelé en pré-clic depuis <PlaceContactLink> sur la fiche lieu publique.
+ * Le clic ouvre le lien sans attendre la réponse (keepalive: true).
+ *
+ * NOTE — différence avec /api/track/contact :
+ *  - whitelist contact_type différente (cf. PLACE_CONTACT_TYPES dans
+ *    lib/tracking.ts) : 'google_maps' au lieu de 'linkedin'.
+ *  - cible place_contacts au lieu de profile_contacts.
+ */
+export async function POST(request: Request) {
+  const limited = enforceRateLimit(request, {
+    tag: 'track-place-contact',
+    max: 30,
+    windowMs: 60 * 1000,
+  })
+  if (limited) return limited
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body invalide.' }, { status: 400 })
+  }
+
+  const placeId = (body as { place_id?: unknown })?.place_id
+  const contactType = (body as { contact_type?: unknown })?.contact_type
+
+  if (!isValidUuid(placeId)) {
+    return NextResponse.json(
+      { error: 'place_id requis (uuid).' },
+      { status: 400 },
+    )
+  }
+  if (!isValidPlaceContactType(contactType)) {
+    return NextResponse.json(
+      { error: 'contact_type invalide.' },
+      { status: 400 },
+    )
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const meta = extractTrackingMeta(request)
+
+  const admin = createAdminClient()
+  const { error } = await admin.from('place_contacts').insert({
+    place_id: placeId,
+    clicker_id: user?.id ?? null,
+    contact_type: contactType,
+    country: meta.country,
+    region: meta.region,
+    city: meta.city,
+    referer: meta.referer,
+  })
+
+  if (error) {
+    if (error.code === '23503') {
+      return NextResponse.json(
+        { error: 'place_id introuvable.' },
+        { status: 400 },
+      )
+    }
+    console.error('[track/place-contact] insert failed', error)
+    return new NextResponse(null, { status: 500 })
+  }
+
+  return new NextResponse(null, { status: 204 })
+}

--- a/app/api/track/place-view/route.ts
+++ b/app/api/track/place-view/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { enforceRateLimit } from '@/lib/rate-limit'
+import { extractTrackingMeta, isValidUuid } from '@/lib/tracking'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/track/place-view
+ * Body : { place_id: string (uuid) }
+ * Réponse : 204 No Content si OK, 400 sinon.
+ *
+ * Mirror de /api/track/view (mig 15) pour les fiches lieux. Le tracking
+ * est UNIVERSEL — toutes les places sont trackées peu importe leur palier.
+ * Le gating affichage des stats côté dashboard est fait en lecture
+ * (cf. PR-B2 qui ne montrera les stats qu'aux lieux palier='selection_hilmy').
+ *
+ * Endpoint sur le chemin critique de l'affichage d'une fiche → minimal :
+ * pas de validation business lourde, pas de retour JSON.
+ *
+ * viewer_id est NULL pour les utilisateurs anonymes (la fiche peut être
+ * visitée sans être connectée). Le client est responsable du debounce
+ * 1/session/place via sessionStorage côté <TrackPlaceView />.
+ */
+export async function POST(request: Request) {
+  const limited = enforceRateLimit(request, {
+    tag: 'track-place-view',
+    max: 60,
+    windowMs: 60 * 1000,
+  })
+  if (limited) return limited
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body invalide.' }, { status: 400 })
+  }
+
+  const placeId = (body as { place_id?: unknown })?.place_id
+  if (!isValidUuid(placeId)) {
+    return NextResponse.json(
+      { error: 'place_id requis (uuid).' },
+      { status: 400 },
+    )
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const meta = extractTrackingMeta(request)
+
+  // INSERT via service-role pour bypass RLS (la policy autorise déjà les
+  // inserts publics, mais cohérent avec /api/track/view).
+  const admin = createAdminClient()
+  const { error } = await admin.from('place_views').insert({
+    place_id: placeId,
+    viewer_id: user?.id ?? null,
+    country: meta.country,
+    region: meta.region,
+    city: meta.city,
+    referer: meta.referer,
+    user_agent_hash: meta.userAgentHash,
+  })
+
+  if (error) {
+    // place_id inexistant → 23503 (FK violation).
+    if (error.code === '23503') {
+      return NextResponse.json(
+        { error: 'place_id introuvable.' },
+        { status: 400 },
+      )
+    }
+    console.error('[track/place-view] insert failed', error)
+    return new NextResponse(null, { status: 500 })
+  }
+
+  return new NextResponse(null, { status: 204 })
+}

--- a/app/evenement-v2/[slug]/page.tsx
+++ b/app/evenement-v2/[slug]/page.tsx
@@ -215,7 +215,12 @@ export default async function EvenementV2Page({
                   registrationMode={ev.registration_mode ?? 'internal'}
                   externalUrl={ev.external_signup_url}
                 />
-                <FavoriteButton label="Sauvegarder" labelActive="Sauvegardé" />
+                <FavoriteButton
+                  itemType="evenement"
+                  itemId={ev.id}
+                  label="Sauvegarder"
+                  labelActive="Sauvegardé"
+                />
               </div>
 
               <div className="mt-8 flex flex-wrap items-center gap-6 text-[12px] text-texte-sec">

--- a/app/prestataire-v2/[slug]/page.tsx
+++ b/app/prestataire-v2/[slug]/page.tsx
@@ -285,7 +285,7 @@ export default async function PrestatairePage({
               )}
               {!isPreview && (
                 <div className="mt-6">
-                  <FavoriteButton />
+                  <FavoriteButton itemType="prestataire" itemId={finalRow!.id} />
                 </div>
               )}
             </div>

--- a/app/recommandation/[slug]/page.tsx
+++ b/app/recommandation/[slug]/page.tsx
@@ -2,6 +2,8 @@ import { notFound, redirect } from 'next/navigation'
 import Link from 'next/link'
 import { PageShell } from '@/components/v2/PageShell'
 import { FavoriteButton } from '@/components/v2/FavoriteButton'
+import { TrackPlaceView } from '@/components/v2/TrackPlaceView'
+import { PlaceContactLink } from '@/components/v2/PlaceContactLink'
 import { GoldLine } from '@/components/ui/GoldLine'
 import { FadeInSection } from '@/components/ui/FadeInSection'
 import { LieuCard } from '@/components/v2/LieuCard'
@@ -144,6 +146,7 @@ export default async function RecommandationPage({
 
   return (
     <PageShell>
+      <TrackPlaceView placeId={row.id} />
       {/* Cover */}
       <section
         className="relative h-[54vh] min-h-[420px] overflow-hidden pt-20 md:h-[62vh]"
@@ -316,19 +319,21 @@ export default async function RecommandationPage({
                     Adresse via Google Maps
                   </span>
                 </div>
-                <a
+                <PlaceContactLink
                   href={`https://maps.google.com/?q=${encodeURIComponent(l.adresse)}`}
-                  target="_blank"
-                  rel="noreferrer"
+                  placeId={row.id}
+                  contactType="google_maps"
                   className="mt-6 inline-flex h-11 w-full items-center justify-center gap-2 rounded-full border border-or/40 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-or hover:bg-blanc"
                 >
                   Ouvrir dans Maps
                   <span className="text-or" aria-hidden="true">
                     →
                   </span>
-                </a>
+                </PlaceContactLink>
                 <div className="mt-3 flex flex-col gap-3">
                   <FavoriteButton
+                    itemType="lieu"
+                    itemId={row.id}
                     label="Sauvegarder"
                     labelActive="Sauvegardé"
                     variant="primary"

--- a/components/v2/FavoriteButton.tsx
+++ b/components/v2/FavoriteButton.tsx
@@ -1,22 +1,90 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
+import {
+  addFavori,
+  isFavori,
+  removeFavori,
+} from '@/lib/supabase/queries/favoris'
+import type { FavoriType } from '@/lib/supabase/types'
 
 interface FavoriteButtonProps {
+  /** Quel type d'item est sauvegardé (mig 05 + mig 16) :
+   *  'prestataire' | 'lieu' | 'evenement' | 'recommendation'.
+   *  Pour PR-B1 on utilise les 3 premiers (les recos sont gérées
+   *  ailleurs via le système gamification copine). */
+  itemType: FavoriType
+  /** UUID de l'item sauvegardé (places.id, profiles.id, events.id). */
+  itemId: string
   label?: string
   labelActive?: string
   variant?: 'primary' | 'ghost'
   size?: 'md' | 'sm'
 }
 
+/**
+ * Bouton ♡/♥ qui persiste dans la table `favoris` (mig 05) — wired
+ * polymorphique pour les 3 itemTypes (prestataire / lieu / evenement).
+ *
+ * Avant PR-B1 ce composant était un stub local-state qui n'écrivait
+ * jamais en BDD → la table `favoris` n'a JAMAIS reçu d'INSERT en prod
+ * (vérifié par grep exhaustif). Le wire fix simultanément les saves
+ * sur les 3 produits + fait revivre la page /dashboard/utilisatrice/favoris.
+ *
+ * Source de vérité : lib/supabase/queries/favoris.ts (helpers
+ * `addFavori`, `removeFavori`, `isFavori`). RLS owner-only — un user
+ * non authentifié verra son clic échouer silencieusement (le bouton
+ * est rendu sur des pages déjà gated par redirect /auth/signup).
+ */
 export function FavoriteButton({
+  itemType,
+  itemId,
   label = 'Ajouter à mes favoris',
   labelActive = 'Dans tes favoris',
   variant = 'ghost',
   size = 'md',
 }: FavoriteButtonProps) {
   const [saved, setSaved] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [pending, setPending] = useState(false)
+
+  // Lecture initiale de l'état (existe-t-il déjà un favori pour cet item ?).
+  // Fail silencieux : si erreur réseau, on assume "pas favori" et on
+  // laisse l'utilisatrice toggler manuellement.
+  useEffect(() => {
+    let cancelled = false
+    isFavori(itemType, itemId)
+      .then((result) => {
+        if (!cancelled) setSaved(result)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [itemType, itemId])
+
+  const handleToggle = async () => {
+    if (loading || pending) return
+    setPending(true)
+
+    // Optimistic toggle
+    const previous = saved
+    const next = !previous
+    setSaved(next)
+
+    const op = next
+      ? await addFavori(itemType, itemId)
+      : await removeFavori(itemType, itemId)
+
+    if (op.error) {
+      // Revert
+      setSaved(previous)
+    }
+    setPending(false)
+  }
 
   const base =
     size === 'sm'
@@ -35,9 +103,11 @@ export function FavoriteButton({
   return (
     <button
       type="button"
-      onClick={() => setSaved((s) => !s)}
-      className={`group inline-flex items-center gap-2.5 rounded-full font-medium tracking-[0.22em] uppercase transition-all duration-300 ${base} ${styles}`}
+      onClick={handleToggle}
+      disabled={loading || pending}
+      className={`group inline-flex items-center gap-2.5 rounded-full font-medium tracking-[0.22em] uppercase transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-60 ${base} ${styles}`}
       aria-pressed={saved}
+      aria-busy={pending || loading}
     >
       <AnimatePresence mode="wait" initial={false}>
         <motion.span

--- a/components/v2/PlaceContactLink.tsx
+++ b/components/v2/PlaceContactLink.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import type { PlaceContactType } from '@/lib/tracking'
+
+interface Props {
+  /** URL de destination du clic (ex. https://maps.google.com/?q=…). */
+  href: string
+  /** UUID du lieu pour le tracking. Si null, le clic n'est pas tracké
+   *  (mode preview / mock). */
+  placeId: string | null
+  /** Canal cliqué — doit matcher un slug PLACE_CONTACT_TYPES (mig 41). */
+  contactType: PlaceContactType
+  /** Cible externe (target=_blank) ou interne. */
+  isExternal?: boolean
+  className?: string
+  ariaLabel?: string
+  children: ReactNode
+}
+
+/**
+ * Wrapper client autour d'un <a> sur la fiche lieu publique. Lance un POST
+ * /api/track/place-contact en pré-clic (fire-and-forget) puis laisse le
+ * navigateur suivre le lien normalement.
+ *
+ * Mirror de <SocialChannelLink /> côté prestataires.
+ *
+ * Si placeId est null (mode preview / mock), on skip le tracking.
+ */
+export function PlaceContactLink({
+  href,
+  placeId,
+  contactType,
+  isExternal = true,
+  className,
+  ariaLabel,
+  children,
+}: Props) {
+  const handleClick = () => {
+    if (!placeId) return
+
+    fetch('/api/track/place-contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        place_id: placeId,
+        contact_type: contactType,
+      }),
+      keepalive: true,
+    }).catch(() => {
+      // Silencieux : le tracking ne doit jamais bloquer un clic.
+    })
+  }
+
+  return (
+    <a
+      href={href}
+      onClick={handleClick}
+      target={isExternal ? '_blank' : undefined}
+      rel={isExternal ? 'noopener noreferrer' : undefined}
+      className={className}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </a>
+  )
+}

--- a/components/v2/TrackPlaceView.tsx
+++ b/components/v2/TrackPlaceView.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useEffect } from 'react'
+
+interface Props {
+  placeId: string
+}
+
+/**
+ * Composant invisible qui POST /api/track/place-view une seule fois par
+ * session navigateur et par placeId (debounce via sessionStorage).
+ *
+ * Mirror de <TrackPageView /> côté prestataires.
+ *
+ * sessionStorage est volontaire :
+ *  - reset à la fermeture du tab → un retour le lendemain compte comme une
+ *    nouvelle vue (utile pour les analytics)
+ *  - 5 onglets ouverts en parallèle = 1 vue (pas du spam)
+ *
+ * keepalive: true permet d'envoyer la requête même si la page est fermée
+ * juste après (≈ navigator.sendBeacon mais avec headers JSON).
+ */
+export function TrackPlaceView({ placeId }: Props) {
+  useEffect(() => {
+    if (!placeId) return
+    if (typeof window === 'undefined') return
+
+    const key = `hilmy_place_view_${placeId}`
+    if (sessionStorage.getItem(key)) return
+
+    sessionStorage.setItem(key, String(Date.now()))
+
+    fetch('/api/track/place-view', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ place_id: placeId }),
+      keepalive: true,
+    }).catch(() => {
+      // Silencieux : le tracking ne doit jamais casser la nav.
+    })
+  }, [placeId])
+
+  return null
+}

--- a/lib/supabase/queries/favoris.ts
+++ b/lib/supabase/queries/favoris.ts
@@ -2,34 +2,18 @@
  * Queries favoris (table polymorphique : type_item = prestataire | lieu | evenement).
  * RLS owner-only — auth.uid() est injecté automatiquement par Supabase.
  * Toutes les ops échouent si l'utilisatrice n'est pas connectée.
+ *
+ * ⚠️ Ce module est CÔTÉ CLIENT uniquement (importé par <FavoriteButton />,
+ * un Client Component). Ne PAS y ajouter d'import server-side
+ * (`@/lib/supabase/server` casse le bundle client à cause de `next/headers`).
+ * Si on a besoin d'helpers favoris côté server plus tard, les mettre dans
+ * un fichier séparé `favoris-server.ts`.
  */
 
 import { createClient as createClientBrowser } from "@/lib/supabase/client";
-import { createClient as createClientServer } from "@/lib/supabase/server";
 import type { Favori, FavoriType, QueryResult } from "@/lib/supabase/types";
 
 const FAVORI_SELECT = `id, user_id, type_item, item_id, note_perso, created_at`;
-
-/**
- * Récupère les favoris de l'utilisatrice connectée (tous types confondus).
- * Utilisé côté server (dashboard).
- */
-export async function getFavorisForCurrentUser(): Promise<
-  QueryResult<Favori[]>
-> {
-  try {
-    const supabase = await createClientServer();
-    const { data, error } = await supabase
-      .from("favoris")
-      .select(FAVORI_SELECT)
-      .order("created_at", { ascending: false });
-
-    if (error) return { data: null, error: error.message };
-    return { data: (data ?? []) as unknown as Favori[], error: null };
-  } catch (err) {
-    return { data: null, error: errorMessage(err) };
-  }
-}
 
 /** Ajoute un favori côté client (depuis un bouton cœur). */
 export async function addFavori(

--- a/lib/tracking.ts
+++ b/lib/tracking.ts
@@ -53,7 +53,8 @@ export function isValidUuid(s: unknown): s is string {
   return typeof s === 'string' && UUID_REGEX.test(s)
 }
 
-/** Whitelist des contact_type acceptés (CHECK constraint côté DB). */
+/** Whitelist des contact_type acceptés (CHECK constraint côté DB,
+ *  table `profile_contacts`, mig 15). */
 export const CONTACT_TYPES = [
   'whatsapp',
   'phone',
@@ -70,4 +71,29 @@ export type ContactType = (typeof CONTACT_TYPES)[number]
 
 export function isValidContactType(s: unknown): s is ContactType {
   return typeof s === 'string' && (CONTACT_TYPES as readonly string[]).includes(s)
+}
+
+/** Whitelist des contact_type acceptés pour la table `place_contacts`
+ *  (CHECK constraint mig 41). Différent de CONTACT_TYPES :
+ *   - pas de 'linkedin' (un café n'a pas de LinkedIn)
+ *   - + 'google_maps' (canal natif des fiches places). */
+export const PLACE_CONTACT_TYPES = [
+  'phone',
+  'website',
+  'email',
+  'instagram',
+  'tiktok',
+  'facebook',
+  'youtube',
+  'google_maps',
+  'whatsapp',
+] as const
+
+export type PlaceContactType = (typeof PLACE_CONTACT_TYPES)[number]
+
+export function isValidPlaceContactType(s: unknown): s is PlaceContactType {
+  return (
+    typeof s === 'string' &&
+    (PLACE_CONTACT_TYPES as readonly string[]).includes(s)
+  )
 }


### PR DESCRIPTION
**PR-B1 of Phase 2A** · option **B (data first)** — adds the data collection layer for Sélection Hilmy lieux **AND** fixes a silent regression on FavoriteButton that affected all 3 products since launch.

## Symptôme

Deux symptômes en un :

### A. Sélection Hilmy lieux n'a pas de tracking

Migration 41 (PR-A) a créé les tables `place_views` et `place_contacts`, mais aucun client ne les écrit. Tant qu'on ne pose pas l'instrumentation, le dashboard owner lieu de PR-B2 affichera des compteurs à 0 même sur les fiches en `palier='selection_hilmy'`.

### B. FavoriteButton n'a JAMAIS persisté en prod (silent bug, depuis launch ~avril 2026)

Vérifié par grep exhaustif : la table `favoris` n'a reçu **0 INSERT** dans tout le codebase. Aucun call site sur `addFavori()`, `removeFavori()`, `isFavori()` (helpers existants dans `lib/supabase/queries/favoris.ts`). Le composant `<FavoriteButton />` est un pur stub local-state qui toggle un `useState(saved)` sans rien persister.

Conséquences silencieuses en prod :
- Le bouton ♡ donne l'impression de marcher (l'icône change) mais le favori disparaît au refresh
- Les 3 paliers prestataires et la page Sélection Hilmy auront tous des compteurs "saves" à 0
- La page [/dashboard/utilisatrice/favoris](app/dashboard/utilisatrice/favoris/page.tsx) montre une liste vide systématique pour TOUS les utilisateurs depuis le launch

## Root cause

A. **Tracking lieu** : la migration 41 a posé les tables, mais l'app n'a jamais eu le mirror de `<TrackPageView />` / `<SocialChannelLink />` côté lieux. Pure infra manquante.

B. **FavoriteButton stub** : le composant a été shipé en stub local-state pendant le sprint launch et personne n'a wiré l'integration Supabase. Les helpers `addFavori`/`removeFavori`/`isFavori` ont été écrits mais jamais branchés. Bug latent depuis le launch initial.

## Fix

### 1. Tracking infra place (mirror prestataires mig 15)

| Fichier | Lignes | Rôle |
|---|---|---|
| `app/api/track/place-view/route.ts` | 82 | INSERT `place_views`, rate-limit 60/min/IP, service-role bypass RLS, mirror `track/view` |
| `app/api/track/place-contact/route.ts` | 91 | INSERT `place_contacts`, rate-limit 30/min/IP, valide via `PLACE_CONTACT_TYPES` |
| `components/v2/TrackPlaceView.tsx` | 44 | Client component invisible, sessionStorage debounce 1/session/place, `keepalive: true` |
| `components/v2/PlaceContactLink.tsx` | 67 | `<a>` wrapper pré-clic POST `/api/track/place-contact` |
| `lib/tracking.ts` | +28 | `PLACE_CONTACT_TYPES` (9 canaux dont `google_maps`, distinct de `CONTACT_TYPES` qui a `linkedin` à la place) |

**Tracking universel** : toutes les places sont trackées peu importe leur palier. Le gating `palier='selection_hilmy'` se fera côté dashboard owner (PR-B2) au moment de **lire** les stats. Cohérent avec le pattern profile_views/profile_contacts (mig 15).

### 2. FavoriteButton wired polymorphique

[components/v2/FavoriteButton.tsx](components/v2/FavoriteButton.tsx) refait :
- Props **requises** `itemType: FavoriType` + `itemId: string` (TS empêche tout call site non-wired de compiler)
- `useEffect` initial appelle `isFavori()` pour récupérer l'état persistant
- `onClick` : optimistic toggle → `addFavori()` ou `removeFavori()` → revert en cas d'erreur
- Loading state pendant le fetch initial (disabled + opacity-60)
- `aria-pressed` + `aria-busy` correctement gérés

Polymorphique sur les 3 itemTypes. Wiring sur les 3 call sites :

| Page | itemType | itemId |
|---|---|---|
| `/prestataire-v2/[slug]` | `prestataire` | `finalRow!.id` |
| `/recommandation/[slug]` | `lieu` | `row.id` |
| `/evenement-v2/[slug]` | `evenement` | `ev.id` |

### 3. Intégration sur fiche lieu publique

[app/recommandation/[slug]/page.tsx](app/recommandation/[slug]/page.tsx) :
- `<TrackPlaceView placeId={row.id} />` monté en haut (debounce sessionStorage)
- "Ouvrir dans Maps" wrappé dans `<PlaceContactLink contactType="google_maps">` (le seul canal contact rendu sur la fiche aujourd'hui)
- `<FavoriteButton itemType="lieu" itemId={row.id} />` wired

## Bonus produit (effet de bord du fix B)

- **Saves prestataires deviennent réels** — Premium / Cercle Pro qui regardent leur dashboard verront des chiffres au lieu de 0 (PR-B2 + tout futur dashboard prestataire utilisera `count(favoris) WHERE type_item='prestataire'`)
- **Saves événements deviennent réels** — pas vendu commercialement aujourd'hui mais utile au comptage interne
- **Page `/dashboard/utilisatrice/favoris` se remplit** — silently broken depuis avril 2026, recommencera à montrer les vrais favoris des utilisatrices

## Aucun double-comptage avec gamif

Trigger `gamif_award_save_points` (mig 16) filtre `WHERE type_item='recommendation'` dès la 1ère ligne — les saves de prestataire/lieu/evenement ne déclenchent **aucun** point award. Vérifié dans [supabase/migrations/16_gamification_sprint1.sql](supabase/migrations/16_gamification_sprint1.sql).

## Cleanup incident

`lib/supabase/queries/favoris.ts` :
- Supprimé `getFavorisForCurrentUser()` (0 callers, code mort qui forçait l'import server `next/headers` et cassait le bundle client de FavoriteButton)
- Ajout d'un commentaire d'avertissement : ce module est **client-only**

## Tests manuels à valider sur Vercel preview

- [ ] Visite `/recommandation/[slug]` connectée → 1 row INSERT dans `place_views` (vérifier via Supabase SQL Editor : `SELECT count(*) FROM place_views WHERE place_id='...'`)
- [ ] Refresh la même page dans le même tab → pas de 2e INSERT (sessionStorage debounce)
- [ ] Clique "Ouvrir dans Maps" → 1 row INSERT dans `place_contacts` avec `contact_type='google_maps'`
- [ ] Clique ♡ sur fiche lieu → 1 row INSERT dans `favoris` (type_item='lieu', item_id=place id), bouton passe à ♥
- [ ] Reclique → DELETE row, bouton revient à ♡
- [ ] Refresh → état persisté (♥ si toujours en favori)
- [ ] Clique ♡ sur fiche prestataire → row INSERT type_item='prestataire'
- [ ] Clique ♡ sur fiche événement → row INSERT type_item='evenement'
- [ ] Va sur `/dashboard/utilisatrice/favoris` → liste contient les 3 favoris ajoutés

## Risques

- **Faible.** Tracking universel = pas d'impact perf significatif (60req/min/IP rate-limit). RLS des nouvelles tables déjà testée en PR-A.
- **Aucun changement BDD.** Tout consomme la migration 41 déjà appliquée.
- **Type-safety** : tout call site FavoriteButton qui omettrait `itemType`/`itemId` casse le build. Pas de régression silencieuse possible.

## Sécurité

- ✅ Rate-limit sur les 2 nouvelles API routes (60/min sur view, 30/min sur contact, mirror prestataires)
- ✅ Validation UUID stricte côté API (`isValidUuid`) + whitelist contact_type
- ✅ `keepalive: true` côté client = pas de bloquage si la page se ferme
- ✅ Tracking n'expose aucune PII (viewer_id NULL pour anon, user_agent_hash sha256)
- ✅ Pattern admin-bypass-RLS via service-role aligné sur l'existant (pas de nouveau pattern)
- ✅ Pas de `service_role` côté client

## Refs

- Audit complet : `audit-features-tarifs.md` (P0)
- Brief Phase 2A — sprint Sélection Hilmy lieux, option B data-first
- PR-A : #77 (migration 41 — appliquée en prod 2026-05-09 09:36 UTC)
- Helpers favoris : [lib/supabase/queries/favoris.ts](lib/supabase/queries/favoris.ts) (existants depuis Stage 4, jamais appelés avant cette PR)

## Stop next

PR-B1 mergée + déploiement vert → on attend 1-3 jours de data tracking puis on enchaîne **PR-B2** (dashboard owner lieu, lecture des stats collectées).