### PR TITLE
feat(prestataires): reframe dashboard en voix Sara — data riche/jeune gating

### DIFF
--- a/app/dashboard/prestataire/page.tsx
+++ b/app/dashboard/prestataire/page.tsx
@@ -305,6 +305,36 @@ export default async function PrestataireAccueilPage() {
           </div>
         )}
 
+        {/* Bandeau Premium → Cercle Pro — invitation à monter d'un cran
+            pour accéder au tableau tap-to-contact détaillé par canal.
+            Affiché uniquement pour les Premium pure (ni Standard, ni
+            Cercle Pro). Décision Jiji 2026-05-09 (Sprint K commit add). */}
+        {isPremiumOrAbove && !isCerclePro && (
+          <div className="mt-10 rounded-sm border border-or/40 bg-creme-soft p-6 md:p-7">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-6">
+              <div>
+                <p className="overline text-or">
+                  Le détail des copines · disponible en Cercle Pro
+                </p>
+                <p className="mt-2 font-serif text-[18px] italic leading-[1.4] text-vert md:text-[20px]">
+                  Tu veux savoir précisément comment elles te cherchent ?
+                </p>
+                <p className="mt-2 text-[13px] leading-[1.6] text-texte-sec">
+                  Insta, WhatsApp, Maps, téléphone… Le détail par canal
+                  pour comprendre ce qui marche le mieux.
+                </p>
+              </div>
+              <Link
+                href="/dashboard/prestataire/abonnement"
+                className="inline-flex h-11 shrink-0 items-center gap-2 rounded-full bg-vert px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+              >
+                Passer Cercle Pro
+                <span className="text-or-light" aria-hidden="true">→</span>
+              </Link>
+            </div>
+          </div>
+        )}
+
         {/* Bandeau Cercle Pro — page détaillée disponible */}
         {isCerclePro && (
           <div className="mt-10 rounded-sm bg-vert p-6 text-creme md:p-7">

--- a/app/dashboard/prestataire/page.tsx
+++ b/app/dashboard/prestataire/page.tsx
@@ -83,27 +83,33 @@ export default async function PrestataireAccueilPage() {
 
   // Construction du chart 30j (Premium+ seulement) — bucket par jour, jours
   // sans donnée à 0 pour avoir une courbe propre.
-  const vues30j = isPremiumOrAbove
-    ? buildVues30jSeries(viewsLast30dRes.data ?? [])
-    : []
+  const views30dRows = viewsLast30dRes.data ?? []
+  const views30d = views30dRows.length
+  const vues30j = isPremiumOrAbove ? buildVues30jSeries(views30dRows) : []
 
   const reviews = reviewsRes.data ?? []
   const pendingReplies = reviews.filter((r) => !r.reponse_pro).length
   const upcomingEventsCount = eventsRes.count ?? 0
 
-  const prenom = prestataire.nom.split(' ')[0] ?? prestataire.nom
+  // ─── Gating "data riche" vs "data jeune/encouragement" ──────────────
+  // Voix Sara : on transforme chaque chiffre en récit. Quand la data est
+  // trop jeune pour raconter une histoire, on bascule sur des
+  // encouragements + actions concrètes plutôt que d'afficher des 0
+  // déprimants. Aligné sur le dashboard lieu (PR-B2 #79).
+  const viewsRichMode = viewsTotal >= 10 || viewsLast7 >= 3
+
+  // Pluralisation FR (1 → "", N>1 → "s").
+  const pluralS = (n: number) => (n > 1 ? 's' : '')
 
   return (
     <>
       <DashboardHeader
-        kicker={`Bonjour, ${prenom}`}
+        kicker={`Ton tableau de bord, ${prestataire.nom}`}
         titre={
-          <>
-            Ton activité,{' '}
-            <em className="font-serif italic text-or">en un coup d&apos;œil.</em>
+          <>Voilà ce que les copines{' '}
+            <em className="font-serif italic text-or">pensent de toi.</em>
           </>
         }
-        lead="Les chiffres depuis la création de ta fiche. Vues, contacts, avis."
         actions={
           <div className="flex flex-wrap items-center gap-3">
             {isCerclePro && <PastilleSelectionHilmy />}
@@ -143,74 +149,149 @@ export default async function PrestataireAccueilPage() {
         </section>
       )}
 
-      {/* === STATS PALIER-AWARE ===================================== */}
+      {/* ─── Section 1 — Les copines te découvrent ─────────────────── */}
       <section className="px-6 py-10 md:px-12 md:py-14">
-        <div className="mb-8 flex items-center gap-4">
-          <GoldLine width={40} />
-          <span className="overline text-or">
-            {!isPremiumOrAbove ? 'Mes chiffres' : 'Mes chiffres détaillés'}
-          </span>
-        </div>
+        {viewsRichMode ? (
+          <>
+            <div className="mb-8 flex items-center gap-4">
+              <GoldLine width={40} />
+              <span className="overline text-or">
+                Les copines te découvrent
+              </span>
+            </div>
 
-        {!isPremiumOrAbove ? (
-          <div className="grid gap-4 md:grid-cols-2">
-            <StatCard
-              kicker="Vues totales"
-              value={viewsTotal.toLocaleString('fr-FR')}
-              hint="Depuis la publication de ta fiche"
-              index={0}
-            />
-            <StatCard
-              kicker="Clics totaux"
-              value={contactsTotal.toLocaleString('fr-FR')}
-              hint="WhatsApp, téléphone, email, réseaux…"
-              variant="or"
-              index={1}
-            />
-          </div>
+            {!isPremiumOrAbove ? (
+              <div className="grid gap-4 md:grid-cols-2">
+                <StatCard
+                  kicker="Au total"
+                  value={`${viewsTotal.toLocaleString('fr-FR')} copine${pluralS(viewsTotal)}`}
+                  hint="se sont arrêtées sur ton profil"
+                  variant="vert"
+                  index={0}
+                />
+                <StatCard
+                  kicker="Elles ont fait le pas"
+                  value={contactsTotal.toLocaleString('fr-FR')}
+                  hint="ont voulu te joindre, tous canaux confondus"
+                  variant="or"
+                  index={1}
+                />
+              </div>
+            ) : (
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+                <StatCard
+                  kicker="Au total"
+                  value={`${viewsTotal.toLocaleString('fr-FR')} copine${pluralS(viewsTotal)}`}
+                  hint="se sont arrêtées sur ton profil"
+                  variant="vert"
+                  index={0}
+                />
+                <StatCard
+                  kicker="Cette semaine"
+                  value={viewsLast7.toLocaleString('fr-FR')}
+                  hint="ont voulu te connaître"
+                  variant="or"
+                  index={1}
+                />
+                <StatCard
+                  kicker="Elles t'ont WhatsApp"
+                  value={whatsappCount.toLocaleString('fr-FR')}
+                  hint="ont cliqué pour t'écrire"
+                  variant="vert"
+                  index={2}
+                />
+                <StatCard
+                  kicker="Elles ont voulu te joindre"
+                  value={emailWebsiteCount.toLocaleString('fr-FR')}
+                  hint="via email ou ton site"
+                  index={3}
+                />
+              </div>
+            )}
+          </>
         ) : (
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-            <StatCard
-              kicker="Vues totales"
-              value={viewsTotal.toLocaleString('fr-FR')}
-              hint="Depuis la publication"
-              index={0}
-            />
-            <StatCard
-              kicker="Vues cette semaine"
-              value={viewsLast7.toLocaleString('fr-FR')}
-              hint="Sur les 7 derniers jours"
-              variant="or"
-              index={1}
-            />
-            <StatCard
-              kicker="Clics WhatsApp"
-              value={whatsappCount.toLocaleString('fr-FR')}
-              hint="Visites qui ont cliqué pour t'écrire"
-              variant="vert"
-              index={2}
-            />
-            <StatCard
-              kicker="Clics email / site"
-              value={emailWebsiteCount.toLocaleString('fr-FR')}
-              hint="Email + site web cumulés"
-              index={3}
-            />
-          </div>
+          <>
+            <div className="mb-6 flex items-center gap-4">
+              <GoldLine width={40} />
+              <span className="overline text-or">Ton profil prend ses marques</span>
+            </div>
+            <h2 className="font-serif text-[clamp(1.75rem,3vw,2.25rem)] font-light leading-[1.15] text-vert">
+              Les premières copines{' '}
+              <em className="italic text-or">arrivent.</em>
+            </h2>
+            <p className="mt-4 max-w-xl text-[15px] leading-[1.7] text-texte-sec">
+              Pendant que ta fiche prend ses marques, voilà 3 manières de
+              l&apos;aider à briller :
+            </p>
+
+            <ul className="mt-10 grid gap-6 md:grid-cols-3">
+              <li className="rounded-sm border border-or/15 bg-blanc p-6 md:p-7">
+                <span
+                  className="font-serif text-[44px] font-light italic leading-none text-or"
+                  aria-hidden="true"
+                >
+                  01
+                </span>
+                <h3 className="mt-5 font-serif text-lg font-light leading-snug text-vert">
+                  Partage le lien sur ton Insta story
+                </h3>
+                <p className="mt-3 text-[13px] leading-[1.6] text-texte-sec">
+                  La team Hilmy y est très active.
+                </p>
+              </li>
+
+              <li className="rounded-sm border border-or/15 bg-blanc p-6 md:p-7">
+                <span
+                  className="font-serif text-[44px] font-light italic leading-none text-or"
+                  aria-hidden="true"
+                >
+                  02
+                </span>
+                <h3 className="mt-5 font-serif text-lg font-light leading-snug text-vert">
+                  Glisse un QR code dans tes communications client
+                </h3>
+                <p className="mt-3 text-[13px] leading-[1.6] text-texte-sec">
+                  Tes vraies clientes deviennent ambassadrices.
+                </p>
+              </li>
+
+              <li className="rounded-sm border border-or/15 bg-blanc p-6 md:p-7">
+                <span
+                  className="font-serif text-[44px] font-light italic leading-none text-or"
+                  aria-hidden="true"
+                >
+                  03
+                </span>
+                <Link
+                  href="/dashboard/prestataire/evenements"
+                  className="mt-5 block font-serif text-lg font-light leading-snug text-vert hover:text-or"
+                >
+                  Crée un événement saisonnier{' '}
+                  <span className="text-or" aria-hidden="true">→</span>
+                </Link>
+                <p className="mt-3 text-[13px] leading-[1.6] text-texte-sec">
+                  C&apos;est l&apos;auto-boost de la team Hilmy.
+                </p>
+              </li>
+            </ul>
+          </>
         )}
 
-        {/* Bandeau upsell Standard → Premium */}
+        {/* Bandeau invitation Standard → Premium (toujours visible si non
+            Premium+, indépendant du mode riche/jeune) */}
         {!isPremiumOrAbove && (
-          <div className="mt-6 rounded-sm border border-or/30 bg-or/10 p-6 md:p-7">
+          <div className="mt-10 rounded-sm border border-or/30 bg-or/10 p-6 md:p-7">
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-6">
               <div>
                 <p className="overline text-or">Passe en Premium</p>
                 <p className="mt-2 font-serif text-[18px] italic leading-[1.4] text-vert md:text-[20px]">
-                  Vues hebdo, clics par canal, courbe sur 30 jours…
+                  Le détail des copines qui t&apos;ont voulue, semaine après
+                  semaine.
                 </p>
                 <p className="mt-2 text-[13px] leading-[1.6] text-texte-sec">
-                  Le détail de ton audience et l&apos;évolution de ta fiche
-                  sont réservés aux paliers Premium et Cercle Pro.
+                  Le détail des canaux qu&apos;elles ont cliqués et
+                  l&apos;évolution de ta fiche sur 30 jours sont réservés
+                  aux paliers Premium et Cercle Pro.
                 </p>
               </div>
               <Link
@@ -224,25 +305,26 @@ export default async function PrestataireAccueilPage() {
           </div>
         )}
 
-        {/* Bandeau Stats avancées Cercle Pro — actif depuis Phase 4 */}
+        {/* Bandeau Cercle Pro — page détaillée disponible */}
         {isCerclePro && (
-          <div className="mt-6 rounded-sm bg-vert p-6 text-creme md:p-7">
+          <div className="mt-10 rounded-sm bg-vert p-6 text-creme md:p-7">
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-6">
               <div>
-                <p className="overline text-or">Stats avancées · disponibles</p>
+                <p className="overline text-or">Le détail des copines · disponible</p>
                 <p className="mt-2 font-serif text-[18px] italic leading-[1.4] text-creme md:text-[20px]">
-                  Carte des villes, pics horaires, benchmark catégorie.
+                  D&apos;où elles viennent, quand elles te regardent, comment
+                  tu te situes.
                 </p>
                 <p className="mt-2 text-[13px] leading-[1.6] text-creme/75">
                   Tu fais partie du Cercle Pro — voici la vue 30 jours
-                  glissants pour piloter ton audience en profondeur.
+                  glissants pour comprendre les copines en profondeur.
                 </p>
               </div>
               <Link
                 href="/dashboard/prestataire/stats-avancees"
                 className="inline-flex h-11 shrink-0 items-center gap-2 rounded-full bg-or px-5 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:bg-or-light"
               >
-                Voir mes stats avancées
+                Voir le détail
                 <span aria-hidden="true">→</span>
               </Link>
             </div>
@@ -250,22 +332,24 @@ export default async function PrestataireAccueilPage() {
         )}
       </section>
 
-      {/* === CHART 30 JOURS (Premium+ uniquement) ====================== */}
-      {isPremiumOrAbove && (
+      {/* === CHART 30 JOURS (Premium+ + data riche + ≥5 vues 30d) ====== */}
+      {isPremiumOrAbove && viewsRichMode && views30d >= 5 && (
         <section className="bg-blanc px-6 py-12 md:px-12 md:py-16">
           <div className="rounded-sm border border-or/15 bg-creme-soft p-6 md:p-8">
             <div className="mb-6 flex items-start justify-between gap-4">
               <div>
-                <p className="overline text-or">Évolution des vues</p>
+                <p className="overline text-or">
+                  Quand on s&apos;arrête sur ton profil
+                </p>
                 <h2 className="mt-2 font-serif text-2xl font-light text-vert">
-                  Sur 30 jours.
+                  Les 30 derniers jours en image.
                 </h2>
-                <p className="mt-1 text-[11px] italic text-texte-sec">
-                  Données réelles agrégées par jour.
+                <p className="mt-1 text-[12px] italic text-texte-sec">
+                  Chaque pic, c&apos;est une copine qui t&apos;a découverte.
                 </p>
               </div>
               <span className="font-serif text-xl italic text-or">
-                ↗ {viewsTotal.toLocaleString('fr-FR')}
+                ↗ {views30d}
               </span>
             </div>
             <VuesAreaChart data={vues30j} />
@@ -386,6 +470,12 @@ export default async function PrestataireAccueilPage() {
           </p>
         )}
       </section>
+
+      {/* ─── Footer transparence ──────────────────────────────────── */}
+      <p className="px-6 pb-12 pt-2 text-center font-sans text-[12px] italic text-texte-sec md:px-12">
+        On compte précieusement chaque pas qu&apos;une copine fait vers
+        toi, depuis le 9 mai 2026.
+      </p>
     </>
   )
 }

--- a/app/dashboard/prestataire/stats-avancees/page.tsx
+++ b/app/dashboard/prestataire/stats-avancees/page.tsx
@@ -20,6 +20,34 @@ import {
 } from '@/lib/stats/aggregations'
 
 const SINCE_DAYS = 30
+const SINCE_7D_MS = 7 * 86_400_000
+const SINCE_30D_MS = 30 * 86_400_000
+
+/**
+ * Labels FR voix Sara pour les 9 canaux profile_contacts (CHECK mig 15).
+ * Mirror du dashboard lieu (PR-B2 #79) avec linkedin (au lieu de
+ * google_maps qui est lieu-only). Ajouté Sprint K reframe 2026-05-09.
+ */
+const CONTACT_CHANNEL_COPY: Record<string, { emoji: string; label: string }> = {
+  whatsapp: { emoji: '💬', label: 'Ont voulu te WhatsApper' },
+  phone: { emoji: '📞', label: "Ont voulu t'appeler" },
+  email: { emoji: '✉️', label: "Ont voulu t'écrire" },
+  website: { emoji: '🌐', label: 'Ont voulu visiter ton site' },
+  instagram: { emoji: '📸', label: 'Ont voulu te suivre sur Insta' },
+  tiktok: { emoji: '🎵', label: 'Ont voulu te suivre sur TikTok' },
+  linkedin: { emoji: '💼', label: 'Ont voulu te connecter sur LinkedIn' },
+  facebook: { emoji: '👥', label: 'Ont voulu te suivre sur Facebook' },
+  youtube: { emoji: '▶️', label: 'Ont voulu voir tes vidéos' },
+}
+
+type ContactRow = {
+  channel: string
+  emoji: string
+  label: string
+  last7: number
+  last30: number
+  total: number
+}
 
 export default async function StatsAvanceesPage() {
   const { prestataire } = await requirePrestataire()
@@ -71,13 +99,52 @@ export default async function StatsAvanceesPage() {
     }),
   )
 
-  // 3. Agrégations
+  // 3. Tap-to-contact : agrégation par canal sur 7j/30j/total
+  //    (Sprint K reframe — section nouvelle, exclusivité Cercle Pro qui
+  //    valorise le palier 99€/mois). RLS owner-read sur profile_contacts
+  //    (mig 15) → client standard suffit, pas besoin de service-role.
+  const { data: contactsRows } = await supabase
+    .from('profile_contacts')
+    .select('contact_type, clicked_at')
+    .eq('profile_id', prestataire.id)
+
+  type ClickRow = { contact_type: string; clicked_at: string }
+  const clicks = (contactsRows ?? []) as ClickRow[]
+  const now7 = Date.now() - SINCE_7D_MS
+  const now30 = Date.now() - SINCE_30D_MS
+  const byChannel: Map<string, ContactRow> = new Map()
+  for (const c of clicks) {
+    const ts = new Date(c.clicked_at).getTime()
+    const copy = CONTACT_CHANNEL_COPY[c.contact_type] ?? {
+      emoji: '·',
+      label: c.contact_type,
+    }
+    const row =
+      byChannel.get(c.contact_type) ??
+      {
+        channel: c.contact_type,
+        emoji: copy.emoji,
+        label: copy.label,
+        last7: 0,
+        last30: 0,
+        total: 0,
+      }
+    row.total++
+    if (ts >= now30) row.last30++
+    if (ts >= now7) row.last7++
+    byChannel.set(c.contact_type, row)
+  }
+  const contactRows = Array.from(byChannel.values()).sort(
+    (a, b) => b.total - a.total,
+  )
+
+  // 4. Agrégations vues
   const villes = aggregateByVille(myRows, 8)
   const heures = aggregateByHeure(myRows)
   const percentile = computeCategoryPercentile(myViewsCount, peerCounts)
   const wording = benchmarkWording(percentile)
 
-  // 4. Top heure (pour StatCard)
+  // 5. Top heure (pour StatCard)
   const topHeure = heures.reduce(
     (best, cur) => (cur.vues > best.vues ? cur : best),
     { heure: '—', vues: 0 },
@@ -87,54 +154,63 @@ export default async function StatsAvanceesPage() {
   const categorieLabel =
     CATEGORIES_MAP[prestataire.categorie] ?? prestataire.categorie
 
+  // Pluralisation FR (1 → "", N>1 → "s")
+  const pluralS = (n: number) => (n > 1 ? 's' : '')
+
   return (
     <>
       <DashboardHeader
-        kicker="Stats avancées"
+        kicker={`Le détail des copines, ${prestataire.nom}`}
         titre={
-          <>
-            Ton audience,{' '}
-            <em className="font-serif italic text-or">en profondeur.</em>
+          <>Voilà ce que les copines{' '}
+            <em className="font-serif italic text-or">pensent de toi.</em>
           </>
         }
-        lead={`Carte des villes, pics horaires, benchmark catégorie. Sur les ${SINCE_DAYS} derniers jours.`}
+        lead={`Sur les ${SINCE_DAYS} derniers jours, en profondeur.`}
         actions={
           <Link
             href="/dashboard/prestataire"
             className="inline-flex h-11 items-center gap-2 rounded-full border border-or/40 px-5 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-or hover:bg-blanc"
           >
-            ← Retour au dashboard
+            ← Retour à mon espace
           </Link>
         }
       />
 
-      {/* KPIs résumé */}
+      {/* ─── KPIs résumé ─────────────────────────────────────────── */}
       <section className="px-6 py-10 md:px-12 md:py-14">
         <div className="mb-8 flex items-center gap-4">
           <GoldLine width={40} />
-          <span className="overline text-or">Vue d&apos;ensemble · {SINCE_DAYS}j</span>
+          <span className="overline text-or">
+            Les copines te découvrent · {SINCE_DAYS} derniers jours
+          </span>
         </div>
         <div className="grid gap-4 md:grid-cols-3">
           <StatCard
-            kicker="Vues totales 30j"
-            value={myViewsCount.toLocaleString('fr-FR')}
-            hint="Visiteuses uniques de ta fiche"
+            kicker="Au total"
+            value={`${myViewsCount.toLocaleString('fr-FR')} copine${pluralS(myViewsCount)}`}
+            hint="se sont arrêtées sur ton profil"
+            variant="vert"
             index={0}
           />
           <StatCard
-            kicker="Top ville"
+            kicker="Elles viennent surtout de"
             value={topVille ? topVille.ville : '—'}
-            hint={topVille ? `${topVille.vues} vues` : 'Pas encore de données'}
+            hint={
+              topVille
+                ? `${topVille.vues.toLocaleString('fr-FR')} copine${pluralS(topVille.vues)} de cette ville`
+                : 'On découvrira ta ville préférée sous peu'
+            }
             variant="or"
             index={1}
           />
           <StatCard
-            kicker="Pic horaire"
+            kicker="Quand elles te regardent"
             value={topHeure.vues > 0 ? topHeure.heure : '—'}
             hint={
               topHeure.vues > 0
-                ? `${topHeure.vues} vues à ${topHeure.heure} (UTC)`
-                : 'Pas encore de pic identifiable'
+                ? `Pic à ${topHeure.heure} (heure UTC)`
+                : 'Pas encore d’heure de pic identifiable'
             }
             variant="vert"
             index={2}
@@ -142,17 +218,17 @@ export default async function StatsAvanceesPage() {
         </div>
       </section>
 
-      {/* Carte des villes */}
+      {/* ─── Carte des villes ────────────────────────────────────── */}
       <section className="bg-blanc px-6 py-12 md:px-12 md:py-16">
         <div className="rounded-sm border border-or/15 bg-creme-soft p-6 md:p-8">
           <div className="mb-4 flex items-start justify-between gap-4">
             <div>
-              <p className="overline text-or">Carte des villes</p>
+              <p className="overline text-or">D&apos;où viennent les copines</p>
               <h2 className="mt-2 font-serif text-2xl font-light text-vert">
-                D&apos;où viennent tes copines.
+                Tes 8 villes-pépites.
               </h2>
               <p className="mt-1 text-[12px] italic text-texte-sec">
-                Top 8 villes par nombre de vues sur 30j.
+                Chaque barre, c&apos;est une ville où on parle de toi.
               </p>
             </div>
           </div>
@@ -160,17 +236,17 @@ export default async function StatsAvanceesPage() {
         </div>
       </section>
 
-      {/* Pics horaires */}
+      {/* ─── Pics horaires ───────────────────────────────────────── */}
       <section className="px-6 py-12 md:px-12 md:py-16">
         <div className="rounded-sm border border-or/15 bg-creme-soft p-6 md:p-8">
           <div className="mb-4 flex items-start justify-between gap-4">
             <div>
-              <p className="overline text-or">Pics horaires</p>
+              <p className="overline text-or">Quand on te regarde</p>
               <h2 className="mt-2 font-serif text-2xl font-light text-vert">
-                Quand on te regarde.
+                Les heures où elles s&apos;arrêtent sur ton profil.
               </h2>
               <p className="mt-1 text-[12px] italic text-texte-sec">
-                Distribution des vues par heure de la journée (UTC) sur 30j.
+                Réparti par heure de la journée (UTC) sur les 30 derniers jours.
                 Idéal pour caler tes posts Insta ou tes annonces d&apos;événements.
               </p>
             </div>
@@ -179,25 +255,120 @@ export default async function StatsAvanceesPage() {
         </div>
       </section>
 
-      {/* Benchmark catégorie */}
+      {/* ─── Tap-to-contact tracé (nouveau Sprint K — Cercle Pro only) ─ */}
+      <section className="bg-blanc px-6 py-12 md:px-12 md:py-16">
+        <div className="mb-6 flex items-center gap-4">
+          <GoldLine width={40} />
+          <span className="overline text-or">Elles ont fait le pas</span>
+        </div>
+
+        {clicks.length >= 1 ? (
+          <>
+            <h2 className="mb-8 font-serif text-[clamp(1.75rem,3vw,2.25rem)] font-light leading-[1.15] text-vert">
+              <em className="italic text-or">{clicks.length}</em> copine{pluralS(clicks.length)}{' '}
+              {clicks.length > 1 ? 'sont passées' : 'est passée'} de la
+              curiosité à l&apos;action.
+            </h2>
+            <div className="overflow-hidden rounded-sm border border-or/15 bg-blanc">
+              <table className="w-full">
+                <thead className="border-b border-or/10 bg-creme-soft">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
+                      Comment elles t&apos;ont cherchée
+                    </th>
+                    <th className="px-4 py-3 text-right text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
+                      Cette semaine
+                    </th>
+                    <th className="px-4 py-3 text-right text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
+                      Ce mois
+                    </th>
+                    <th className="px-4 py-3 text-right text-[11px] font-medium tracking-[0.22em] text-or uppercase md:px-6">
+                      Total
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {contactRows.map((row, i) => (
+                    <tr
+                      key={row.channel}
+                      className={
+                        i === contactRows.length - 1
+                          ? ''
+                          : 'border-b border-or/10'
+                      }
+                    >
+                      <td className="px-4 py-4 md:px-6">
+                        <span className="flex items-center gap-3">
+                          <span
+                            className="text-[18px] leading-none"
+                            aria-hidden="true"
+                          >
+                            {row.emoji}
+                          </span>
+                          <span className="text-[14px] font-medium text-vert">
+                            {row.label}
+                          </span>
+                        </span>
+                      </td>
+                      <td className="px-4 py-4 text-right text-[14px] text-texte md:px-6">
+                        {row.last7.toLocaleString('fr-FR')}
+                      </td>
+                      <td className="px-4 py-4 text-right text-[14px] text-texte md:px-6">
+                        {row.last30.toLocaleString('fr-FR')}
+                      </td>
+                      <td className="px-4 py-4 text-right font-serif text-[15px] italic text-or-deep md:px-6">
+                        {row.total.toLocaleString('fr-FR')}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        ) : (
+          <div className="rounded-sm border border-or/15 bg-creme-soft p-8 md:p-12">
+            <h2 className="font-serif text-[clamp(1.75rem,3vw,2.25rem)] font-light leading-[1.15] text-vert">
+              Pour qu&apos;elles te contactent, il faut qu&apos;elles{' '}
+              <em className="italic text-or">trouvent comment.</em>
+            </h2>
+            <p className="mt-4 max-w-2xl text-[15px] leading-[1.7] text-texte-sec">
+              Vérifie que tes infos contact sont à jour sur ta fiche —
+              c&apos;est la première chose qu&apos;on regarde.
+            </p>
+            {prestataire.slug && (
+              <Link
+                href={`/prestataire-v2/${prestataire.slug}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-7 inline-flex h-12 items-center gap-2 rounded-full bg-vert px-7 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+              >
+                Voir ma fiche publique
+                <span className="text-or-light" aria-hidden="true">→</span>
+              </Link>
+            )}
+          </div>
+        )}
+      </section>
+
+      {/* ─── Où tu te situes (benchmark catégorie reframé) ───────── */}
       <section className="bg-vert px-6 py-12 text-creme md:px-12 md:py-16">
         <div className="mx-auto max-w-3xl">
           <div className="flex items-center gap-4">
             <GoldLine width={40} />
-            <span className="overline text-or">Benchmark catégorie</span>
+            <span className="overline text-or">Où tu te situes</span>
           </div>
           <h2 className="mt-4 font-serif text-3xl font-light text-creme md:text-4xl">
-            Où tu te situes en{' '}
+            Parmi les copines en{' '}
             <em className="italic text-or">{categorieLabel}</em>.
           </h2>
 
           {percentile !== null && (
             <div className="mt-8 rounded-sm border border-or/30 bg-vert-dark/40 p-6 md:p-8">
               <p className="font-serif text-[64px] font-light leading-none text-or md:text-[80px]">
-                {percentile}
+                {percentile}<span className="text-[36px] md:text-[44px]">e</span>
               </p>
               <p className="mt-1 text-[11px] tracking-[0.28em] text-or-light uppercase">
-                Percentile dans ta catégorie
+                Tu te places ici dans ta catégorie
               </p>
             </div>
           )}
@@ -207,16 +378,17 @@ export default async function StatsAvanceesPage() {
           </p>
 
           <p className="mt-6 text-[11px] italic text-creme/55">
-            Comparaison vs les autres prestataires Premium et Cercle Pro de la
-            catégorie {categorieLabel} sur la même fenêtre 30j (échantillon
-            de {peerCounts.length} prestataires).
+            Comparé aux autres copines de la catégorie {categorieLabel}{' '}
+            (paliers Premium et Cercle Pro, sur la même fenêtre 30 jours,
+            échantillon de {peerCounts.length} fiches).
           </p>
         </div>
       </section>
 
-      {/* Footer reassurance */}
-      <p className="px-6 pb-12 pt-8 text-center font-sans text-[12px] italic text-texte-sec">
-        Stats avancées · Cercle Pro · données agrégées 30j glissants
+      {/* ─── Footer transparence ──────────────────────────────────── */}
+      <p className="px-6 pb-12 pt-8 text-center font-sans text-[12px] italic text-texte-sec md:px-12">
+        On compte précieusement chaque pas qu&apos;une copine fait vers
+        toi, depuis le 9 mai 2026.
       </p>
     </>
   )


### PR DESCRIPTION
**Sprint K** · mirror du reframe lieu (PR-B2 #79) sur les **2 pages stats du dashboard prestataire**. Décision Jiji 2026-05-09 : avant d'ouvrir les ventes, harmoniser TOUT le dashboard avec la voix Sara — chaque chiffre devient un récit émotionnel valorisant. Une cliente Cercle Pro à 99€/mois qui voit son dashboard en jargon SaaS churne.

## Symptôme

Après PR-B2, le dashboard owner **lieu** affiche des copies émotionnelles ("X copines se sont arrêtées sur ta fiche", "Le carnet d'or des copines", "Elles ont fait le pas"…). Mais le dashboard **prestataire** (Standard/Premium/Cercle Pro) restait en jargon SaaS : "Vues totales", "Stats avancées", "Clics WhatsApp", "Audience", "Benchmark catégorie", etc.

Inconsistance perceptible côté cliente — surtout pour une Cercle Pro à 99€/mois qui mérite un dashboard qui raconte ses copines, pas qui débite des métriques.

## Root cause

Le reframe avait été fait uniquement sur le dashboard lieu en PR-B2. Les pages prestataire n'avaient jamais été touchées sur l'aspect copy/voix.

## Fix

### Étape 1 — Audit complet (10 fichiers `app/dashboard/prestataire/**/*.tsx`)

Audit ligne-par-ligne, partagé pour validation Jiji avant tout edit.

| Fichier | Verdict | Raison |
|---|---|---|
| `page.tsx` (accueil) | 🔴 À reframer | Stats brutes, jargon |
| `stats-avancees/page.tsx` | 🔴 À reframer | Page Cercle Pro, le plus exposé |
| `layout.tsx` (sidebar) | 🟢 OK | Aucun jargon |
| `avis/page.tsx` | 🟢 OK | Pas de section stats |
| `abonnement/page.tsx` | 🟢 OK | Déjà voix Sara depuis PR #75 |
| `devis`, `evenements`, `fiche`, `parametres` | 🟡 hors scope | Forms / sous-features |

### Étape 2 — Reframe (ce commit)

#### `app/dashboard/prestataire/page.tsx` (accueil) — 6 changements

**Header** : kicker `"Ton tableau de bord, [nom]"` + titre `"Voilà ce que les copines pensent de toi."`

**Section stats — gating riche/jeune (NEW)** :
- `viewsRichMode = viewsTotal >= 10 || viewsLast7 >= 3`
- Mode riche Standard (2 cards): `"[N] copines / se sont arrêtées sur ton profil"` + `"[N] / ont voulu te joindre, tous canaux confondus"`
- Mode riche Premium+ (4 cards): `"[N] copines"` + `"Cette semaine"` + `"Elles t'ont WhatsApp"` + `"Elles ont voulu te joindre"`
- Mode jeune (tous paliers): `"Les premières copines arrivent."` + 3 actions 01/02/03 (Insta story / QR code / événement saisonnier → `/dashboard/prestataire/evenements`)

**Bandeau Standard → Premium** : reframé sans changer la logique de palier
- `"Le détail des copines qui t'ont voulue, semaine après semaine."`

**Bandeau Cercle Pro stats avancées** : reframé
- Overline `"Le détail des copines · disponible"` + CTA `"Voir le détail"`

**Chart 30j** : gating renforcé (`isPremiumOrAbove && viewsRichMode && views30d >= 5`)
- Titre : `"Quand on s'arrête sur ton profil"` + sub `"Chaque pic, c'est une copine qui t'a découverte."`

**Footer transparence (NEW)** : `"On compte précieusement chaque pas qu'une copine fait vers toi, depuis le 9 mai 2026."`

**Section Avis récents** : intacte (déjà voix Sara compatible).

#### `app/dashboard/prestataire/stats-avancees/page.tsx` (Cercle Pro) — 7 changements

**Header** : `"Le détail des copines, [nom]"` + `"Voilà ce que les copines pensent de toi."` (cohérent avec accueil)

**KPIs résumé (3 cards reformulées)** :
- `"Au total / [N] copines / se sont arrêtées sur ton profil"`
- `"Elles viennent surtout de / [ville] / [N] copines de cette ville"`
- `"Quand elles te regardent / [heure] / Pic à [heure] (UTC)"`

**Carte des villes** : titre `"Tes 8 villes-pépites."` + sub `"Chaque barre, c'est une ville où on parle de toi."`

**Pics horaires** : titre `"Les heures où elles s'arrêtent sur ton profil."`

**🆕 Section tap-to-contact tracé (NOUVELLE — décision Jiji (c))** : exclusivité Cercle Pro
- Mode riche (≥1 clic) : tableau par canal avec emoji + verbes émotionnels :

| Canal | Emoji | Label voix Sara |
|---|---|---|
| whatsapp | 💬 | Ont voulu te WhatsApper |
| phone | 📞 | Ont voulu t'appeler |
| email | ✉️ | Ont voulu t'écrire |
| website | 🌐 | Ont voulu visiter ton site |
| instagram | 📸 | Ont voulu te suivre sur Insta |
| tiktok | 🎵 | Ont voulu te suivre sur TikTok |
| linkedin | 💼 | Ont voulu te connecter sur LinkedIn |
| facebook | 👥 | Ont voulu te suivre sur Facebook |
| youtube | ▶️ | Ont voulu voir tes vidéos |

- Mode encouragement (0 clic) : `"Pour qu'elles te contactent, il faut qu'elles trouvent comment."` + CTA `"Voir ma fiche publique"`

9 canaux `profile_contacts` (mig 15) — distinct de `place_contacts` (linkedin au lieu de google_maps).

**Benchmark catégorie** : reframé
- Overline `"Où tu te situes"` + titre `"Parmi les copines en [cat]."`
- Label percentile : `"Percentile dans ta catégorie"` → `"Tu te places ici dans ta catégorie"` + suffixe ordinal "e" stylé

**Footer transparence** : `"On compte précieusement chaque pas qu'une copine fait vers toi, depuis le 9 mai 2026."` (cohérent avec accueil + lieu)

## Audit voix Sara

Grep complet sur les 2 fichiers, mots interdits :
- `vues / saves / stats / métriques / performance / utilisateurs / membres / communauté / plateforme / insights / engagement / conversion / audience`

✅ **Aucune fuite UI public.** Tous les hits restants sont commentaires de code, noms de variables internes (`viewsTotal`, `vues30j`, `myViewsCount`…), imports, ou slugs URL.

## Changements techniques minimaux

- 1 nouvelle query Supabase sur `stats-avancees`: `profile_contacts` (RLS owner-read OK via mig 15, pas besoin service-role)
- `CONTACT_CHANNEL_COPY` map ajouté (mirror dashboard lieu mais avec linkedin)
- Helper `pluralS()` pour pluralisation FR
- **Aucune migration BDD**
- **Aucun nouveau composant** (StatCard / VuesAreaChart / AdvancedCharts intacts — vérifié qu'ils ne contiennent aucune copie hardcodée)
- **Aucune nouvelle dépendance**

## Tests manuels à valider sur Vercel preview

- [ ] Standard data riche : 2 cards émotionnelles + bandeau "Passe en Premium" reframé
- [ ] Standard data jeune : 3 actions 01/02/03 + bandeau Premium reframé
- [ ] Premium+ data riche : 4 cards émotionnelles + chart 30j (si ≥5 vues 30d)
- [ ] Premium+ data jeune : 3 actions + pas de chart
- [ ] Cercle Pro : bandeau "Le détail des copines" + accès `/stats-avancees`
- [ ] Stats avancées : 3 KPIs reformulés + carte villes + pics horaires + nouveau tableau tap-to-contact + benchmark "Où tu te situes" + footer transparence
- [ ] Stats avancées 0 clic : EmptyState "Pour qu'elles te contactent..." + CTA "Voir ma fiche publique"
- [ ] Founder (`is_founder=true`, palier='standard') : voit la version Cercle Pro effective (déjà géré par `getEffectivePalier` PR #75)

## Risques

- **Faible.** Pure copy + gating logique, aucune modif de logique business, aucune migration.
- **Composants partagés intacts** (StatCard / Charts) — pas de risque de régression latente sur d'autres pages qui les consomment.
- **Backward compat** : tous les call sites de queries existantes (`profile_views`, `profile_contacts`, `recommendations`, `events`) inchangés. Une seule query ajoutée (profile_contacts en lecture sur stats-avancees).

## Sécurité

- ✅ `requirePrestataire()` au layout level → pages owner-gated
- ✅ RLS `profile_contacts` mig 15 owner-read suffit → pas de service-role
- ✅ Aucun nouveau write path
- ✅ Aucun nouveau pattern admin
- ✅ Auth + 3 paliers prestataires intouchés (juste reformulation copy)

## Refs

- `idees.md` (Sprint K planifié)
- PR-B2 [#79](https://github.com/jihaneessmaliki-sys/hilmy/pull/79) (template reframe lieu)
- Brief Sprint K 2026-05-09 (Mode Hilmy UX + Tech)

## Stop next

Sprint K mergé + déployé → on attend ton GO pour Phase 2A PR-C (public UI Sélection Hilmy : pastille + tri prio feed + photos illimitées).