### PR TITLE
feat(media): vidéo infra — mig 43 + buckets + helpers TS (PR-2)

### DIFF
--- a/lib/palier-limits.ts
+++ b/lib/palier-limits.ts
@@ -8,8 +8,15 @@
  * (mig 42). Si tu changes ici, change aussi en BDD — sinon UI ment au
  * user (côté client il pense pouvoir, côté serveur le trigger rejette).
  *
+ * Caps vidéos (durée max + count max) sont APPLIQUÉS CÔTÉ API ROUTE
+ * (PR-3, pas de trigger SQL). Le CHECK constraint duration_seconds<=90
+ * (mig 43) est juste la borne dure absolue. Si tu changes les caps par
+ * palier ici, le client affichera des limites trompeuses tant que
+ * l'API route n'est pas synchronisée.
+ *
  * Quand on change ces valeurs, mettre à jour aussi :
- *  - supabase/migrations/42_photos_gating_server_side.sql (caps SQL)
+ *  - supabase/migrations/42_photos_gating_server_side.sql (caps photos SQL)
+ *  - supabase/migrations/43_videos_infra.sql (CHECK durée vidéo SQL)
  *  - app/tarifs/_lib/pricing.ts (libellés des features)
  *  - components/v2/PalierBadge.tsx (badges)
  */
@@ -90,4 +97,111 @@ export function placePhotoCountLabel(
     return `${currentCount} photo${currentCount > 1 ? 's' : ''} · illimité`
   }
   return `${currentCount} / ${limit} photos`
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   VIDÉOS PRESTATAIRES (mig 43)
+   ═══════════════════════════════════════════════════════════════════ */
+
+/**
+ * Durée maximum d'une vidéo en secondes selon le palier prestataire.
+ *  - standard   : 0 → pas de vidéo autorisée
+ *  - premium    : 60 secondes par vidéo
+ *  - cercle_pro : 90 secondes par vidéo
+ *
+ * ⚠️ Doit rester aligné avec le CHECK constraint
+ * `profile_videos_duration_check (duration_seconds <= 90)` (mig 43).
+ * Le cap dur BDD est 90 (max absolu) ; le cap par palier est appliqué
+ * côté API route avant insertion (PR-3).
+ */
+export const VIDEO_DURATION_MAX: Record<Palier, number> = {
+  standard: 0,
+  premium: 60,
+  cercle_pro: 90,
+}
+
+/**
+ * Nombre maximum de vidéos par fiche prestataire selon le palier.
+ *  - standard   : 0 → pas de vidéo
+ *  - premium    : 1 vidéo
+ *  - cercle_pro : illimité (matérialisé par null)
+ *
+ * Pas de trigger SQL pour ce cap (cf décision Jiji 2026-05-10) :
+ * validation côté API route en PR-3, plus simple et testable.
+ */
+export const VIDEO_COUNT_MAX: Record<Palier, number | null> = {
+  standard: 0,
+  premium: 1,
+  cercle_pro: null,
+}
+
+/** Helper boolean : peut-on uploader une vidéo de plus ? */
+export function canUploadVideo(palier: Palier, currentCount: number): boolean {
+  const max = VIDEO_COUNT_MAX[palier]
+  if (max === 0) return false
+  return max === null || currentCount < max
+}
+
+/** Cap durée max pour ce palier (en secondes). 0 = pas de vidéo autorisée. */
+export function getVideoDurationCap(palier: Palier): number {
+  return VIDEO_DURATION_MAX[palier]
+}
+
+/** Libellé compteur vidéos UI ("0 / 1 vidéo", "3 vidéos · illimité"). */
+export function videoCountLabel(palier: Palier, currentCount: number): string {
+  const max = VIDEO_COUNT_MAX[palier]
+  if (max === 0) return 'Vidéo non incluse dans ton palier'
+  if (max === null) {
+    return `${currentCount} vidéo${currentCount > 1 ? 's' : ''} · illimité`
+  }
+  return `${currentCount} / ${max} vidéo${max > 1 ? 's' : ''}`
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   VIDÉOS LIEUX (mig 43)
+   ═══════════════════════════════════════════════════════════════════ */
+
+/**
+ * Durée maximum d'une vidéo en secondes selon le palier lieu.
+ *  - aucun           : 0 → pas de vidéo autorisée
+ *  - selection_hilmy : 90 secondes par vidéo
+ */
+export const PLACE_VIDEO_DURATION_MAX: Record<LieuPalier, number> = {
+  aucun: 0,
+  selection_hilmy: 90,
+}
+
+/**
+ * Nombre maximum de vidéos par fiche lieu selon le palier.
+ *  - aucun           : 0
+ *  - selection_hilmy : illimité (null)
+ */
+export const PLACE_VIDEO_COUNT_MAX: Record<LieuPalier, number | null> = {
+  aucun: 0,
+  selection_hilmy: null,
+}
+
+export function canUploadPlaceVideo(
+  palier: LieuPalier,
+  currentCount: number,
+): boolean {
+  const max = PLACE_VIDEO_COUNT_MAX[palier]
+  if (max === 0) return false
+  return max === null || currentCount < max
+}
+
+export function getPlaceVideoDurationCap(palier: LieuPalier): number {
+  return PLACE_VIDEO_DURATION_MAX[palier]
+}
+
+export function placeVideoCountLabel(
+  palier: LieuPalier,
+  currentCount: number,
+): string {
+  const max = PLACE_VIDEO_COUNT_MAX[palier]
+  if (max === 0) return 'Vidéo non incluse dans ce palier'
+  if (max === null) {
+    return `${currentCount} vidéo${currentCount > 1 ? 's' : ''} · illimité`
+  }
+  return `${currentCount} / ${max} vidéo${max > 1 ? 's' : ''}`
 }

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -434,6 +434,45 @@ export interface EventsConfigAdmin {
 }
 
 /* ─────────────────────────────────────────────────────────────
+   profile_videos (vidéos prestataires — mig 43)
+   ───────────────────────────────────────────────────────────── */
+
+/** Vidéo MP4 attachée à une fiche prestataire (Premium 60s × 1,
+ *  Cercle Pro 90s × illimitées). Cap par palier appliqué côté API
+ *  route en PR-3. Le CHECK BDD borne dur à 90s / 50MB. */
+export interface ProfileVideo {
+  id: string;
+  profile_id: string;
+  /** Path interne au bucket profile-videos, format `{user_id}/{nanoid}.mp4`
+   *  (cf storage_owner_from_path mig 08 + storage convention). */
+  storage_path: string;
+  /** Path interne au bucket profile-videos pour le thumbnail JPEG.
+   *  NULL si la génération ffmpeg.wasm a échoué (vidéo reste utilisable). */
+  thumbnail_storage_path: string | null;
+  duration_seconds: number;
+  size_bytes: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   place_videos (vidéos lieux Sélection Hilmy — mig 43)
+   ───────────────────────────────────────────────────────────── */
+
+/** Vidéo MP4 attachée à une fiche lieu Sélection Hilmy (90s × illimitées).
+ *  Mirror ProfileVideo. Owner = places.created_by_user_id (mig 28). */
+export interface PlaceVideo {
+  id: string;
+  place_id: string;
+  storage_path: string;
+  thumbnail_storage_path: string | null;
+  duration_seconds: number;
+  size_bytes: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/* ─────────────────────────────────────────────────────────────
    Résultat standardisé des queries (gestion d'erreur uniforme)
    ───────────────────────────────────────────────────────────── */
 

--- a/supabase/migrations/43_videos_infra.sql
+++ b/supabase/migrations/43_videos_infra.sql
@@ -1,0 +1,353 @@
+-- =====================================================================
+-- HILMY · 43 — Videos infra (Phase 3 · PR-2)
+--
+-- Pose le terrain BDD + Storage pour le support vidéo MP4 dans les
+-- fiches prestataires (Premium 60s × 1, Cercle Pro 90s × illimitées) et
+-- les fiches lieux Sélection Hilmy (90s × illimitées).
+--
+-- AUCUNE UI dans cette migration — l'UploadVideo + VideoPlayer + intégration
+-- viendront en PR-3. PR-2 = pure infra.
+--
+-- Décisions Jiji 2026-05-10 :
+--   - D : storage path interne au bucket = `{user_id}/{nanoid}.mp4`
+--         (cohérent storage_owner_from_path() mig 08, pas de préfixe bucket)
+--   - E : trust client + bucket file_size_limit = 50 MB
+--   - B(γ) : helpers TS prêts mais UI lieu déférée
+--   - Pas de trigger BEFORE INSERT pour cap nombre vidéos (validation
+--     côté API route en PR-3)
+--   - Étendre les 4 policies hilmy_buckets_* (mig 08) plutôt que créer
+--     de nouvelles policies dédiées
+--
+-- ⚠️ Tables référencent `public.profiles(id)` (PAS `prestataires(id)` qui
+--    n'existe pas). Cf docs/db-schema-summary.md conventions piégeantes.
+--
+-- Idempotente. Voir bas de fichier pour rollback.
+-- =====================================================================
+
+
+-- =====================================================================
+-- 1. Table profile_videos
+-- =====================================================================
+
+create table if not exists public.profile_videos (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  -- Path interne au bucket profile-videos (sans préfixe bucket).
+  -- Convention HILMY : `{user_id}/{nanoid}.mp4`
+  storage_path text not null,
+  -- Path interne au bucket profile-videos pour le thumbnail JPEG.
+  -- Nullable : si la génération thumbnail (ffmpeg.wasm) échoue,
+  -- la vidéo reste utilisable sans poster image.
+  thumbnail_storage_path text,
+  duration_seconds integer not null,
+  size_bytes bigint not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- CHECK constraints (drop+add pour idempotence sur replay)
+alter table public.profile_videos drop constraint if exists profile_videos_duration_check;
+alter table public.profile_videos add constraint profile_videos_duration_check
+  check (duration_seconds > 0 and duration_seconds <= 90);
+
+alter table public.profile_videos drop constraint if exists profile_videos_size_check;
+alter table public.profile_videos add constraint profile_videos_size_check
+  check (size_bytes > 0 and size_bytes <= 52428800);  -- 50 MB
+
+create index if not exists idx_profile_videos_profile
+  on public.profile_videos(profile_id);
+
+comment on table public.profile_videos is
+  'Vidéos MP4 attachées à une fiche prestataire (Premium 60s × 1, '
+  'Cercle Pro 90s × illimitées). Le cap par palier est appliqué côté '
+  'API route en PR-3, pas via trigger SQL. Le CHECK duration <= 90 '
+  'est la borne dure BDD (max absolu Cercle Pro). Storage_path = '
+  '{user_id}/{nanoid}.mp4 dans le bucket profile-videos.';
+
+
+-- =====================================================================
+-- 2. Table place_videos
+-- =====================================================================
+
+create table if not exists public.place_videos (
+  id uuid primary key default gen_random_uuid(),
+  place_id uuid not null references public.places(id) on delete cascade,
+  storage_path text not null,
+  thumbnail_storage_path text,
+  duration_seconds integer not null,
+  size_bytes bigint not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.place_videos drop constraint if exists place_videos_duration_check;
+alter table public.place_videos add constraint place_videos_duration_check
+  check (duration_seconds > 0 and duration_seconds <= 90);
+
+alter table public.place_videos drop constraint if exists place_videos_size_check;
+alter table public.place_videos add constraint place_videos_size_check
+  check (size_bytes > 0 and size_bytes <= 52428800);
+
+create index if not exists idx_place_videos_place
+  on public.place_videos(place_id);
+
+comment on table public.place_videos is
+  'Vidéos MP4 attachées à une fiche lieu Sélection Hilmy (90s × '
+  'illimitées). Mirror profile_videos. Owner = places.created_by_user_id '
+  '(mig 28). Storage_path = {user_id}/{nanoid}.mp4 dans bucket place-videos.';
+
+
+-- =====================================================================
+-- 3. RLS profile_videos
+-- =====================================================================
+
+alter table public.profile_videos enable row level security;
+
+drop policy if exists "profile_videos_public_read" on public.profile_videos;
+create policy "profile_videos_public_read"
+  on public.profile_videos
+  for select
+  to anon, authenticated
+  using (true);
+
+drop policy if exists "profile_videos_owner_write" on public.profile_videos;
+create policy "profile_videos_owner_write"
+  on public.profile_videos
+  for all
+  to authenticated
+  using (
+    profile_id in (
+      select id from public.profiles where user_id = auth.uid()
+    )
+  )
+  with check (
+    profile_id in (
+      select id from public.profiles where user_id = auth.uid()
+    )
+  );
+
+drop policy if exists "profile_videos_admin_all" on public.profile_videos;
+create policy "profile_videos_admin_all"
+  on public.profile_videos
+  for all
+  to authenticated
+  using (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  )
+  with check (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+
+-- =====================================================================
+-- 4. RLS place_videos
+-- =====================================================================
+
+alter table public.place_videos enable row level security;
+
+drop policy if exists "place_videos_public_read" on public.place_videos;
+create policy "place_videos_public_read"
+  on public.place_videos
+  for select
+  to anon, authenticated
+  using (true);
+
+drop policy if exists "place_videos_owner_write" on public.place_videos;
+create policy "place_videos_owner_write"
+  on public.place_videos
+  for all
+  to authenticated
+  using (
+    place_id in (
+      select id from public.places where created_by_user_id = auth.uid()
+    )
+  )
+  with check (
+    place_id in (
+      select id from public.places where created_by_user_id = auth.uid()
+    )
+  );
+
+drop policy if exists "place_videos_admin_all" on public.place_videos;
+create policy "place_videos_admin_all"
+  on public.place_videos
+  for all
+  to authenticated
+  using (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  )
+  with check (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+
+-- =====================================================================
+-- 5. Storage buckets profile-videos + place-videos
+-- =====================================================================
+-- Buckets PUBLICS pour lecture directe (UUID dans path = obscurité).
+-- file_size_limit = 50 MB (cap dur, aligné CHECK size_bytes BDD).
+-- MIME types : video/mp4, video/webm pour les vidéos, image/jpeg pour
+-- les thumbnails générés par ffmpeg.wasm (PR-3) — pas de bucket dédié
+-- thumbnails pour simplifier.
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values
+  ('profile-videos', 'profile-videos', true, 52428800,
+    array['video/mp4', 'video/webm', 'image/jpeg']::text[]),
+  ('place-videos', 'place-videos', true, 52428800,
+    array['video/mp4', 'video/webm', 'image/jpeg']::text[])
+on conflict (id) do nothing;
+
+
+-- =====================================================================
+-- 6. Extension des 4 policies hilmy_buckets_* (mig 08)
+-- =====================================================================
+-- On AJOUTE 'profile-videos' et 'place-videos' aux 4 buckets existants
+-- couverts par le pattern owner-from-path. DROP POLICY puis CREATE pour
+-- idempotence.
+
+drop policy if exists "hilmy_buckets_public_read" on storage.objects;
+create policy "hilmy_buckets_public_read"
+  on storage.objects for select
+  to anon, authenticated
+  using (
+    bucket_id in (
+      'prestataire-photos',
+      'recommendation-photos',
+      'event-flyers',
+      'user-avatars',
+      'profile-videos',
+      'place-videos'
+    )
+  );
+
+drop policy if exists "hilmy_buckets_owner_insert" on storage.objects;
+create policy "hilmy_buckets_owner_insert"
+  on storage.objects for insert
+  to authenticated
+  with check (
+    bucket_id in (
+      'prestataire-photos',
+      'recommendation-photos',
+      'event-flyers',
+      'user-avatars',
+      'profile-videos',
+      'place-videos'
+    )
+    and public.storage_owner_from_path(name) = auth.uid()
+  );
+
+drop policy if exists "hilmy_buckets_owner_update" on storage.objects;
+create policy "hilmy_buckets_owner_update"
+  on storage.objects for update
+  to authenticated
+  using (
+    bucket_id in (
+      'prestataire-photos',
+      'recommendation-photos',
+      'event-flyers',
+      'user-avatars',
+      'profile-videos',
+      'place-videos'
+    )
+    and public.storage_owner_from_path(name) = auth.uid()
+  )
+  with check (
+    bucket_id in (
+      'prestataire-photos',
+      'recommendation-photos',
+      'event-flyers',
+      'user-avatars',
+      'profile-videos',
+      'place-videos'
+    )
+    and public.storage_owner_from_path(name) = auth.uid()
+  );
+
+drop policy if exists "hilmy_buckets_owner_delete" on storage.objects;
+create policy "hilmy_buckets_owner_delete"
+  on storage.objects for delete
+  to authenticated
+  using (
+    bucket_id in (
+      'prestataire-photos',
+      'recommendation-photos',
+      'event-flyers',
+      'user-avatars',
+      'profile-videos',
+      'place-videos'
+    )
+    and public.storage_owner_from_path(name) = auth.uid()
+  );
+
+
+-- =====================================================================
+-- 7. updated_at triggers (cohérence avec autres tables récentes)
+-- =====================================================================
+
+create or replace function public.bump_profile_videos_updated_at()
+returns trigger as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists profile_videos_updated_at_trg on public.profile_videos;
+create trigger profile_videos_updated_at_trg
+  before update on public.profile_videos
+  for each row execute function public.bump_profile_videos_updated_at();
+
+create or replace function public.bump_place_videos_updated_at()
+returns trigger as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists place_videos_updated_at_trg on public.place_videos;
+create trigger place_videos_updated_at_trg
+  before update on public.place_videos
+  for each row execute function public.bump_place_videos_updated_at();
+
+
+-- =====================================================================
+-- 8. Reload PostgREST schema cache
+-- =====================================================================
+notify pgrst, 'reload schema';
+
+
+-- =====================================================================
+-- ROLLBACK (à exécuter manuellement si besoin)
+-- =====================================================================
+-- -- Triggers updated_at
+-- drop trigger if exists place_videos_updated_at_trg on public.place_videos;
+-- drop trigger if exists profile_videos_updated_at_trg on public.profile_videos;
+-- drop function if exists public.bump_place_videos_updated_at();
+-- drop function if exists public.bump_profile_videos_updated_at();
+--
+-- -- Restore les 4 policies hilmy_buckets_* à leur état mig 08 (sans
+-- -- profile-videos / place-videos)
+-- drop policy if exists "hilmy_buckets_owner_delete" on storage.objects;
+-- drop policy if exists "hilmy_buckets_owner_update" on storage.objects;
+-- drop policy if exists "hilmy_buckets_owner_insert" on storage.objects;
+-- drop policy if exists "hilmy_buckets_public_read" on storage.objects;
+-- -- (Re-créer via mig 08 si besoin — copier le bloc original)
+--
+-- -- Buckets storage (laisser DELETE FROM hors transaction Supabase Mgmt
+-- -- car contient peut-être des objets uploadés)
+-- delete from storage.buckets where id in ('profile-videos','place-videos');
+--
+-- -- RLS policies des 2 tables
+-- drop policy if exists "place_videos_admin_all" on public.place_videos;
+-- drop policy if exists "place_videos_owner_write" on public.place_videos;
+-- drop policy if exists "place_videos_public_read" on public.place_videos;
+-- drop policy if exists "profile_videos_admin_all" on public.profile_videos;
+-- drop policy if exists "profile_videos_owner_write" on public.profile_videos;
+-- drop policy if exists "profile_videos_public_read" on public.profile_videos;
+--
+-- -- Tables (CASCADE supprime les indexes + check constraints)
+-- drop table if exists public.place_videos;
+-- drop table if exists public.profile_videos;
+-- =====================================================================


### PR DESCRIPTION
**Sprint 3 · PR-2** · Phase 3 photos+vidéos · 2e sous-PR du découpage 3-PRs (PR-3 = UI Upload + Player + intégration). Pose le terrain BDD + Storage pour le support vidéo MP4 **sans aucune UI**.

## Symptôme

Les promesses /tarifs Premium ("1 vidéo 60s") et Cercle Pro ("Vidéos illimitées 90s") + Sélection Hilmy lieux ("90s illimitées") sont 0% implémentées. Aucune table BDD pour stocker les vidéos, aucun bucket Storage, aucun helper TS pour gater le palier.

## Root cause

Schéma BDD vidéo jamais posé. Le brief Sprint 3 d'origine référençait `prestataires(id)` (table inexistante — c'est `profiles(id)`, cf [docs/db-schema-summary.md](docs/db-schema-summary.md)) et `videos/{prestataire_id}/...` storage path qui ne match pas `storage_owner_from_path()` mig 08. Migration 43 fixe ces 2 hypothèses.

## Fix

### Migration 43 — `supabase/migrations/43_videos_infra.sql` (353 lignes)

**Tables :**
- `public.profile_videos` (FK → `public.profiles(id)` ON DELETE CASCADE)
- `public.place_videos` (FK → `public.places(id)` ON DELETE CASCADE)

Colonnes : `id`, `profile_id`/`place_id`, `storage_path`, `thumbnail_storage_path` (nullable), `duration_seconds` CHECK > 0 AND ≤ 90, `size_bytes` CHECK > 0 AND ≤ 52428800 (50 MB), `created_at`, `updated_at` (trigger).

**RLS — 3 policies par table** (mirror du pattern mig 41) :

| Policy | Cible | Logique |
|---|---|---|
| `*_public_read` | SELECT TO anon, authenticated | `USING (true)` — gating affichage UI fait au read-time |
| `*_owner_write` | FOR ALL TO authenticated | `profile_id IN (SELECT id FROM profiles WHERE user_id=auth.uid())` ou `place_id IN (SELECT id FROM places WHERE created_by_user_id=auth.uid())` |
| `*_admin_all` | FOR ALL TO authenticated | `coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)` |

**Storage buckets :**
- `profile-videos` (50 MB, MIME `video/mp4`, `video/webm`, `image/jpeg`)
- `place-videos` (idem)

`image/jpeg` accepté pour les thumbnails JPEG générés par ffmpeg.wasm en PR-3 — pas de bucket dédié pour simplifier.

**Storage RLS — extension du pattern mig 08** :

Au lieu de créer 4 nouvelles policies dédiées, j'étends l'array `bucket_id IN (...)` des 4 policies génériques `hilmy_buckets_*` (mig 08) pour inclure `profile-videos` + `place-videos`. Convention path inchangée : `{user_id}/{nanoid}.ext`, validée par `storage_owner_from_path()` (mig 08).

### Helpers TS — `lib/palier-limits.ts`

Étendu avec :

```typescript
VIDEO_DURATION_MAX: { standard: 0, premium: 60, cercle_pro: 90 }
VIDEO_COUNT_MAX:    { standard: 0, premium: 1, cercle_pro: null /* illimité */ }
canUploadVideo(palier, currentCount): boolean
getVideoDurationCap(palier): number
videoCountLabel(palier, currentCount): string

PLACE_VIDEO_DURATION_MAX: { aucun: 0, selection_hilmy: 90 }
PLACE_VIDEO_COUNT_MAX:    { aucun: 0, selection_hilmy: null }
canUploadPlaceVideo(palier, currentCount): boolean
getPlaceVideoDurationCap(palier): number
placeVideoCountLabel(palier, currentCount): string
```

Doc en-tête mise à jour pour expliciter : caps vidéos enforced **côté API route** (PR-3) pas via trigger SQL ; le CHECK BDD `duration_seconds <= 90` est juste la borne dure absolue (max Cercle Pro).

### Types — `lib/supabase/types.ts`

Nouveaux : `ProfileVideo`, `PlaceVideo` (mirror des tables BDD).

## Smoke tests prod 8/8 ✅

| # | Test | Résultat |
|---|---|---|
| 1 | Tables `profile_videos` + `place_videos` créées (0 rows) | OK |
| 2 | Buckets `profile-videos` + `place-videos` (50 MB, MIME corrects) | OK |
| 3 | Policy `hilmy_buckets_public_read` inclut bien les 2 nouveaux buckets | OK |
| 4 | RLS `profile_videos` active + 3 policies (`public_read`, `owner_write`, `admin_all`) | OK |
| 5 | RLS `place_videos` idem | OK |
| 6 | INSERT `duration=120` → **REJECTED** (CHECK 23514) | OK |
| 7 | INSERT `size_bytes=60MB` → **REJECTED** (CHECK 23514) | OK |
| 8 | INSERT valide (45s, 5MB) → OK + DELETE cleanup | OK |

## Décisions Jiji 2026-05-10 actées dans cette PR

- **D** : storage path interne au bucket = `{user_id}/{nanoid}.mp4`
- **E** : trust client + `bucket.file_size_limit=50MB` (cap dur BDD aligné)
- **B(γ)** : helpers TS prêts mais UI lieu déférée
- Pas de trigger BEFORE INSERT pour cap nombre vidéos (validation API route en PR-3, plus simple)
- Étendre les 4 policies `hilmy_buckets_*` plutôt que créer de nouvelles policies dédiées
- Type TS `Palier` (existant) au lieu de `PalierPrestataire`

## Risques

- **Faible.** Pure infra, aucune UI, aucune nouvelle écriture côté code applicatif.
- **Backward compat** : les 13 policies legacy storage.objects continuent de cohabiter sans conflit (cf tech-debt.md #6 ajouté pour cleanup ultérieur).
- **Idempotence** : la migration utilise `create table if not exists`, `drop policy if exists` puis create, `on conflict (id) do nothing` sur les buckets. Replay sans dégât.
- **Rollback documenté** en commentaires bas de fichier.

## Sécurité

- ✅ RLS activée sur les 2 nouvelles tables
- ✅ Pattern admin via JWT `user_metadata.is_admin` (cohérent mig 06, 15, 41)
- ✅ Storage `bucket.file_size_limit=50MB` + MIME types whitelist (cap dur)
- ✅ Convention path `{user_id}/...` validée par `storage_owner_from_path()` (anti-cross-user)
- ✅ Aucun nouveau pattern admin, aucun service-role côté client
- ✅ Auth + 3 paliers prestataires intouchés

## Tech-debt ajouté

Pendant l'audit, 2 incohérences storage hors-scope-PR-2 détectées et notées dans [tech-debt.md](tech-debt.md) :

- **#5** : 2 buckets `profile-photos` + `uploads` créés hors mig 08, `file_size_limit=null` + `allowed_mime_types=null` (illimité, tout type) — risque facture Supabase si abuse
- **#6** : 13 policies legacy `storage.objects` (noms français, créées hors mig) en doublon des 4 `hilmy_buckets_*` génériques — à comparer puis dropper

Sprint storage cleanup proposé semaine 11-16 mai.

## Backup pre-apply

✅ 8 backups physical Supabase confirmés disponibles avant apply (Jiji 2026-05-09 20:18). Filet de sécurité direct si rollback nécessaire.

## Out of scope (PR-3)

- UI `UploadVideo` component avec ffmpeg.wasm lazy-import
- UI `VideoPlayer` component avec thumbnail + clic-to-play
- API route `POST /api/videos/upload` avec validation palier server-side
- Intégration sur 2 fiches publiques (`/prestataire-v2/[slug]`, `/recommandation/[slug]`)
- Intégration sur 2 dashboards owner (`/dashboard/prestataire/fiche`, `/dashboard/lieu/[placeId]`)
- Badges ▶ "VIDÉO" sur cards feed (`PrestataireCard`, `LieuCard`)
- Tabs Photos / Vidéos sur fiches publiques
- COOP/COEP headers scopés sur routes dashboard (décision C — pour ffmpeg.wasm multi-thread)

## Refs

- [idees.md](idees.md) — Sprint 3 planifié
- Brief Sprint 3 PR-2 + 6 décisions par défaut validées Jiji 2026-05-10
- [docs/db-schema-summary.md](docs/db-schema-summary.md) — conventions piégeantes
- Mig 41 PR-A ([#77](https://github.com/jihaneessmaliki-sys/hilmy/pull/77)) — pattern Sélection Hilmy + RLS
- Mig 08 — pattern storage policies génériques étendues ici
- PR-1 ([#82](https://github.com/jihaneessmaliki-sys/hilmy/pull/82)) — photos gating server-side

## Stop next

Je t'attends pour relire/tester puis GO merge. Après merge, on enchaîne **PR-3** (UI vidéo : UploadVideo + VideoPlayer + intégration, ~1000 lignes ~3h CC).
