### PR TITLE
feat(media): photos gating server-side via SQL triggers (mig 42)

### DIFF
--- a/app/dashboard/prestataire/fiche/page.tsx
+++ b/app/dashboard/prestataire/fiche/page.tsx
@@ -190,9 +190,10 @@ export default function MaFichePage() {
     if (!userId || !profileId) return
     if (!canUploadMorePhotos(palier, draft.galerie.length)) {
       const limit = PHOTO_LIMIT[palier]
+      const nextPalier = palier === 'standard' ? 'Premium' : 'Cercle Pro'
       setError(
         limit !== null
-          ? `Limite atteinte (${limit} photos pour le palier ${palier === 'standard' ? 'Standard' : 'Premium'}). Passe au palier supérieur depuis /tarifs pour en ajouter plus.`
+          ? `Tu as atteint ta limite de ${limit} photo${limit > 1 ? 's' : ''}. Passe en ${nextPalier} pour en ajouter plus, ou réorganise celles que tu as déjà.`
           : 'Limite atteinte.',
       )
       return

--- a/lib/palier-limits.ts
+++ b/lib/palier-limits.ts
@@ -1,14 +1,21 @@
 /**
- * Limites quantitatives par palier prestataire.
+ * Limites quantitatives par palier prestataire ET par palier lieu.
  * Single source of truth — alignée avec PALIER_INFO.features dans
  * app/tarifs/_lib/pricing.ts.
  *
+ * ⚠️ Caps photos doivent rester alignés avec le trigger SQL
+ * `enforce_profiles_galerie_cap` / `enforce_places_photos_cap`
+ * (mig 42). Si tu changes ici, change aussi en BDD — sinon UI ment au
+ * user (côté client il pense pouvoir, côté serveur le trigger rejette).
+ *
  * Quand on change ces valeurs, mettre à jour aussi :
+ *  - supabase/migrations/42_photos_gating_server_side.sql (caps SQL)
  *  - app/tarifs/_lib/pricing.ts (libellés des features)
  *  - components/v2/PalierBadge.tsx (badges)
  */
 
 import type { Palier } from '@/app/tarifs/_lib/pricing'
+import type { LieuPalier } from '@/lib/permissions-lieux'
 
 /**
  * Nombre maximum de photos dans la galerie prestataire selon le palier.
@@ -40,6 +47,45 @@ export function canUploadMorePhotos(
  */
 export function photoCountLabel(palier: Palier, currentCount: number): string {
   const limit = PHOTO_LIMIT[palier]
+  if (limit === null) {
+    return `${currentCount} photo${currentCount > 1 ? 's' : ''} · illimité`
+  }
+  return `${currentCount} / ${limit} photos`
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   PALIERS LIEUX (places.palier — mig 41)
+   ═══════════════════════════════════════════════════════════════════ */
+
+/**
+ * Nombre maximum de photos pour la galerie d'un lieu selon le palier.
+ *  - aucun           : 8 photos (cap "matière minimale" pour fiche gratuite)
+ *  - selection_hilmy : illimité (matérialisé par null)
+ *
+ * ⚠️ Doit rester aligné avec le trigger SQL `enforce_places_photos_cap`
+ * (mig 42). Si tu changes ici, change aussi en BDD.
+ */
+export const PLACE_PHOTO_LIMIT: Record<LieuPalier, number | null> = {
+  aucun: 8,
+  selection_hilmy: null,
+}
+
+/** Helper boolean : le lieu peut-il ajouter une nouvelle photo ? */
+export function canUploadMorePlacePhotos(
+  palier: LieuPalier,
+  currentCount: number,
+): boolean {
+  const limit = PLACE_PHOTO_LIMIT[palier]
+  if (limit === null) return true
+  return currentCount < limit
+}
+
+/** Libellé compteur côté UI lieu (mirror photoCountLabel pour prestataires). */
+export function placePhotoCountLabel(
+  palier: LieuPalier,
+  currentCount: number,
+): string {
+  const limit = PLACE_PHOTO_LIMIT[palier]
   if (limit === null) {
     return `${currentCount} photo${currentCount > 1 ? 's' : ''} · illimité`
   }

--- a/supabase/migrations/42_photos_gating_server_side.sql
+++ b/supabase/migrations/42_photos_gating_server_side.sql
@@ -1,0 +1,155 @@
+-- =====================================================================
+-- HILMY · 42 — Photos gating server-side (Phase 3 · PR-1)
+--
+-- Trigger BEFORE UPDATE on profiles.galerie qui REJETTE l'UPDATE si
+-- jsonb_array_length(NEW.galerie) > cap selon palier+is_founder ET si
+-- la nouvelle galerie est PLUS LONGUE que l'ancienne (downgrade gracieux).
+--
+-- Trigger BEFORE UPDATE on places.photos avec même logique selon
+-- places.palier ('aucun'=8, 'selection_hilmy'=illimité).
+--
+-- Caps DOIVENT rester alignés avec lib/palier-limits.ts (PHOTO_LIMIT +
+-- PLACE_PHOTO_LIMIT). Si tu changes les valeurs ici, change aussi le TS
+-- — sinon UI ment au user (côté client il pense pouvoir, côté serveur
+-- le trigger rejette).
+--
+-- Idempotente. Voir bas de fichier pour rollback.
+-- ⚠️ Application en prod : SUR DEMANDE EXPLICITE de Jiji uniquement,
+--    après backup Supabase manuel.
+-- =====================================================================
+
+
+-- =====================================================================
+-- 1. Trigger profiles.galerie cap
+-- =====================================================================
+
+create or replace function public.enforce_profiles_galerie_cap()
+returns trigger
+language plpgsql
+as $$
+declare
+  v_old_count int;
+  v_new_count int;
+  v_cap int;
+begin
+  -- Skip si galerie n'a pas changé (UPDATE d'autres colonnes)
+  if old.galerie is not distinct from new.galerie then
+    return new;
+  end if;
+
+  -- Cap selon palier effectif. Founder = cercle_pro effectif = illimité,
+  -- aligné avec getEffectivePalier() côté TS (lib/permissions.ts).
+  v_cap := case
+    when new.is_founder = true then null
+    when new.palier = 'cercle_pro' then null
+    when new.palier = 'premium' then 20
+    when new.palier = 'standard' then 5
+    else 5  -- défaut conservateur (palier inconnu / null)
+  end;
+
+  -- null = illimité → skip
+  if v_cap is null then
+    return new;
+  end if;
+
+  v_old_count := coalesce(jsonb_array_length(coalesce(old.galerie, '[]'::jsonb)), 0);
+  v_new_count := coalesce(jsonb_array_length(coalesce(new.galerie, '[]'::jsonb)), 0);
+
+  -- Reject seulement si NEW > cap ET NEW augmente vs OLD.
+  -- Permet le "downgrade gracieux" : un Premium qui passe en Standard
+  -- avec 18 photos peut les conserver et les réduire, juste pas en
+  -- ajouter au-delà du nouveau cap (5).
+  if v_new_count > v_cap and v_new_count > v_old_count then
+    raise exception
+      'Photo cap exceeded for palier %: % photos > % max (was %)',
+      new.palier, v_new_count, v_cap, v_old_count
+      using errcode = 'check_violation';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_enforce_galerie_cap on public.profiles;
+create trigger profiles_enforce_galerie_cap
+  before update of galerie on public.profiles
+  for each row execute function public.enforce_profiles_galerie_cap();
+
+
+-- =====================================================================
+-- 2. Trigger places.photos cap
+-- =====================================================================
+
+create or replace function public.enforce_places_photos_cap()
+returns trigger
+language plpgsql
+as $$
+declare
+  v_old_count int;
+  v_new_count int;
+  v_cap int;
+begin
+  if old.photos is not distinct from new.photos then
+    return new;
+  end if;
+
+  v_cap := case
+    when new.palier = 'selection_hilmy' then null  -- illimité
+    else 8  -- 'aucun' (default mig 41) = 8 photos max
+  end;
+
+  if v_cap is null then
+    return new;
+  end if;
+
+  v_old_count := coalesce(jsonb_array_length(coalesce(old.photos, '[]'::jsonb)), 0);
+  v_new_count := coalesce(jsonb_array_length(coalesce(new.photos, '[]'::jsonb)), 0);
+
+  if v_new_count > v_cap and v_new_count > v_old_count then
+    raise exception
+      'Photo cap exceeded for place palier %: % photos > % max (was %)',
+      new.palier, v_new_count, v_cap, v_old_count
+      using errcode = 'check_violation';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists places_enforce_photos_cap on public.places;
+create trigger places_enforce_photos_cap
+  before update of photos on public.places
+  for each row execute function public.enforce_places_photos_cap();
+
+
+-- =====================================================================
+-- 3. Comments
+-- =====================================================================
+
+comment on function public.enforce_profiles_galerie_cap() is
+  'Server-side photo cap enforcement for prestataires. Caps must stay '
+  'aligned with lib/palier-limits.ts PHOTO_LIMIT. Founder is_founder=true '
+  '→ unlimited (cercle_pro effectif). Downgrade-gracieux : autorise les '
+  'reductions au-dessus du cap, rejette uniquement les augmentations '
+  'au-dessus du cap.';
+
+comment on function public.enforce_places_photos_cap() is
+  'Server-side photo cap enforcement for places. Cap aligned with '
+  'lib/palier-limits.ts PLACE_PHOTO_LIMIT (aucun=8, selection_hilmy='
+  'unlimited). Same downgrade-gracieux logic que profiles.';
+
+
+-- =====================================================================
+-- Reload PostgREST schema cache
+-- =====================================================================
+notify pgrst, 'reload schema';
+
+
+-- =====================================================================
+-- ROLLBACK (à exécuter manuellement si besoin)
+-- =====================================================================
+-- drop trigger if exists places_enforce_photos_cap on public.places;
+-- drop trigger if exists profiles_enforce_galerie_cap on public.profiles;
+-- drop function if exists public.enforce_places_photos_cap();
+-- drop function if exists public.enforce_profiles_galerie_cap();
+-- =====================================================================


### PR DESCRIPTION
**Sprint 3 · PR-1** · Phase 3 photos+vidéos · première sous-PR du découpage 3-PRs (PR-2 = infra vidéo, PR-3 = UI vidéo).

## Symptôme

Le gating photos prestataires existait **uniquement côté client** ([lib/palier-limits.ts](lib/palier-limits.ts) + check dans [fiche/page.tsx](app/dashboard/prestataire/fiche/page.tsx)). Un user technique (devtools / supabase-js direct) pouvait bypass et UPDATE `profiles.galerie` avec autant de photos qu'il voulait. Pas de risque immédiat (les 2 utilisatrices test n'allaient pas le faire), mais defense in depth manquante avant ouverture des ventes.

Côté lieux, **aucun cap** non plus.

## Root cause

Les helpers TS étaient seuls — pas de check côté BDD. Le brief original Sprint 3 proposait `SELECT count(*) FROM prestataire_photos` mais cette table n'existe pas (les photos sont dans `profiles.galerie` jsonb inline, cf [docs/db-schema-summary.md](docs/db-schema-summary.md)).

## Fix : 2 triggers BEFORE UPDATE jsonb

### Migration 42 — `supabase/migrations/42_photos_gating_server_side.sql`

| Cible | Cap |
|---|---|
| `profiles` is_founder=true OU palier=cercle_pro | illimité |
| `profiles` palier=premium | 20 |
| `profiles` palier=standard | 5 |
| `places` palier=selection_hilmy | illimité |
| `places` palier=aucun (default) | 8 |

**Logique downgrade-gracieux** : reject seulement si `NEW > cap AND NEW > OLD`. Permet à un Premium qui passe à Standard avec 18 photos de :
- garder ses 18 photos
- réduire (17, 10, 5)
- mais **pas en ajouter** (19 → REJECTED)

`RAISE EXCEPTION` avec `errcode='check_violation'` (23514) → remontée côté supabase-js comme erreur. Pas SECURITY DEFINER (aligné `bump_profile_nb_vues` mig 15 prod-tested).

### TS helpers — `lib/palier-limits.ts`

Étendu avec :
- `PLACE_PHOTO_LIMIT: { aucun: 8, selection_hilmy: null }`
- `canUploadMorePlacePhotos(palier, count)` (mirror)
- `placePhotoCountLabel(palier, count)` (mirror)

Ces helpers seront consommés par le futur form édition lieu (PR ultérieure — décision Jiji B(γ) : on défer l'UI lieu pour ce sprint).

### UI message voix Sara — `app/dashboard/prestataire/fiche/page.tsx:191-198`

**Avant :**
```
"Limite atteinte (5 photos pour le palier Standard). Passe au palier
supérieur depuis /tarifs pour en ajouter plus."
```

**Après (voix Sara, mirror Sprint K) :**
```
"Tu as atteint ta limite de 5 photos. Passe en Premium pour en ajouter
plus, ou réorganise celles que tu as déjà."
```

Fix au passage le bug ternaire qui ne couvrait pas Cercle Pro (pas critique car ce palier n'arrive jamais dans cette branche via le check `canUploadMorePhotos`, mais propre).

## Smoke tests prod (6/6 ✅, validés post-apply)

| # | Test | Résultat |
|---|---|---|
| 1 | profiles cap=5 + 6 photos | REJECTED (HTTP 400, 23514) |
| 2 | profiles cap=5 + 5 photos | OK |
| 3 | profiles cap=5 + 6 photos (était 5) | REJECTED |
| 4 | profiles downgrade gracieux : premium→18 photos, switch standard, update 17 photos | OK (réduction autorisée) |
| 5 | profiles : update 19 photos sur standard (était 18) | REJECTED (augmentation rejetée) |
| 6 | places cap=8 + 9 photos sur palier=aucun | REJECTED |
| 7 | places palier=selection_hilmy + 25 photos | OK |

Cleanup post-tests : Atelier Nouage et Nora Benkhaled restorés à `photos=[]` / `galerie=[]`. `created_by_user_id` Atelier Nouage gardé sur Jiji (utile pour PR-2/3 vidéos lieu).

## Risques

- **Faible.** Les triggers fire uniquement sur `UPDATE OF galerie/photos`, pas sur les UPDATE d'autres colonnes. Les fiches existantes en prod ne sont **pas affectées** tant qu'on n'UPDATE pas leurs photos.
- **Backward compat** : tous les UPDATE qui ne touchent pas `galerie` / `photos` continuent de fonctionner sans impact.
- **Idempotence** : la migration utilise `create or replace function`, `drop trigger if exists` puis `create trigger`. Replay sans dégât.
- **Rollback documenté** en commentaires bas de fichier (drop dans ordre inverse).

## Sécurité

- ✅ Defense in depth : trigger BDD doublé du check client-side existant
- ✅ `errcode='check_violation'` cohérent avec autres CHECK constraints du repo
- ✅ Pas de nouvelle policy RLS, pas de nouveau pattern admin
- ✅ Aucun nouveau write path
- ✅ Auth + 3 paliers prestataires intouchés (juste enforcement automatique)

## Backup

- ✅ Backup Supabase confirmé Jiji avant apply (8 backups physical disponibles, dernier 2026-05-09 00:28 UTC + PITR 7j)
- Migration appliquée prod via `bash scripts/run-migration.sh ...` (HTTP 201)

## Out of scope

- Form édition lieu côté dashboard owner (décision B(γ) — helpers TS prêts mais UI déférée)
- Validation server-side photos via API route (a opté trigger SQL via décision A(a))
- Storage policy size cap photos (existant déjà à 5MB par bucket)
- **Vidéos MP4** (PR-2 = infra mig + buckets + helpers, PR-3 = UI Upload + Player + intégration fiches)

## Refs

- Brief Sprint 3 + 6 décisions par défaut validées Jiji 2026-05-09
- [idees.md](idees.md) — Sprint 3 planifié
- [docs/db-schema-summary.md](docs/db-schema-summary.md) (#81) — référence schéma
- Mig 41 PR-A ([#77](https://github.com/jihaneessmaliki-sys/hilmy/pull/77)) — pattern places.palier
- Mig 39 ([#73](https://github.com/jihaneessmaliki-sys/hilmy/pull/73)) — pattern is_founder

## Stop next

Je t'attends pour relire/tester puis GO merge. Après merge, on enchaîne **PR-2** (infra vidéo : mig `profile_videos` + `place_videos` + buckets + lib helpers, ~400 lignes, ~2h CC).