### PR TITLE
feat(lieux): dashboard owner with stats reading (Sélection Hilmy gated)

### DIFF
--- a/app/dashboard/lieu/[placeId]/page.tsx
+++ b/app/dashboard/lieu/[placeId]/page.tsx
@@ -1,0 +1,464 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
+import { StatCard } from '@/components/dashboard/StatCard'
+import { EmptyState } from '@/components/dashboard/EmptyState'
+import { VuesAreaChart } from '@/components/dashboard/Charts'
+import { GoldLine } from '@/components/ui/GoldLine'
+import { PastilleSelectionHilmy } from '@/components/v2/PastilleSelectionHilmy'
+import { requireUser } from '@/lib/supabase/session'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { getOwnedPlaceById } from '@/lib/supabase/queries/places'
+import { isSelectionHilmy } from '@/lib/permissions-lieux'
+
+const SINCE_7D_MS = 7 * 86_400_000
+const SINCE_30D_MS = 30 * 86_400_000
+
+/**
+ * Labels FR humains pour les contact_type stockés dans place_contacts
+ * (CHECK constraint mig 41 — 9 valeurs). Évite d'afficher "google_maps"
+ * brut dans le tableau tap-to-contact.
+ */
+const CONTACT_LABELS: Record<string, string> = {
+  phone: 'Téléphone',
+  website: 'Site web',
+  email: 'Email',
+  instagram: 'Instagram',
+  tiktok: 'TikTok',
+  facebook: 'Facebook',
+  youtube: 'YouTube',
+  google_maps: 'Google Maps',
+  whatsapp: 'WhatsApp',
+}
+
+type ContactRow = {
+  channel: string
+  label: string
+  last7: number
+  last30: number
+  total: number
+}
+
+/**
+ * Construit la série [{jour: 'DD/MM', vues: n}] pour les 30 derniers
+ * jours, avec 0 pour les jours sans donnée. Aligné sur le helper
+ * équivalent du dashboard prestataire (app/dashboard/prestataire/page.tsx).
+ */
+function buildVues30jSeries(rows: { viewed_at: string }[]) {
+  const buckets: Record<string, number> = {}
+  for (let i = 29; i >= 0; i--) {
+    const d = new Date()
+    d.setHours(0, 0, 0, 0)
+    d.setDate(d.getDate() - i)
+    const key = d.toISOString().slice(0, 10)
+    buckets[key] = 0
+  }
+  for (const row of rows) {
+    const key = row.viewed_at.slice(0, 10)
+    if (key in buckets) buckets[key]++
+  }
+  return Object.entries(buckets).map(([key, vues]) => {
+    const [, mm, dd] = key.split('-')
+    return { jour: `${dd}/${mm}`, vues }
+  })
+}
+
+/**
+ * Dashboard owner lieu — page détail d'un lieu (Phase 2A · PR-B2).
+ *
+ * Gating produit :
+ *   - palier='aucun'           → bloc upsell, pas de stats affichées
+ *   - palier='selection_hilmy' → 3 sections stats (vues, saves, contacts)
+ *
+ * Sécurité : `getOwnedPlaceById` filtre `created_by_user_id = auth.uid()`,
+ * retourne null silencieusement si l'utilisatrice n'est pas owner — on
+ * redirect vers la liste sans révéler l'existence du lieu (403-style).
+ *
+ * RLS :
+ *   - place_views, place_contacts : owner-read via mig 41 → client standard OK
+ *   - favoris : RLS owner-only sur user_id (mig 05) → l'owner du LIEU ne
+ *     peut pas lire les favoris des AUTRES users via client standard. On
+ *     utilise admin client (service-role) pour la query agrégée saves.
+ *     Justifié : agrégat sans PII, server component only, pattern aligné
+ *     sur les API routes de tracking.
+ */
+export default async function LieuDetailPage({
+  params,
+}: {
+  params: Promise<{ placeId: string }>
+}) {
+  const { placeId } = await params
+  const user = await requireUser()
+
+  const { data: place } = await getOwnedPlaceById(user.id, placeId)
+  if (!place) {
+    // Soit le lieu n'existe pas, soit l'utilisatrice n'est pas owner.
+    // Redirect silencieux vers la liste — on ne révèle pas la cause.
+    redirect('/dashboard/lieu')
+  }
+
+  // Best-effort prénom pour le header (fallback "toi").
+  const supabase = await createClient()
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('prenom')
+    .eq('user_id', user.id)
+    .maybeSingle()
+  const prenom = (profile?.prenom as string | undefined) ?? 'Toi'
+
+  const isSelection = isSelectionHilmy(place)
+
+  const headerActions = (
+    <div className="flex flex-wrap items-center gap-3">
+      {isSelection && <PastilleSelectionHilmy />}
+      {place.slug && (
+        <Link
+          href={`/recommandation/${place.slug}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group inline-flex h-11 items-center gap-2 rounded-full border border-or/40 px-5 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-or hover:bg-blanc"
+        >
+          Voir ma fiche publique
+          <span
+            className="text-or transition-transform group-hover:translate-x-1"
+            aria-hidden="true"
+          >
+            →
+          </span>
+        </Link>
+      )}
+    </div>
+  )
+
+  // ─── Cas 1 : palier='aucun' → upsell, pas de stats ────────────────
+  if (!isSelection) {
+    return (
+      <>
+        <DashboardHeader
+          kicker={`Bonjour, ${prenom}`}
+          titre={
+            <>
+              Tu gères{' '}
+              <em className="font-serif italic text-or">{place.name}</em>
+            </>
+          }
+          lead={`${place.city ?? '—'}. Pour débloquer les stats et la mise en avant, passe en Sélection Hilmy.`}
+          actions={headerActions}
+        />
+        <section className="px-6 py-12 md:px-12 md:py-16">
+          <div className="rounded-sm bg-vert p-8 text-creme md:p-12">
+            <div className="flex items-center gap-4">
+              <GoldLine width={40} />
+              <span className="overline text-or">Passe en Sélection Hilmy</span>
+            </div>
+            <h2 className="mt-5 font-serif text-[clamp(1.75rem,3.5vw,2.5rem)] font-light leading-[1.1] text-creme">
+              Donne à <em className="italic text-or">{place.name}</em> sa
+              place dans le carnet des copines.
+            </h2>
+            <p className="mt-5 max-w-2xl text-[14px] leading-[1.7] text-creme/85">
+              Sélection Hilmy, c&apos;est la formule pour les lieux qu&apos;on
+              veut mettre en avant entre nous : un café-cocooning, un brunch
+              du dimanche, une boutique-pépite. Tu gardes ta fiche dans
+              l&apos;annuaire — Sélection Hilmy ajoute le reste.
+            </p>
+            <ul className="mt-8 grid gap-3 text-[14px] leading-[1.55] md:grid-cols-2">
+              {[
+                'Pastille Sélection Hilmy sur la fiche publique',
+                'Mise en avant dans le feed des recommandations',
+                'Stats vues + saves + tap-to-contact tracé',
+                'Photos illimitées sur ta galerie',
+                'Auto-mise-en-avant quand tu publies un événement',
+                'Support prioritaire de la team',
+              ].map((feature) => (
+                <li key={feature} className="flex items-start gap-3">
+                  <span
+                    className="mt-[7px] h-1 w-1 shrink-0 rounded-full bg-or"
+                    aria-hidden="true"
+                  />
+                  <span className="text-creme/90">{feature}</span>
+                </li>
+              ))}
+            </ul>
+            <div className="mt-10 flex flex-wrap items-baseline gap-3">
+              <span className="font-serif text-[44px] font-light leading-none text-or md:text-[52px]">
+                39€
+              </span>
+              <span className="text-sm text-creme/70">/ mois</span>
+              <span className="text-[12px] italic text-creme/55">
+                · sans engagement, résiliable à tout moment
+              </span>
+            </div>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link
+                href="/tarifs#selection-hilmy"
+                className="inline-flex h-12 items-center gap-2 rounded-full bg-or px-7 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:bg-or-light"
+              >
+                Passer Sélection Hilmy
+                <span aria-hidden="true">→</span>
+              </Link>
+              <Link
+                href="/tarifs"
+                className="inline-flex h-12 items-center gap-2 rounded-full border border-or/40 px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:border-or hover:text-or-light"
+              >
+                Voir les détails
+              </Link>
+            </div>
+          </div>
+        </section>
+      </>
+    )
+  }
+
+  // ─── Cas 2 : palier='selection_hilmy' → stats ─────────────────────
+  const since7d = new Date(Date.now() - SINCE_7D_MS).toISOString()
+  const since30d = new Date(Date.now() - SINCE_30D_MS).toISOString()
+
+  // place_views : owner-read RLS OK via client standard.
+  // place_contacts : owner-read RLS OK via client standard.
+  // favoris : RLS owner-only user_id → admin client pour count agrégé
+  // (justification cf header comment).
+  const admin = createAdminClient()
+
+  const [
+    views7Res,
+    views30Rows,
+    contactsRes,
+    saves7Res,
+    saves30Res,
+    savesTotalRes,
+  ] = await Promise.all([
+    supabase
+      .from('place_views')
+      .select('id', { count: 'exact', head: true })
+      .eq('place_id', place.id)
+      .gte('viewed_at', since7d),
+    supabase
+      .from('place_views')
+      .select('viewed_at')
+      .eq('place_id', place.id)
+      .gte('viewed_at', since30d)
+      .order('viewed_at', { ascending: true }),
+    supabase
+      .from('place_contacts')
+      .select('contact_type, clicked_at')
+      .eq('place_id', place.id),
+    admin
+      .from('favoris')
+      .select('id', { count: 'exact', head: true })
+      .eq('type_item', 'lieu')
+      .eq('item_id', place.id)
+      .gte('created_at', since7d),
+    admin
+      .from('favoris')
+      .select('id', { count: 'exact', head: true })
+      .eq('type_item', 'lieu')
+      .eq('item_id', place.id)
+      .gte('created_at', since30d),
+    admin
+      .from('favoris')
+      .select('id', { count: 'exact', head: true })
+      .eq('type_item', 'lieu')
+      .eq('item_id', place.id),
+  ])
+
+  const viewsTotal = place.nb_vues ?? 0
+  const views7d = views7Res.count ?? 0
+  const views30dRows = (views30Rows.data ?? []) as { viewed_at: string }[]
+  const views30d = views30dRows.length
+  const series = buildVues30jSeries(views30dRows)
+
+  const saves7d = saves7Res.count ?? 0
+  const saves30d = saves30Res.count ?? 0
+  const savesTotal = savesTotalRes.count ?? 0
+
+  // Tap-to-contact : agrégation par canal sur 7j/30j/total.
+  type ClickRow = { contact_type: string; clicked_at: string }
+  const clicks = (contactsRes.data ?? []) as ClickRow[]
+  const now7 = Date.now() - SINCE_7D_MS
+  const now30 = Date.now() - SINCE_30D_MS
+  const byChannel: Map<string, ContactRow> = new Map()
+  for (const c of clicks) {
+    const ts = new Date(c.clicked_at).getTime()
+    const row =
+      byChannel.get(c.contact_type) ??
+      {
+        channel: c.contact_type,
+        label: CONTACT_LABELS[c.contact_type] ?? c.contact_type,
+        last7: 0,
+        last30: 0,
+        total: 0,
+      }
+    row.total++
+    if (ts >= now30) row.last30++
+    if (ts >= now7) row.last7++
+    byChannel.set(c.contact_type, row)
+  }
+  const contactRows = Array.from(byChannel.values()).sort(
+    (a, b) => b.total - a.total,
+  )
+
+  return (
+    <>
+      <DashboardHeader
+        kicker={`Bonjour, ${prenom}`}
+        titre={
+          <>
+            Tu gères{' '}
+            <em className="font-serif italic text-or">{place.name}</em>
+          </>
+        }
+        lead={`${place.city ?? '—'}. Voici tes chiffres en direct.`}
+        actions={headerActions}
+      />
+
+      {/* Section 1 — Stats vues */}
+      <section className="px-6 py-10 md:px-12 md:py-14">
+        <div className="mb-8 flex items-center gap-4">
+          <GoldLine width={40} />
+          <span className="overline text-or">Mes vues</span>
+        </div>
+        <div className="grid gap-4 md:grid-cols-3">
+          <StatCard
+            kicker="Total"
+            value={viewsTotal.toLocaleString('fr-FR')}
+            hint="Depuis la création de ta fiche"
+            index={0}
+          />
+          <StatCard
+            kicker="7 derniers jours"
+            value={views7d.toLocaleString('fr-FR')}
+            hint="Sur la dernière semaine"
+            variant="or"
+            index={1}
+          />
+          <StatCard
+            kicker="30 derniers jours"
+            value={views30d.toLocaleString('fr-FR')}
+            hint="Sur le dernier mois"
+            variant="vert"
+            index={2}
+          />
+        </div>
+
+        {views30d >= 5 && (
+          <div className="mt-8 rounded-sm border border-or/15 bg-creme-soft p-6 md:p-8">
+            <div className="mb-6 flex items-start justify-between gap-4">
+              <div>
+                <p className="overline text-or">Évolution sur 30 jours</p>
+                <h2 className="mt-2 font-serif text-2xl font-light text-vert">
+                  Quand on regarde ta fiche.
+                </h2>
+                <p className="mt-1 text-[11px] italic text-texte-sec">
+                  Données réelles agrégées par jour.
+                </p>
+              </div>
+              <span className="font-serif text-xl italic text-or">
+                ↗ {views30d}
+              </span>
+            </div>
+            <VuesAreaChart data={series} />
+          </div>
+        )}
+      </section>
+
+      {/* Section 2 — Stats saves */}
+      <section className="bg-blanc px-6 py-10 md:px-12 md:py-14">
+        <div className="mb-8 flex items-center gap-4">
+          <GoldLine width={40} />
+          <span className="overline text-or">Mes saves</span>
+        </div>
+        <div className="grid gap-4 md:grid-cols-3">
+          <StatCard
+            kicker="Total saves"
+            value={savesTotal.toLocaleString('fr-FR')}
+            hint="Copines qui ont sauvegardé"
+            index={0}
+          />
+          <StatCard
+            kicker="7 derniers jours"
+            value={saves7d.toLocaleString('fr-FR')}
+            hint="Saves cette semaine"
+            variant="or"
+            index={1}
+          />
+          <StatCard
+            kicker="30 derniers jours"
+            value={saves30d.toLocaleString('fr-FR')}
+            hint="Saves ce mois"
+            variant="vert"
+            index={2}
+          />
+        </div>
+      </section>
+
+      {/* Section 3 — Tap-to-contact tracé */}
+      <section className="px-6 py-10 md:px-12 md:py-14">
+        <div className="mb-8 flex items-center gap-4">
+          <GoldLine width={40} />
+          <span className="overline text-or">Tap-to-contact tracé</span>
+        </div>
+
+        {contactRows.length === 0 ? (
+          <EmptyState
+            kicker="En attente"
+            titre="Aucun clic sur tes canaux contact pour le moment."
+            pitch="Dès qu'une copine clique sur un de tes canaux (Maps, téléphone, site web, Insta…) depuis ta fiche publique, le clic apparaîtra ici. Patience — la collecte démarre dès que les copines arrivent."
+          />
+        ) : (
+          <div className="overflow-hidden rounded-sm border border-or/15 bg-blanc">
+            <table className="w-full">
+              <thead className="border-b border-or/10 bg-creme-soft">
+                <tr>
+                  <th className="px-4 py-3 text-left text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
+                    Canal
+                  </th>
+                  <th className="px-4 py-3 text-right text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
+                    7 jours
+                  </th>
+                  <th className="px-4 py-3 text-right text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
+                    30 jours
+                  </th>
+                  <th className="px-4 py-3 text-right text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
+                    Total
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {contactRows.map((row, i) => (
+                  <tr
+                    key={row.channel}
+                    className={
+                      i === contactRows.length - 1
+                        ? ''
+                        : 'border-b border-or/10'
+                    }
+                  >
+                    <td className="px-4 py-4 text-[14px] font-medium text-vert md:px-6">
+                      {row.label}
+                    </td>
+                    <td className="px-4 py-4 text-right text-[14px] text-texte md:px-6">
+                      {row.last7.toLocaleString('fr-FR')}
+                    </td>
+                    <td className="px-4 py-4 text-right text-[14px] text-texte md:px-6">
+                      {row.last30.toLocaleString('fr-FR')}
+                    </td>
+                    <td className="px-4 py-4 text-right font-serif text-[15px] italic text-or-deep md:px-6">
+                      {row.total.toLocaleString('fr-FR')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        <p className="mt-6 text-[11px] italic text-texte-sec">
+          Les clics sont trackés depuis le déploiement de PR-B1
+          (2026-05-09). Les fiches plus anciennes peuvent avoir reçu des
+          clics non comptabilisés avant cette date.
+        </p>
+      </section>
+    </>
+  )
+}

--- a/app/dashboard/lieu/[placeId]/page.tsx
+++ b/app/dashboard/lieu/[placeId]/page.tsx
@@ -16,24 +16,26 @@ const SINCE_7D_MS = 7 * 86_400_000
 const SINCE_30D_MS = 30 * 86_400_000
 
 /**
- * Labels FR humains pour les contact_type stockés dans place_contacts
- * (CHECK constraint mig 41 — 9 valeurs). Évite d'afficher "google_maps"
- * brut dans le tableau tap-to-contact.
+ * Labels FR voix Sara pour les 9 canaux place_contacts (CHECK mig 41).
+ * Reformulés en récit émotionnel : "ce que les copines ont voulu faire"
+ * plutôt que le nom technique du canal. Emoji volontaire (cf brief
+ * reframe UX 2026-05-09 — exception aux brand rules sur emoji UI).
  */
-const CONTACT_LABELS: Record<string, string> = {
-  phone: 'Téléphone',
-  website: 'Site web',
-  email: 'Email',
-  instagram: 'Instagram',
-  tiktok: 'TikTok',
-  facebook: 'Facebook',
-  youtube: 'YouTube',
-  google_maps: 'Google Maps',
-  whatsapp: 'WhatsApp',
+const CONTACT_CHANNEL_COPY: Record<string, { emoji: string; label: string }> = {
+  google_maps: { emoji: '🗺️', label: 'Sont venues te voir (Maps)' },
+  phone: { emoji: '📞', label: "Ont voulu t'appeler" },
+  email: { emoji: '✉️', label: "Ont voulu t'écrire" },
+  instagram: { emoji: '📸', label: 'Ont voulu te suivre sur Insta' },
+  tiktok: { emoji: '🎵', label: 'Ont voulu te suivre sur TikTok' },
+  facebook: { emoji: '👥', label: 'Ont voulu te suivre sur Facebook' },
+  youtube: { emoji: '▶️', label: 'Ont voulu voir tes vidéos' },
+  whatsapp: { emoji: '💬', label: 'Ont voulu te WhatsApper' },
+  website: { emoji: '🌐', label: 'Ont voulu visiter ton site' },
 }
 
 type ContactRow = {
   channel: string
+  emoji: string
   label: string
   last7: number
   last30: number
@@ -272,7 +274,7 @@ export default async function LieuDetailPage({
   const saves30d = saves30Res.count ?? 0
   const savesTotal = savesTotalRes.count ?? 0
 
-  // Tap-to-contact : agrégation par canal sur 7j/30j/total.
+  // Agrégation des clics par canal sur 7j/30j/total.
   type ClickRow = { contact_type: string; clicked_at: string }
   const clicks = (contactsRes.data ?? []) as ClickRow[]
   const now7 = Date.now() - SINCE_7D_MS
@@ -280,11 +282,16 @@ export default async function LieuDetailPage({
   const byChannel: Map<string, ContactRow> = new Map()
   for (const c of clicks) {
     const ts = new Date(c.clicked_at).getTime()
+    const copy = CONTACT_CHANNEL_COPY[c.contact_type] ?? {
+      emoji: '·',
+      label: c.contact_type,
+    }
     const row =
       byChannel.get(c.contact_type) ??
       {
         channel: c.contact_type,
-        label: CONTACT_LABELS[c.contact_type] ?? c.contact_type,
+        emoji: copy.emoji,
+        label: copy.label,
         last7: 0,
         last30: 0,
         total: 0,
@@ -298,165 +305,295 @@ export default async function LieuDetailPage({
     (a, b) => b.total - a.total,
   )
 
+  // ─── Gating "data riche" vs "data jeune/encouragement" ──────────────
+  // Voix Sara : on transforme chaque chiffre en récit. Quand la data
+  // est trop jeune pour raconter une histoire, on bascule sur des
+  // encouragements + actions concrètes plutôt que d'afficher des 0
+  // déprimants. Seuils choisis pour qu'une fiche fraîche tombe en
+  // mode jeune/encouragement et qu'une fiche établie passe en mode riche.
+  const viewsRichMode = viewsTotal >= 10 || views7d >= 3
+  const savesRichMode = savesTotal >= 1
+  const contactsRichMode = clicks.length >= 1
+
+  // Pluralisation simple FR (1 → "nouvelle", N>1 → "nouvelles", etc.)
+  const pluralS = (n: number) => (n > 1 ? 's' : '')
+
   return (
     <>
       <DashboardHeader
-        kicker={`Bonjour, ${prenom}`}
+        kicker={`Ton tableau de bord, ${place.name}`}
         titre={
-          <>
-            Tu gères{' '}
-            <em className="font-serif italic text-or">{place.name}</em>
+          <>Voilà ce que les copines{' '}
+            <em className="font-serif italic text-or">pensent de toi.</em>
           </>
         }
-        lead={`${place.city ?? '—'}. Voici tes chiffres en direct.`}
         actions={headerActions}
       />
 
-      {/* Section 1 — Stats vues */}
+      {/* ─── Section 1 — Les copines te découvrent ─────────────────── */}
       <section className="px-6 py-10 md:px-12 md:py-14">
-        <div className="mb-8 flex items-center gap-4">
-          <GoldLine width={40} />
-          <span className="overline text-or">Mes vues</span>
-        </div>
-        <div className="grid gap-4 md:grid-cols-3">
-          <StatCard
-            kicker="Total"
-            value={viewsTotal.toLocaleString('fr-FR')}
-            hint="Depuis la création de ta fiche"
-            index={0}
-          />
-          <StatCard
-            kicker="7 derniers jours"
-            value={views7d.toLocaleString('fr-FR')}
-            hint="Sur la dernière semaine"
-            variant="or"
-            index={1}
-          />
-          <StatCard
-            kicker="30 derniers jours"
-            value={views30d.toLocaleString('fr-FR')}
-            hint="Sur le dernier mois"
-            variant="vert"
-            index={2}
-          />
-        </div>
-
-        {views30d >= 5 && (
-          <div className="mt-8 rounded-sm border border-or/15 bg-creme-soft p-6 md:p-8">
-            <div className="mb-6 flex items-start justify-between gap-4">
-              <div>
-                <p className="overline text-or">Évolution sur 30 jours</p>
-                <h2 className="mt-2 font-serif text-2xl font-light text-vert">
-                  Quand on regarde ta fiche.
-                </h2>
-                <p className="mt-1 text-[11px] italic text-texte-sec">
-                  Données réelles agrégées par jour.
-                </p>
-              </div>
-              <span className="font-serif text-xl italic text-or">
-                ↗ {views30d}
-              </span>
+        {viewsRichMode ? (
+          <>
+            <div className="mb-8 flex items-center gap-4">
+              <GoldLine width={40} />
+              <span className="overline text-or">Les copines te découvrent</span>
             </div>
-            <VuesAreaChart data={series} />
-          </div>
+            <div className="grid gap-4 md:grid-cols-3">
+              <StatCard
+                kicker="Au total"
+                value={`${viewsTotal.toLocaleString('fr-FR')} copine${pluralS(viewsTotal)}`}
+                hint="se sont arrêtées sur ta fiche"
+                variant="vert"
+                index={0}
+              />
+              <StatCard
+                kicker="Cette semaine"
+                value={`${views7d.toLocaleString('fr-FR')}`}
+                hint="ont voulu te connaître"
+                variant="or"
+                index={1}
+              />
+              <StatCard
+                kicker="Ce mois"
+                value={`${views30d.toLocaleString('fr-FR')} découverte${pluralS(views30d)}`}
+                hint="sur les 30 derniers jours"
+                variant="vert"
+                index={2}
+              />
+            </div>
+
+            {views30d >= 5 && (
+              <div className="mt-8 rounded-sm border border-or/15 bg-creme-soft p-6 md:p-8">
+                <div className="mb-6 flex items-start justify-between gap-4">
+                  <div>
+                    <p className="overline text-or">
+                      Quand on s&apos;arrête sur ta fiche
+                    </p>
+                    <h2 className="mt-2 font-serif text-2xl font-light text-vert">
+                      Les 30 derniers jours en image.
+                    </h2>
+                    <p className="mt-1 text-[12px] italic text-texte-sec">
+                      Chaque pic, c&apos;est une copine qui t&apos;a découverte.
+                    </p>
+                  </div>
+                  <span className="font-serif text-xl italic text-or">
+                    ↗ {views30d}
+                  </span>
+                </div>
+                <VuesAreaChart data={series} />
+              </div>
+            )}
+          </>
+        ) : (
+          <>
+            <div className="mb-6 flex items-center gap-4">
+              <GoldLine width={40} />
+              <span className="overline text-or">Ta fiche est jeune</span>
+            </div>
+            <h2 className="font-serif text-[clamp(1.75rem,3vw,2.25rem)] font-light leading-[1.15] text-vert">
+              Les premières copines{' '}
+              <em className="italic text-or">arrivent.</em>
+            </h2>
+            <p className="mt-4 max-w-xl text-[15px] leading-[1.7] text-texte-sec">
+              Pendant qu&apos;elle prend ses marques, voilà 3 manières de
+              l&apos;aider à briller :
+            </p>
+
+            <ul className="mt-10 grid gap-6 md:grid-cols-3">
+              <li className="rounded-sm border border-or/15 bg-blanc p-6 md:p-7">
+                <span
+                  className="font-serif text-[44px] font-light italic leading-none text-or"
+                  aria-hidden="true"
+                >
+                  01
+                </span>
+                <h3 className="mt-5 font-serif text-lg font-light leading-snug text-vert">
+                  Partage le lien sur ton Insta story
+                </h3>
+                <p className="mt-3 text-[13px] leading-[1.6] text-texte-sec">
+                  La team Hilmy y est très active.
+                </p>
+              </li>
+
+              <li className="rounded-sm border border-or/15 bg-blanc p-6 md:p-7">
+                <span
+                  className="font-serif text-[44px] font-light italic leading-none text-or"
+                  aria-hidden="true"
+                >
+                  02
+                </span>
+                <h3 className="mt-5 font-serif text-lg font-light leading-snug text-vert">
+                  Glisse un QR code chez toi
+                </h3>
+                <p className="mt-3 text-[13px] leading-[1.6] text-texte-sec">
+                  Tes vraies clientes deviennent ambassadrices.
+                </p>
+              </li>
+
+              <li className="rounded-sm border border-or/15 bg-blanc p-6 md:p-7">
+                <span
+                  className="font-serif text-[44px] font-light italic leading-none text-or"
+                  aria-hidden="true"
+                >
+                  03
+                </span>
+                {/* TODO PR-D : remplacer href="#" par /dashboard/lieu/[placeId]/evenements
+                   une fois la sous-route événements lieu créée. */}
+                <Link
+                  href="#"
+                  className="mt-5 block font-serif text-lg font-light leading-snug text-vert hover:text-or"
+                >
+                  Crée un événement saisonnier{' '}
+                  <span className="text-or" aria-hidden="true">→</span>
+                </Link>
+                <p className="mt-3 text-[13px] leading-[1.6] text-texte-sec">
+                  C&apos;est l&apos;auto-boost de la team Hilmy.
+                </p>
+              </li>
+            </ul>
+          </>
         )}
       </section>
 
-      {/* Section 2 — Stats saves */}
+      {/* ─── Section 2 — Elles te gardent précieusement ────────────── */}
       <section className="bg-blanc px-6 py-10 md:px-12 md:py-14">
-        <div className="mb-8 flex items-center gap-4">
-          <GoldLine width={40} />
-          <span className="overline text-or">Mes saves</span>
-        </div>
-        <div className="grid gap-4 md:grid-cols-3">
-          <StatCard
-            kicker="Total saves"
-            value={savesTotal.toLocaleString('fr-FR')}
-            hint="Copines qui ont sauvegardé"
-            index={0}
-          />
-          <StatCard
-            kicker="7 derniers jours"
-            value={saves7d.toLocaleString('fr-FR')}
-            hint="Saves cette semaine"
-            variant="or"
-            index={1}
-          />
-          <StatCard
-            kicker="30 derniers jours"
-            value={saves30d.toLocaleString('fr-FR')}
-            hint="Saves ce mois"
-            variant="vert"
-            index={2}
-          />
-        </div>
+        {savesRichMode ? (
+          <>
+            <div className="mb-6 flex items-center gap-4">
+              <GoldLine width={40} />
+              <span className="overline text-or">
+                Elles te gardent précieusement
+              </span>
+            </div>
+            <h2 className="font-serif text-[clamp(1.75rem,3vw,2.25rem)] font-light leading-[1.15] text-vert">
+              <em className="italic text-or">{savesTotal}</em> copine{pluralS(savesTotal)}{' '}
+              t&apos;ont ajoutée à leur carnet personnel <span aria-hidden="true">❤️</span>
+            </h2>
+            {saves7d >= 1 && (
+              <p className="mt-5 text-[15px] leading-[1.7] text-texte">
+                Cette semaine : <strong className="text-vert">{saves7d} nouvelle{pluralS(saves7d)}</strong>.
+              </p>
+            )}
+            <p className="mt-5 max-w-2xl text-[15px] leading-[1.7] text-texte-sec">
+              Tu fais partie de leurs bonnes adresses, celles qu&apos;on
+              garde et qu&apos;on partage entre nous.
+            </p>
+          </>
+        ) : (
+          <>
+            <div className="mb-6 flex items-center gap-4">
+              <GoldLine width={40} />
+              <span className="overline text-or">Le carnet d&apos;or des copines</span>
+            </div>
+            <h2 className="font-serif text-[clamp(1.75rem,3vw,2.25rem)] font-light leading-[1.15] text-vert">
+              Pour qu&apos;on te garde, on doit{' '}
+              <em className="italic text-or">te connaître.</em>
+            </h2>
+            <p className="mt-4 max-w-2xl text-[15px] leading-[1.7] text-texte-sec">
+              Tes premières fans arrivent — concentre-toi sur ta visibilité
+              d&apos;abord, les saves suivront.
+            </p>
+          </>
+        )}
       </section>
 
-      {/* Section 3 — Tap-to-contact tracé */}
+      {/* ─── Section 3 — Elles ont fait le pas ─────────────────────── */}
       <section className="px-6 py-10 md:px-12 md:py-14">
-        <div className="mb-8 flex items-center gap-4">
+        <div className="mb-6 flex items-center gap-4">
           <GoldLine width={40} />
-          <span className="overline text-or">Tap-to-contact tracé</span>
+          <span className="overline text-or">Elles ont fait le pas</span>
         </div>
 
-        {contactRows.length === 0 ? (
-          <EmptyState
-            kicker="En attente"
-            titre="Aucun clic sur tes canaux contact pour le moment."
-            pitch="Dès qu'une copine clique sur un de tes canaux (Maps, téléphone, site web, Insta…) depuis ta fiche publique, le clic apparaîtra ici. Patience — la collecte démarre dès que les copines arrivent."
-          />
-        ) : (
-          <div className="overflow-hidden rounded-sm border border-or/15 bg-blanc">
-            <table className="w-full">
-              <thead className="border-b border-or/10 bg-creme-soft">
-                <tr>
-                  <th className="px-4 py-3 text-left text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
-                    Canal
-                  </th>
-                  <th className="px-4 py-3 text-right text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
-                    7 jours
-                  </th>
-                  <th className="px-4 py-3 text-right text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
-                    30 jours
-                  </th>
-                  <th className="px-4 py-3 text-right text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
-                    Total
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {contactRows.map((row, i) => (
-                  <tr
-                    key={row.channel}
-                    className={
-                      i === contactRows.length - 1
-                        ? ''
-                        : 'border-b border-or/10'
-                    }
-                  >
-                    <td className="px-4 py-4 text-[14px] font-medium text-vert md:px-6">
-                      {row.label}
-                    </td>
-                    <td className="px-4 py-4 text-right text-[14px] text-texte md:px-6">
-                      {row.last7.toLocaleString('fr-FR')}
-                    </td>
-                    <td className="px-4 py-4 text-right text-[14px] text-texte md:px-6">
-                      {row.last30.toLocaleString('fr-FR')}
-                    </td>
-                    <td className="px-4 py-4 text-right font-serif text-[15px] italic text-or-deep md:px-6">
-                      {row.total.toLocaleString('fr-FR')}
-                    </td>
+        {contactsRichMode ? (
+          <>
+            <h2 className="mb-8 font-serif text-[clamp(1.75rem,3vw,2.25rem)] font-light leading-[1.15] text-vert">
+              <em className="italic text-or">{clicks.length}</em> copine{pluralS(clicks.length)}{' '}
+              {clicks.length > 1 ? 'sont passées' : 'est passée'} de la
+              curiosité à l&apos;action.
+            </h2>
+            <div className="overflow-hidden rounded-sm border border-or/15 bg-blanc">
+              <table className="w-full">
+                <thead className="border-b border-or/10 bg-creme-soft">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
+                      Comment elles t&apos;ont cherchée
+                    </th>
+                    <th className="px-4 py-3 text-right text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
+                      Cette semaine
+                    </th>
+                    <th className="px-4 py-3 text-right text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
+                      Ce mois
+                    </th>
+                    <th className="px-4 py-3 text-right text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
+                      Total
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {contactRows.map((row, i) => (
+                    <tr
+                      key={row.channel}
+                      className={
+                        i === contactRows.length - 1
+                          ? ''
+                          : 'border-b border-or/10'
+                      }
+                    >
+                      <td className="px-4 py-4 md:px-6">
+                        <span className="flex items-center gap-3">
+                          <span
+                            className="text-[18px] leading-none"
+                            aria-hidden="true"
+                          >
+                            {row.emoji}
+                          </span>
+                          <span className="text-[14px] font-medium text-vert">
+                            {row.label}
+                          </span>
+                        </span>
+                      </td>
+                      <td className="px-4 py-4 text-right text-[14px] text-texte md:px-6">
+                        {row.last7.toLocaleString('fr-FR')}
+                      </td>
+                      <td className="px-4 py-4 text-right text-[14px] text-texte md:px-6">
+                        {row.last30.toLocaleString('fr-FR')}
+                      </td>
+                      <td className="px-4 py-4 text-right font-serif text-[15px] italic text-or-deep md:px-6">
+                        {row.total.toLocaleString('fr-FR')}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        ) : (
+          <div className="rounded-sm border border-or/15 bg-blanc p-8 md:p-12">
+            <h2 className="font-serif text-[clamp(1.75rem,3vw,2.25rem)] font-light leading-[1.15] text-vert">
+              Pour qu&apos;elles te contactent, il faut qu&apos;elles{' '}
+              <em className="italic text-or">trouvent comment.</em>
+            </h2>
+            <p className="mt-4 max-w-2xl text-[15px] leading-[1.7] text-texte-sec">
+              Vérifie que tes infos contact sont à jour sur ta fiche —
+              c&apos;est la première chose qu&apos;on regarde.
+            </p>
+            {place.slug && (
+              <Link
+                href={`/recommandation/${place.slug}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-7 inline-flex h-12 items-center gap-2 rounded-full bg-vert px-7 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+              >
+                Voir ma fiche publique
+                <span className="text-or-light" aria-hidden="true">→</span>
+              </Link>
+            )}
           </div>
         )}
 
         <p className="mt-6 text-[11px] italic text-texte-sec">
-          Les clics sont trackés depuis le déploiement de PR-B1
-          (2026-05-09). Les fiches plus anciennes peuvent avoir reçu des
-          clics non comptabilisés avant cette date.
+          On compte précieusement chaque pas qu&apos;une copine fait vers
+          toi, depuis le 9 mai 2026.
         </p>
       </section>
     </>

--- a/app/dashboard/lieu/layout.tsx
+++ b/app/dashboard/lieu/layout.tsx
@@ -1,0 +1,69 @@
+import { Sidebar, type SidebarItem } from '@/components/dashboard/Sidebar'
+import { requireUser } from '@/lib/supabase/session'
+import { createClient } from '@/lib/supabase/server'
+
+/**
+ * Layout du dashboard owner lieu (Phase 2A · PR-B2).
+ *
+ * Pattern aligné sur app/dashboard/prestataire/layout.tsx mais simplifié :
+ *  - Pas de `requirePrestataire()` parce que le concept "owner lieu" n'a
+ *    pas de table dédiée — on utilise places.created_by_user_id (mig 28).
+ *    L'auth est juste vérifiée via requireUser() ; la page elle-même fait
+ *    les queries places.
+ *  - Sidebar à 3 entrées dont 2 placeholders (PR-D activera "Mes événements",
+ *    une PR ultérieure activera l'édition fiche lieu).
+ */
+export default async function LieuDashboardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const user = await requireUser()
+  const isAdmin = Boolean(user.user_metadata?.is_admin)
+
+  // Lecture user_profile pour prénom + avatar dans la sidebar (best-effort).
+  // Un user qui aurait skip l'onboarding utilisatrice peut ne pas en avoir.
+  const supabase = await createClient()
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('prenom, avatar_url')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  const items: SidebarItem[] = [
+    { href: '/dashboard/lieu', label: 'Accueil', icon: '·' },
+    // Placeholders — actifs en PRs futures. href='#' pour l'instant : pas
+    // de navigation, badge "Bientôt" pour clarifier le statut.
+    { href: '#', label: 'Ma fiche', icon: '❋', badge: 'Bientôt' },
+    { href: '#', label: 'Mes événements', icon: '◇', badge: 'PR-D' },
+    // Raccourci admin — uniquement si user_metadata.is_admin=true.
+    ...(isAdmin
+      ? ([
+          {
+            href: '/admin',
+            label: 'Admin',
+            icon: '⚡',
+            badge: 'BACK-OFFICE',
+          },
+        ] as SidebarItem[])
+      : []),
+  ]
+
+  const prenom = (profile?.prenom as string | undefined) ?? 'Toi'
+  const avatar = (profile?.avatar_url as string | undefined) ?? '#D4C5B0'
+
+  return (
+    <div className="flex min-h-screen flex-col bg-creme text-texte md:flex-row">
+      <Sidebar
+        items={items}
+        user={{
+          prenom,
+          avatar,
+          meta: 'Espace lieu',
+        }}
+        signOutLabel="À bientôt"
+      />
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  )
+}

--- a/app/dashboard/lieu/page.tsx
+++ b/app/dashboard/lieu/page.tsx
@@ -1,0 +1,127 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
+import { EmptyState } from '@/components/dashboard/EmptyState'
+import { GoldLine } from '@/components/ui/GoldLine'
+import { PastilleSelectionHilmy } from '@/components/v2/PastilleSelectionHilmy'
+import { requireUser } from '@/lib/supabase/session'
+import { getMyOwnedPlaces } from '@/lib/supabase/queries/places'
+import { isSelectionHilmy } from '@/lib/permissions-lieux'
+
+/**
+ * Dashboard owner lieu — page d'accueil / liste des lieux possédés.
+ *
+ * Phase 2A · PR-B2 · décision Jiji B1 (multi-lieux : liste + détail) :
+ *   - 0 lieu → EmptyState avec CTA création (route existante
+ *     /dashboard/utilisatrice/recommandations/nouvelle qui crée une
+ *     ghost-fiche via Google Places autocomplete + reco associée)
+ *   - 1 lieu → redirect /dashboard/lieu/[id] pour éviter le silent fail
+ *     "écran liste avec une seule carte"
+ *   - 2+ lieux → liste de cartes triées Sélection Hilmy d'abord, puis
+ *     alphabétiquement (cf getMyOwnedPlaces order)
+ */
+export default async function LieuDashboardPage() {
+  const user = await requireUser()
+  const { data: places, error } = await getMyOwnedPlaces(user.id)
+  const list = places ?? []
+
+  // Auto-redirect single-place. Ne PAS faire si error pour ne pas masquer
+  // un échec réseau silencieusement.
+  if (!error && list.length === 1) {
+    redirect(`/dashboard/lieu/${list[0].id}`)
+  }
+
+  // 0 lieu possédé : EmptyState avec CTA vers le flow de création.
+  if (list.length === 0) {
+    return (
+      <>
+        <DashboardHeader
+          kicker="Espace lieu"
+          titre={
+            <>
+              Tu n&apos;as pas encore{' '}
+              <em className="font-serif italic text-or">de fiche lieu.</em>
+            </>
+          }
+          lead="Crée ta première fiche pour la rejoindre dans l'annuaire des copines. Tu pourras ensuite passer en Sélection Hilmy quand tu seras prête."
+        />
+        <section className="px-6 py-14 md:px-12 md:py-20">
+          {error && (
+            <p className="mb-6 rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[12px] text-red-900">
+              {error}
+            </p>
+          )}
+          <EmptyState
+            kicker="Premiers pas"
+            titre="Aucun lieu pour l'instant."
+            pitch="Une recommandation sur un café, un restaurant, une boutique que tu adores ? Crée la fiche depuis Google Maps en deux clics — elle apparaîtra ensuite ici."
+            ctaLabel="Créer ma première fiche"
+            ctaHref="/dashboard/utilisatrice/recommandations/nouvelle"
+          />
+        </section>
+      </>
+    )
+  }
+
+  // 2+ lieux : liste de cartes
+  return (
+    <>
+      <DashboardHeader
+        kicker="Espace lieu"
+        titre={
+          <>
+            Tes lieux,{' '}
+            <em className="font-serif italic text-or">en un coup d&apos;œil.</em>
+          </>
+        }
+        lead={`Tu en gères ${list.length}. Clique sur une fiche pour voir ses stats et la gérer.`}
+      />
+      <section className="px-6 py-10 md:px-12 md:py-14">
+        {error && (
+          <p className="mb-6 rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[12px] text-red-900">
+            {error}
+          </p>
+        )}
+        <div className="mb-8 flex items-center gap-4">
+          <GoldLine width={40} />
+          <span className="overline text-or">Mes fiches</span>
+        </div>
+        <ul className="grid gap-4 md:grid-cols-2">
+          {list.map((place) => {
+            const isSelection = isSelectionHilmy(place)
+            return (
+              <li key={place.id}>
+                <Link
+                  href={`/dashboard/lieu/${place.id}`}
+                  className="group flex h-full flex-col gap-3 rounded-sm border border-or/15 bg-blanc p-6 transition-all hover:-translate-y-0.5 hover:border-or hover:shadow-[0_24px_48px_-32px_rgba(15,61,46,0.25)] md:p-7"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <h2 className="font-serif text-[20px] font-light leading-tight text-vert">
+                      {place.name}
+                    </h2>
+                    {isSelection && <PastilleSelectionHilmy />}
+                  </div>
+                  <p className="text-[12px] tracking-[0.22em] text-texte-sec uppercase">
+                    {place.city || '—'}
+                  </p>
+                  <div className="mt-auto flex items-center justify-between gap-3 border-t border-or/10 pt-4">
+                    <span className="text-[12px] text-texte-sec">
+                      {(place.nb_vues ?? 0).toLocaleString('fr-FR')} vue
+                      {(place.nb_vues ?? 0) > 1 ? 's' : ''}
+                    </span>
+                    <span
+                      className="inline-flex items-center gap-1.5 text-[11px] font-medium tracking-[0.22em] text-or uppercase transition-transform group-hover:translate-x-0.5"
+                      aria-hidden="true"
+                    >
+                      Gérer →
+                    </span>
+                  </div>
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      </section>
+    </>
+  )
+}

--- a/lib/supabase/queries/places.ts
+++ b/lib/supabase/queries/places.ts
@@ -2,6 +2,12 @@
  * Queries lieux (table : places).
  * Pas de status/modération sur places — on récupère tout.
  * Le filtrage se fait via recommendations (type='place').
+ *
+ * PLACE_SELECT inclut depuis mig 41 : palier (default 'aucun'), nb_vues
+ * (compteur agrégé bumpé par trigger sur place_views), created_by_user_id
+ * (mig 28 — owner concept pour le dashboard owner). Ces 3 colonnes sont
+ * optionnelles dans le type Place donc tous les call sites existants
+ * compilent sans modif (elles arrivent juste enrichies).
  */
 
 import { createClient } from "@/lib/supabase/server";
@@ -23,6 +29,9 @@ const PLACE_SELECT = `
   hilmy_category,
   main_photo_url,
   photos,
+  created_by_user_id,
+  palier,
+  nb_vues,
   created_at,
   updated_at
 `;
@@ -79,6 +88,59 @@ export async function getPlacesByCategorie(
 
     if (error) return { data: null, error: error.message };
     return { data: (data ?? []) as unknown as Place[], error: null };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
+/**
+ * Liste les lieux possédés par une utilisatrice (côté dashboard owner lieu,
+ * Phase 2A · PR-B2). "Owner" = `places.created_by_user_id` (mig 28) — décision
+ * Jiji A1 du brief : pas de système `owner_user_id` séparé pour le MVP.
+ *
+ * Tri : Sélection Hilmy d'abord (les fiches payantes en haut), puis ordre
+ * alphabétique sur `name` pour stabilité visuelle si plusieurs lieux gratuits.
+ */
+export async function getMyOwnedPlaces(
+  userId: string
+): Promise<QueryResult<Place[]>> {
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from("places")
+      .select(PLACE_SELECT)
+      .eq("created_by_user_id", userId)
+      .order("palier", { ascending: false }) // 'selection_hilmy' avant 'aucun' (string DESC)
+      .order("name", { ascending: true });
+
+    if (error) return { data: null, error: error.message };
+    return { data: (data ?? []) as unknown as Place[], error: null };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
+/**
+ * Récupère un lieu par id ET ownership. Retourne null silencieusement si
+ * le lieu n'existe pas OU si l'utilisatrice n'en est pas owner — la page
+ * dashboard détail s'en sert pour rediriger en 403-style sans révéler
+ * l'existence d'autres lieux. Pas de service-role : RLS owner-read suffit.
+ */
+export async function getOwnedPlaceById(
+  userId: string,
+  placeId: string
+): Promise<QueryResult<Place | null>> {
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from("places")
+      .select(PLACE_SELECT)
+      .eq("id", placeId)
+      .eq("created_by_user_id", userId)
+      .maybeSingle();
+
+    if (error) return { data: null, error: error.message };
+    return { data: (data as unknown as Place) ?? null, error: null };
   } catch (err) {
     return { data: null, error: errorMessage(err) };
   }


### PR DESCRIPTION
**PR-B2 of Phase 2A** · option B (data first) · pure read layer. Consume the data collected by PR-B1 (place_views, place_contacts, favoris).

**No new writes, no migration.** Just queries + dashboard UI.

## Symptôme

Audit Phase 1 (`audit-features-tarifs.md`) a identifié que la promesse Sélection Hilmy 39€/mois ne livre 0/5 features. PR-A a posé le schéma BDD, PR-B1 a wiré la collecte de data — il manquait l'interface owner pour consulter ces stats. Sans dashboard, une cliente Sélection Hilmy paie 39€/mois sans rien pouvoir consulter.

## Root cause

`app/dashboard/` ne contenait que `prestataire/` et `utilisatrice/`. Aucun dashboard lieu n'existait — il fallait tout créer en mirroirant le pattern prestataire mais avec le concept d'ownership différent (`places.created_by_user_id` mig 28 au lieu de `profiles.user_id`).

## Fix

### Query helpers étendus

[lib/supabase/queries/places.ts](lib/supabase/queries/places.ts) :
- `PLACE_SELECT` enrichi avec `palier`, `nb_vues`, `created_by_user_id` (mig 41 + mig 28). **Backward-compat** : ces 3 champs sont optionnels sur le type `Place`, donc le seul call site existant ([app/recommandation/[slug]/page.tsx](app/recommandation/[slug]/page.tsx)) compile sans modif et reçoit juste de la data enrichie.
- `getMyOwnedPlaces(userId)` : tri Sélection Hilmy d'abord, puis alphabétique.
- `getOwnedPlaceById(userId, placeId)` : retourne `null` silencieusement si non-owner (utilisé par la détail page pour redirect 403-style sans révéler l'existence).

### Layout (69 lignes)

[app/dashboard/lieu/layout.tsx](app/dashboard/lieu/layout.tsx) :
- `requireUser()` (pas de `requireLieu` : décision A1, `created_by_user_id` IS l'owner concept MVP)
- Sidebar avec 3 entrées dont 2 placeholders (`#` href + badge "Bientôt" / "PR-D")
- Le link "Voir ma fiche publique" est dans le header de la page détail (plus contextuel)

### Page liste (127 lignes)

[app/dashboard/lieu/page.tsx](app/dashboard/lieu/page.tsx) — dispatcher logic (décision B1) :

| Cas | Comportement |
|---|---|
| **0 lieu** | EmptyState + CTA → `/dashboard/utilisatrice/recommandations/nouvelle` |
| **1 lieu** | `redirect('/dashboard/lieu/' + place.id)` (pas de "list of one" silent fail) |
| **2+ lieux** | Grille de cartes : nom + ville + pastille Sélection Hilmy si applicable + nb_vues |

### Page détail (464 lignes)

[app/dashboard/lieu/[placeId]/page.tsx](app/dashboard/lieu/[placeId]/page.tsx) — branchement par palier :

#### Cas A — `palier='aucun'`

Bloc upsell (vert, large) :
- Liste 6 features Sélection Hilmy
- Prix `39€/mois` + note "sans engagement"
- CTAs `/tarifs#selection-hilmy` (or) et `/tarifs` (border)
- Pas de stats affichées (la cliente n'y a pas droit)

#### Cas B — `palier='selection_hilmy'` → 3 sections stats

| Section | Contenu |
|---|---|
| **Mes vues** | 3 StatCards (Total `nb_vues` / 7d / 30d) + VuesAreaChart 30j (rendu si ≥5 vues 30d, évite chart vide) |
| **Mes saves** | 3 StatCards (Total / 7d / 30d) sur `favoris` WHERE type_item='lieu' |
| **Tap-to-contact tracé** | Tableau par canal (7d / 30d / Total), sorted by total desc. EmptyState si 0 click |

**6 queries en parallèle** via `Promise.all` pour réduire latence.

#### Footer note transparence

> *Les clics sont trackés depuis le déploiement de PR-B1 (2026-05-09). Les fiches plus anciennes peuvent avoir reçu des clics non comptabilisés avant cette date.*

## RLS reads

| Table | RLS | Client utilisé |
|---|---|---|
| `places` | owner-read OK via `created_by_user_id` (mig 28) | server (createClient) |
| `place_views` | owner-read OK via mig 41 RLS | server |
| `place_contacts` | owner-read OK via mig 41 RLS | server |
| `favoris` | owner-only sur `user_id` (mig 05) — un lieu owner ne peut PAS lire les saves d'autres users | **admin** (service-role) — agrégat sans PII, server-component-only |

L'utilisation du service-role pour l'agrégat `favoris` est documentée dans le header de la page. Pattern aligné avec les API routes `/api/track/*` qui ont besoin du même bypass.

## Tests manuels à valider sur Vercel preview

- [ ] User avec **0 lieux** → voit EmptyState + CTA "Créer ma première fiche"
- [ ] User avec **1 lieu palier='aucun'** → redirect immédiat vers détail, voit upsell vert, pas de stats
- [ ] User avec **1 lieu palier='selection_hilmy'** → redirect détail, voit 3 sections stats + chart 30j (si ≥5 vues)
- [ ] User avec **2+ lieux mixed paliers** → voit liste, Sélection Hilmy d'abord, clique → arrive sur détail
- [ ] User non-owner accède à `/dashboard/lieu/{id-d-un-lieu-d-un-autre-user}` → redirect silencieux vers `/dashboard/lieu` (pas erreur, pas révélation d'existence)
- [ ] User non auth → redirect `/auth/login` (via `requireUser()`)
- [ ] Admin (`user_metadata.is_admin=true`) → voit le raccourci sidebar "Admin"
- [ ] Tableau tap-to-contact rendu correctement quand des clics existent (créés par PR-B1 depuis ~1h)
- [ ] StatCard "saves" affiche 0 sur lieux non-favorités, ≥1 sur lieux où l'auteur a cliqué ♡

## Risques

- **Faible.** Pure read, no writes, no migration.
- **Service-role usage** : limité à 1 query agrégée. Justifié dans le code. Pas de leak côté client (server component only).
- **Charge** : 6 queries `Promise.all` sur la détail page. Light puisque `head: true` + filtres indexés.
- **Backward compat queries** : PLACE_SELECT enrichi mais le seul call site (recommandation/[slug]) ignore les nouveaux champs et continue de fonctionner. Vérifié par grep : `getAllPlaces` n'a aucun call site (mort potentiel à signaler — voir Out of scope).

## Observation pendant le sprint (9e incohérence ?)

`getAllPlaces` est exporté de `lib/supabase/queries/places.ts` mais n'est appelé **nulle part** (vérifié par grep). Code mort potentiel. **Non corrigé dans cette PR** (hors scope strict PR-B2). À traiter en cleanup PR séparée si tu veux.

## Sécurité

- ✅ `requireUser()` au layout level → bloque tout l'arbre `/dashboard/lieu/**` aux non-auth
- ✅ Double-filter `id + created_by_user_id` sur la détail page (anti-enumeration)
- ✅ 403-style redirect silencieux (ne révèle pas l'existence d'autres lieux)
- ✅ Service-role client confiné au server component (pas de leak bundle)
- ✅ Aucun nouveau write path
- ✅ Auth + 3 paliers prestataires intouchés

## Out of scope (PR-C / PR-D)

- Pastille publique sur fiche `/recommandation/[slug]` + tri prio dans `/recommandations` + photos illimitées → **PR-C**
- Form select `boost_event_type` sur création event lieu + admin `/admin/events-config` + fonction `is_lieu_boosted` + tri feed boosté → **PR-D**
- Wiring "Ma fiche" et "Mes événements" sidebar (`href='#'` aujourd'hui) → PRs ultérieures
- Self-claim flow "vrai owner ≠ ghost creator" (cas rare) → manuel via Supabase admin pour MVP

## Refs

- Audit complet : `audit-features-tarifs.md` (P0)
- Brief Phase 2A — sprint Sélection Hilmy lieux
- PR-A : [#77](https://github.com/jihaneessmaliki-sys/hilmy/pull/77) (mig 41 appliquée prod 2026-05-09)
- PR-B1 : [#78](https://github.com/jihaneessmaliki-sys/hilmy/pull/78) (tracking infra déployée prod 2026-05-09)

## Stop next

PR-B2 mergée + déployée → on attend ton GO pour PR-C (public-facing UI Sélection Hilmy : pastille + tri + photos illimitées).