### PR TITLE
feat(media): UI vidéo MP4 — UploadVideo + VideoPlayer + intégration (PR-3)

### DIFF
--- a/app/annuaire/page.tsx
+++ b/app/annuaire/page.tsx
@@ -6,6 +6,7 @@ import {
   type Prestataire as MockPrestataire,
 } from '@/lib/mock-data'
 import { getAllPrestataires } from '@/lib/supabase/queries/prestataires'
+import { getProfileIdsWithVideos } from '@/lib/supabase/queries/videos'
 import type { Prestataire as DbPrestataire } from '@/lib/supabase/types'
 import { AnnuaireClient } from './AnnuaireClient'
 
@@ -87,7 +88,16 @@ export default async function AnnuairePage() {
     )
   }
 
-  const adapted = (data ?? []).map(adaptPrestataireFromDb)
+  const rows = data ?? []
+
+  // Pré-fetch en batch des IDs prestataires qui ont au moins 1 vidéo
+  // (évite N+1 sur le badge ▶ VIDÉO côté card). Mig 43 PR-3.
+  const idsWithVideos = await getProfileIdsWithVideos(rows.map((p) => p.id))
+
+  const adapted = rows.map((p) => ({
+    ...adaptPrestataireFromDb(p),
+    has_videos: idsWithVideos.has(p.id),
+  }))
   const sorted = sortByPalierThenServerOrder(adapted)
 
   return <AnnuaireClient prestataires={sorted} />

--- a/app/api/videos/[id]/route.ts
+++ b/app/api/videos/[id]/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { isValidUuid } from '@/lib/tracking'
+
+export const runtime = 'nodejs'
+
+/**
+ * DELETE /api/videos/[id]?type=prestataire|lieu
+ *
+ * Supprime une vidéo + son thumbnail Storage + son row BDD.
+ * Auth + ownership check obligatoire.
+ *
+ * Best-effort sur le DELETE Storage : si le fichier n'existe plus
+ * (déjà delete par Supabase ON DELETE CASCADE par exemple), on ignore.
+ *
+ * Le query param ?type est obligatoire pour savoir quelle table cibler.
+ */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params
+  if (!isValidUuid(id)) {
+    return NextResponse.json({ error: 'id invalide' }, { status: 400 })
+  }
+
+  const url = new URL(request.url)
+  const type = url.searchParams.get('type')
+  if (type !== 'prestataire' && type !== 'lieu') {
+    return NextResponse.json(
+      { error: 'Query param ?type=prestataire|lieu requis.' },
+      { status: 400 },
+    )
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Non authentifiée' }, { status: 401 })
+  }
+
+  // Ownership check : on JOIN profiles/places pour vérifier
+  // user_id / created_by_user_id correspond à l'utilisateur courant.
+  if (type === 'prestataire') {
+    const { data: video } = await supabase
+      .from('profile_videos')
+      .select(
+        'id, storage_path, thumbnail_storage_path, profile:profiles!inner(user_id)',
+      )
+      .eq('id', id)
+      .maybeSingle()
+    if (!video) {
+      return NextResponse.json({ error: 'Vidéo introuvable.' }, { status: 404 })
+    }
+    const ownerUserId = Array.isArray(video.profile)
+      ? video.profile[0]?.user_id
+      : (video.profile as { user_id?: string } | null)?.user_id
+    if (ownerUserId !== user.id) {
+      return NextResponse.json(
+        { error: "Tu n'es pas owner de cette vidéo." },
+        { status: 403 },
+      )
+    }
+
+    await deleteStorageFiles(
+      'profile-videos',
+      video.storage_path,
+      video.thumbnail_storage_path,
+    )
+
+    const admin = createAdminClient()
+    const { error } = await admin.from('profile_videos').delete().eq('id', id)
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+    return new NextResponse(null, { status: 204 })
+  }
+
+  // type === 'lieu'
+  const { data: video } = await supabase
+    .from('place_videos')
+    .select(
+      'id, storage_path, thumbnail_storage_path, place:places!inner(created_by_user_id)',
+    )
+    .eq('id', id)
+    .maybeSingle()
+  if (!video) {
+    return NextResponse.json({ error: 'Vidéo introuvable.' }, { status: 404 })
+  }
+  const ownerUserId = Array.isArray(video.place)
+    ? video.place[0]?.created_by_user_id
+    : (video.place as { created_by_user_id?: string } | null)?.created_by_user_id
+  if (ownerUserId !== user.id) {
+    return NextResponse.json(
+      { error: "Tu n'es pas owner de cette vidéo." },
+      { status: 403 },
+    )
+  }
+
+  await deleteStorageFiles(
+    'place-videos',
+    video.storage_path,
+    video.thumbnail_storage_path,
+  )
+
+  const admin = createAdminClient()
+  const { error } = await admin.from('place_videos').delete().eq('id', id)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return new NextResponse(null, { status: 204 })
+}
+
+/**
+ * Supprime vidéo + thumbnail du bucket. Best-effort (silent fail si
+ * fichier déjà absent — race condition possible avec ON DELETE CASCADE
+ * ou un cleanup cron).
+ */
+async function deleteStorageFiles(
+  bucket: 'profile-videos' | 'place-videos',
+  videoPath: string,
+  thumbnailPath: string | null,
+) {
+  try {
+    const admin = createAdminClient()
+    const paths = [videoPath]
+    if (thumbnailPath) paths.push(thumbnailPath)
+    await admin.storage.from(bucket).remove(paths)
+  } catch (err) {
+    // Best-effort : on log mais on continue le DELETE BDD
+    console.error('[videos delete] storage cleanup failed', err)
+  }
+}

--- a/app/api/videos/upload/route.ts
+++ b/app/api/videos/upload/route.ts
@@ -1,0 +1,254 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { enforceRateLimit } from '@/lib/rate-limit'
+import { isValidUuid } from '@/lib/tracking'
+import {
+  insertProfileVideoAdmin,
+  insertPlaceVideoAdmin,
+} from '@/lib/supabase/queries/videos'
+import {
+  canUploadVideo,
+  canUploadPlaceVideo,
+  getVideoDurationCap,
+  getPlaceVideoDurationCap,
+} from '@/lib/palier-limits'
+import { getEffectivePalier } from '@/lib/permissions'
+import { getEffectivePalierLieu } from '@/lib/permissions-lieux'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/videos/upload
+ *
+ * Body: {
+ *   profile_id?: string (uuid),
+ *   place_id?: string (uuid),
+ *   storage_path: string,
+ *   thumbnail_storage_path?: string | null,
+ *   duration_seconds: number (1-90),
+ *   size_bytes: number (1 - 52428800)
+ * }
+ *
+ * Le client a DÉJÀ uploadé le fichier vidéo + thumbnail dans Storage
+ * (bucket profile-videos ou place-videos). Cet endpoint :
+ *   1. Vérifie ownership (profile.user_id ou place.created_by_user_id)
+ *   2. Vérifie palier autorise vidéos + duration_seconds <= cap palier
+ *   3. Vérifie count(videos) < cap palier (cap nombre, pas trigger SQL)
+ *   4. INSERT BDD via admin client (bypass RLS, on a validé manuellement)
+ *
+ * Retourne 201 + le row ou 4xx avec erreur lisible côté UI.
+ *
+ * XOR profile_id/place_id : exactement un des deux doit être fourni.
+ */
+export async function POST(request: Request) {
+  const limited = enforceRateLimit(request, {
+    tag: 'videos-upload',
+    max: 10,
+    windowMs: 60 * 1000,
+  })
+  if (limited) return limited
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Non authentifiée' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body invalide' }, { status: 400 })
+  }
+
+  const {
+    profile_id,
+    place_id,
+    storage_path,
+    thumbnail_storage_path,
+    duration_seconds,
+    size_bytes,
+  } = body as Record<string, unknown>
+
+  // ─── XOR profile_id / place_id ────────────────────────────────────
+  const hasProfile = typeof profile_id === 'string' && profile_id.length > 0
+  const hasPlace = typeof place_id === 'string' && place_id.length > 0
+  if (hasProfile === hasPlace) {
+    return NextResponse.json(
+      { error: 'Fournis profile_id OU place_id, exactement un des deux.' },
+      { status: 400 },
+    )
+  }
+  if (hasProfile && !isValidUuid(profile_id)) {
+    return NextResponse.json({ error: 'profile_id invalide.' }, { status: 400 })
+  }
+  if (hasPlace && !isValidUuid(place_id)) {
+    return NextResponse.json({ error: 'place_id invalide.' }, { status: 400 })
+  }
+
+  // ─── Validate other fields ────────────────────────────────────────
+  if (typeof storage_path !== 'string' || storage_path.length === 0) {
+    return NextResponse.json({ error: 'storage_path requis.' }, { status: 400 })
+  }
+  if (
+    typeof duration_seconds !== 'number' ||
+    !Number.isFinite(duration_seconds) ||
+    duration_seconds <= 0 ||
+    duration_seconds > 90
+  ) {
+    return NextResponse.json(
+      { error: 'duration_seconds doit être entre 1 et 90.' },
+      { status: 400 },
+    )
+  }
+  if (
+    typeof size_bytes !== 'number' ||
+    !Number.isFinite(size_bytes) ||
+    size_bytes <= 0 ||
+    size_bytes > 52428800
+  ) {
+    return NextResponse.json(
+      { error: 'size_bytes invalide (max 50 MB).' },
+      { status: 400 },
+    )
+  }
+  const thumbPath =
+    typeof thumbnail_storage_path === 'string' && thumbnail_storage_path.length > 0
+      ? thumbnail_storage_path
+      : null
+
+  // ─── Branche prestataire ──────────────────────────────────────────
+  if (hasProfile) {
+    const { data: profile, error: pErr } = await supabase
+      .from('profiles')
+      .select('id, user_id, palier, is_founder')
+      .eq('id', profile_id as string)
+      .maybeSingle()
+
+    if (pErr || !profile) {
+      return NextResponse.json(
+        { error: 'Prestataire introuvable.' },
+        { status: 404 },
+      )
+    }
+    if (profile.user_id !== user.id) {
+      return NextResponse.json(
+        { error: "Tu n'es pas owner de cette fiche." },
+        { status: 403 },
+      )
+    }
+
+    const palier = getEffectivePalier(profile)
+    const durationCap = getVideoDurationCap(palier)
+    if (durationCap === 0) {
+      return NextResponse.json(
+        { error: 'Ton palier ne te permet pas d\'ajouter une vidéo.' },
+        { status: 403 },
+      )
+    }
+    const durSec = duration_seconds as number
+    if (durSec > durationCap) {
+      return NextResponse.json(
+        {
+          error: `Cette vidéo dépasse ${durationCap}s autorisées sur ton palier.`,
+        },
+        { status: 422 },
+      )
+    }
+
+    // Check count cap
+    const { count } = await supabase
+      .from('profile_videos')
+      .select('id', { count: 'exact', head: true })
+      .eq('profile_id', profile_id as string)
+    const currentCount = count ?? 0
+    if (!canUploadVideo(palier, currentCount)) {
+      return NextResponse.json(
+        { error: 'Tu as atteint ta limite de vidéos pour ce palier.' },
+        { status: 422 },
+      )
+    }
+
+    const { data, error } = await insertProfileVideoAdmin({
+      profile_id: profile_id as string,
+      storage_path: storage_path as string,
+      thumbnail_storage_path: thumbPath,
+      duration_seconds: durSec,
+      size_bytes: size_bytes as number,
+    })
+
+    if (error || !data) {
+      return NextResponse.json(
+        { error: error || 'Insertion échouée' },
+        { status: 500 },
+      )
+    }
+    return NextResponse.json(data, { status: 201 })
+  }
+
+  // ─── Branche lieu ─────────────────────────────────────────────────
+  const { data: place, error: lErr } = await supabase
+    .from('places')
+    .select('id, created_by_user_id, palier')
+    .eq('id', place_id as string)
+    .maybeSingle()
+
+  if (lErr || !place) {
+    return NextResponse.json({ error: 'Lieu introuvable.' }, { status: 404 })
+  }
+  if (place.created_by_user_id !== user.id) {
+    return NextResponse.json(
+      { error: "Tu n'es pas owner de ce lieu." },
+      { status: 403 },
+    )
+  }
+
+  const palierLieu = getEffectivePalierLieu(place)
+  const durationCap = getPlaceVideoDurationCap(palierLieu)
+  if (durationCap === 0) {
+    return NextResponse.json(
+      { error: 'Le palier de ce lieu ne permet pas d\'ajouter une vidéo.' },
+      { status: 403 },
+    )
+  }
+  const durSec = duration_seconds as number
+  if (durSec > durationCap) {
+    return NextResponse.json(
+      {
+        error: `Cette vidéo dépasse ${durationCap}s autorisées sur ce palier.`,
+      },
+      { status: 422 },
+    )
+  }
+
+  const { count } = await supabase
+    .from('place_videos')
+    .select('id', { count: 'exact', head: true })
+    .eq('place_id', place_id as string)
+  const currentCount = count ?? 0
+  if (!canUploadPlaceVideo(palierLieu, currentCount)) {
+    return NextResponse.json(
+      { error: 'Ce lieu a atteint sa limite de vidéos.' },
+      { status: 422 },
+    )
+  }
+
+  const { data, error } = await insertPlaceVideoAdmin({
+    place_id: place_id as string,
+    storage_path: storage_path as string,
+    thumbnail_storage_path: thumbPath,
+    duration_seconds: durSec,
+    size_bytes: size_bytes as number,
+  })
+
+  if (error || !data) {
+    return NextResponse.json(
+      { error: error || 'Insertion échouée' },
+      { status: 500 },
+    )
+  }
+  return NextResponse.json(data, { status: 201 })
+}

--- a/app/dashboard/lieu/[placeId]/page.tsx
+++ b/app/dashboard/lieu/[placeId]/page.tsx
@@ -10,7 +10,8 @@ import { requireUser } from '@/lib/supabase/session'
 import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { getOwnedPlaceById } from '@/lib/supabase/queries/places'
-import { isSelectionHilmy } from '@/lib/permissions-lieux'
+import { getEffectivePalierLieu, isSelectionHilmy } from '@/lib/permissions-lieux'
+import { VideosManager } from '@/components/v2/VideosManager'
 
 const SINCE_7D_MS = 7 * 86_400_000
 const SINCE_30D_MS = 30 * 86_400_000
@@ -595,6 +596,24 @@ export default async function LieuDetailPage({
           On compte précieusement chaque pas qu&apos;une copine fait vers
           toi, depuis le 9 mai 2026.
         </p>
+      </section>
+
+      {/* ─── Mes vidéos (Sélection Hilmy seulement) ─────────────────
+          VideosManager affiche le mode "non incluse" si le lieu est
+          en palier='aucun', donc on peut le rendre inconditionnellement
+          mais ici on rend uniquement pour les Sélection Hilmy car on est
+          déjà dans la branche cas B. */}
+      <section className="bg-blanc px-6 py-12 md:px-12 md:py-16">
+        <div className="mb-6 flex items-center gap-4">
+          <GoldLine width={40} />
+          <span className="overline text-or">Mes vidéos</span>
+        </div>
+        <VideosManager
+          scope="lieu"
+          placeId={place.id}
+          userId={user.id}
+          palier={getEffectivePalierLieu(place)}
+        />
       </section>
     </>
   )

--- a/app/dashboard/prestataire/fiche/page.tsx
+++ b/app/dashboard/prestataire/fiche/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { motion, AnimatePresence } from 'motion/react'
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
 import { GoldLine } from '@/components/ui/GoldLine'
+import { VideosManager } from '@/components/v2/VideosManager'
 import { createClient } from '@/lib/supabase/client'
 import { CATEGORIES_MAP } from '@/lib/constants'
 import {
@@ -664,6 +665,19 @@ export default function MaFichePage() {
                     </ul>
                   )}
                 </Group>
+
+                {/* Section Mes vidéos — gating server-side via API route
+                    /api/videos/upload (cap durée + count par palier). */}
+                {profileId && userId && (
+                  <Group kicker="Mes vidéos">
+                    <VideosManager
+                      scope="prestataire"
+                      profileId={profileId}
+                      userId={userId}
+                      palier={palier}
+                    />
+                  </Group>
+                )}
 
                 <div className="flex items-center gap-4">
                   <button

--- a/app/prestataire-v2/[slug]/page.tsx
+++ b/app/prestataire-v2/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { FadeInSection } from '@/components/ui/FadeInSection'
 import { PrestataireCard } from '@/components/v2/PrestataireCard'
 import { PhotoGallery } from '@/components/v2/PhotoGallery'
 import { GalleryAutoplayCarousel } from '@/components/v2/GalleryAutoplayCarousel'
+import { VideoPlayer } from '@/components/v2/VideoPlayer'
 import { DevisExpressCTA } from '@/components/v2/DevisExpressCTA'
 import { SocialChannelsButtons } from '@/components/v2/SocialChannelsButtons'
 import { TrackPageView } from '@/components/v2/TrackPageView'
@@ -22,6 +23,7 @@ import {
   getPrestataireBySlugForOwner,
   getPrestatairesByCategorie,
 } from '@/lib/supabase/queries/prestataires'
+import { getProfileVideos } from '@/lib/supabase/queries/videos'
 import { createClient } from '@/lib/supabase/server'
 import type { Prestataire as DbPrestataire } from '@/lib/supabase/types'
 
@@ -110,6 +112,7 @@ export default async function PrestatairePage({
   const [
     { data: rowsSim },
     avisRes,
+    { data: videos },
   ] = await Promise.all([
     getPrestatairesByCategorie(finalRow!.categorie),
     supabase
@@ -122,7 +125,22 @@ export default async function PrestatairePage({
       .eq('status', 'published')
       .order('created_at', { ascending: false })
       .limit(12),
+    getProfileVideos(finalRow!.id),
   ])
+
+  // Compute public URLs pour les vidéos + thumbnails (bucket public).
+  const videoEntries = (videos ?? []).map((v) => {
+    const videoUrl = supabase.storage.from('profile-videos').getPublicUrl(v.storage_path).data.publicUrl
+    const thumbnailUrl = v.thumbnail_storage_path
+      ? supabase.storage.from('profile-videos').getPublicUrl(v.thumbnail_storage_path).data.publicUrl
+      : null
+    return {
+      id: v.id,
+      videoUrl,
+      thumbnailUrl,
+      durationSeconds: v.duration_seconds,
+    }
+  })
 
   const similaires: MockPrestataire[] = (rowsSim ?? [])
     .filter((x) => x.slug !== slug)
@@ -338,11 +356,37 @@ export default async function PrestatairePage({
                 </ul>
               </FadeInSection>
 
-              {p.galerie.length > 0 && (
+              {videoEntries.length > 0 && (
                 <FadeInSection>
                   <header className="flex items-center gap-5">
                     <span className="font-serif text-[44px] font-light leading-none text-or">
                       03
+                    </span>
+                    <GoldLine width={60} />
+                    <span className="overline text-or">
+                      Découvre {p.nom} en vidéo
+                    </span>
+                  </header>
+                  <div className="mt-6 grid gap-5 md:grid-cols-2">
+                    {videoEntries.map((v) => (
+                      <VideoPlayer
+                        key={v.id}
+                        videoUrl={v.videoUrl}
+                        thumbnailUrl={v.thumbnailUrl}
+                        durationSeconds={v.durationSeconds}
+                        ariaLabel={`Voir la vidéo de ${p.nom}`}
+                        fallbackColor={p.cover}
+                      />
+                    ))}
+                  </div>
+                </FadeInSection>
+              )}
+
+              {p.galerie.length > 0 && (
+                <FadeInSection>
+                  <header className="flex items-center gap-5">
+                    <span className="font-serif text-[44px] font-light leading-none text-or">
+                      {videoEntries.length > 0 ? '04' : '03'}
                     </span>
                     <GoldLine width={60} />
                     <span className="overline text-or">Galerie</span>

--- a/app/prestataire-v2/[slug]/page.tsx
+++ b/app/prestataire-v2/[slug]/page.tsx
@@ -367,18 +367,32 @@ export default async function PrestatairePage({
                       Découvre {p.nom} en vidéo
                     </span>
                   </header>
-                  <div className="mt-6 grid gap-5 md:grid-cols-2">
-                    {videoEntries.map((v) => (
+                  {videoEntries.length === 1 ? (
+                    <div className="mt-6">
                       <VideoPlayer
-                        key={v.id}
-                        videoUrl={v.videoUrl}
-                        thumbnailUrl={v.thumbnailUrl}
-                        durationSeconds={v.durationSeconds}
+                        videoUrl={videoEntries[0].videoUrl}
+                        thumbnailUrl={videoEntries[0].thumbnailUrl}
+                        durationSeconds={videoEntries[0].durationSeconds}
                         ariaLabel={`Voir la vidéo de ${p.nom}`}
                         fallbackColor={p.cover}
+                        size="large"
                       />
-                    ))}
-                  </div>
+                    </div>
+                  ) : (
+                    <div className="mt-6 grid gap-5 md:grid-cols-2">
+                      {videoEntries.map((v) => (
+                        <VideoPlayer
+                          key={v.id}
+                          videoUrl={v.videoUrl}
+                          thumbnailUrl={v.thumbnailUrl}
+                          durationSeconds={v.durationSeconds}
+                          ariaLabel={`Voir la vidéo de ${p.nom}`}
+                          fallbackColor={p.cover}
+                          size="medium"
+                        />
+                      ))}
+                    </div>
+                  )}
                 </FadeInSection>
               )}
 

--- a/app/recommandation/[slug]/page.tsx
+++ b/app/recommandation/[slug]/page.tsx
@@ -16,8 +16,10 @@ import {
   getPlacesByCategorie,
 } from '@/lib/supabase/queries/places'
 import { getRecommendationsByPlace } from '@/lib/supabase/queries/recommendations'
+import { getPlaceVideos } from '@/lib/supabase/queries/videos'
 import { createClient } from '@/lib/supabase/server'
 import type { Place, Recommendation } from '@/lib/supabase/types'
+import { VideoPlayer } from '@/components/v2/VideoPlayer'
 import { DIET_TAGS_MAP, dietTagLabel, recTagLabel } from '@/lib/constants'
 
 type RecoView = {
@@ -102,6 +104,21 @@ export default async function RecommandationPage({
   const { data: row, error } = await getPlaceBySlug(slug)
   if (error || !row) notFound()
   const l: MockLieu = adaptDbPlace(row)
+
+  // Fetch des vidéos du lieu (mig 43 PR-3) — public read OK via RLS.
+  const { data: videos } = await getPlaceVideos(row.id)
+  const videoEntries = (videos ?? []).map((v) => {
+    const videoUrl = supabase.storage.from('place-videos').getPublicUrl(v.storage_path).data.publicUrl
+    const thumbnailUrl = v.thumbnail_storage_path
+      ? supabase.storage.from('place-videos').getPublicUrl(v.thumbnail_storage_path).data.publicUrl
+      : null
+    return {
+      id: v.id,
+      videoUrl,
+      thumbnailUrl,
+      durationSeconds: v.duration_seconds,
+    }
+  })
 
   // Fetch les recommandations publiées pour ce lieu + leurs autrices.
   const { data: recos } = await getRecommendationsByPlace(row.id)
@@ -191,6 +208,36 @@ export default async function RecommandationPage({
           </div>
         </div>
       </section>
+
+      {/* Section Vidéos — Sélection Hilmy uniquement (vidéos absentes
+          sinon). Affiché juste après le hero pour mettre en avant le
+          format pour les fiches premium. */}
+      {videoEntries.length > 0 && (
+        <section className="bg-creme-soft py-12 md:py-16">
+          <div className="mx-auto max-w-container px-6 md:px-20">
+            <FadeInSection>
+              <header className="flex items-center gap-5">
+                <GoldLine width={60} />
+                <span className="overline text-or">
+                  Découvre {l.nom} en vidéo
+                </span>
+              </header>
+              <div className="mt-6 grid gap-5 md:grid-cols-2">
+                {videoEntries.map((v) => (
+                  <VideoPlayer
+                    key={v.id}
+                    videoUrl={v.videoUrl}
+                    thumbnailUrl={v.thumbnailUrl}
+                    durationSeconds={v.durationSeconds}
+                    ariaLabel={`Voir la vidéo de ${l.nom}`}
+                    fallbackColor={l.cover}
+                  />
+                ))}
+              </div>
+            </FadeInSection>
+          </div>
+        </section>
+      )}
 
       <section className="py-16 md:py-24">
         <div className="mx-auto max-w-container px-6 md:px-20">

--- a/app/recommandation/[slug]/page.tsx
+++ b/app/recommandation/[slug]/page.tsx
@@ -222,18 +222,32 @@ export default async function RecommandationPage({
                   Découvre {l.nom} en vidéo
                 </span>
               </header>
-              <div className="mt-6 grid gap-5 md:grid-cols-2">
-                {videoEntries.map((v) => (
+              {videoEntries.length === 1 ? (
+                <div className="mt-6">
                   <VideoPlayer
-                    key={v.id}
-                    videoUrl={v.videoUrl}
-                    thumbnailUrl={v.thumbnailUrl}
-                    durationSeconds={v.durationSeconds}
+                    videoUrl={videoEntries[0].videoUrl}
+                    thumbnailUrl={videoEntries[0].thumbnailUrl}
+                    durationSeconds={videoEntries[0].durationSeconds}
                     ariaLabel={`Voir la vidéo de ${l.nom}`}
                     fallbackColor={l.cover}
+                    size="large"
                   />
-                ))}
-              </div>
+                </div>
+              ) : (
+                <div className="mt-6 grid gap-5 md:grid-cols-2">
+                  {videoEntries.map((v) => (
+                    <VideoPlayer
+                      key={v.id}
+                      videoUrl={v.videoUrl}
+                      thumbnailUrl={v.thumbnailUrl}
+                      durationSeconds={v.durationSeconds}
+                      ariaLabel={`Voir la vidéo de ${l.nom}`}
+                      fallbackColor={l.cover}
+                      size="medium"
+                    />
+                  ))}
+                </div>
+              )}
             </FadeInSection>
           </div>
         </section>

--- a/app/recommandations/page.tsx
+++ b/app/recommandations/page.tsx
@@ -72,9 +72,26 @@ export default function RecommandationsPage() {
           setLoading(false)
           return
         }
-        const adapted = (data ?? []).map((row) =>
-          adaptPlaceFromDb(row as unknown as Place),
-        )
+        const placeRows = (data ?? []) as unknown as (Place & { id: string })[]
+
+        // Pré-fetch has_videos en batch (mig 43 PR-3 — badge ▶ VIDÉO).
+        // Public read OK via RLS place_videos_public_read.
+        const placeIds = placeRows.map((p) => p.id)
+        let videoIds = new Set<string>()
+        if (placeIds.length > 0) {
+          const { data: videoRows } = await supabase
+            .from('place_videos')
+            .select('place_id')
+            .in('place_id', placeIds)
+          videoIds = new Set(
+            ((videoRows ?? []) as { place_id: string }[]).map((r) => r.place_id),
+          )
+        }
+
+        const adapted = placeRows.map((row) => ({
+          ...adaptPlaceFromDb(row),
+          has_videos: videoIds.has(row.id),
+        }))
         setLiveLieux(adapted)
         setLoading(false)
       } catch (e) {

--- a/components/v2/LieuCard.tsx
+++ b/components/v2/LieuCard.tsx
@@ -60,6 +60,17 @@ export function LieuCard({ lieu, index = 0 }: Props) {
           <div className="absolute left-5 top-5 inline-flex max-w-[60%] items-center gap-2 truncate rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
             {catLabel(lieu.categorie)}
           </div>
+          {lieu.has_videos && (
+            <div
+              className="absolute right-5 top-5 inline-flex shrink-0 items-center gap-1.5 rounded-full bg-blanc/90 px-2.5 py-1 text-[10px] font-medium tracking-[0.22em] text-vert backdrop-blur uppercase"
+              aria-label="Cette fiche contient une vidéo"
+            >
+              <svg width="10" height="10" viewBox="0 0 22 22" fill="currentColor" aria-hidden="true" className="text-or">
+                <path d="M5 3l14 8-14 8z" />
+              </svg>
+              Vidéo
+            </div>
+          )}
           {lieu.recommandePar.length > 0 && (
             <div className="absolute bottom-5 left-5 flex items-center gap-2">
               <div className="flex -space-x-2">

--- a/components/v2/PrestataireCard.tsx
+++ b/components/v2/PrestataireCard.tsx
@@ -59,6 +59,17 @@ export function PrestataireCard({ p, index = 0 }: Props) {
               {p.note.toFixed(1)}
             </div>
           )}
+          {p.has_videos && (
+            <div
+              className={`absolute ${p.lesAvis && p.lesAvis.length > 0 ? 'right-5 top-12' : 'right-5 top-5'} inline-flex shrink-0 items-center gap-1.5 rounded-full bg-blanc/90 px-2.5 py-1 text-[10px] font-medium tracking-[0.22em] text-vert backdrop-blur uppercase`}
+              aria-label="Cette fiche contient une vidéo"
+            >
+              <svg width="10" height="10" viewBox="0 0 22 22" fill="currentColor" aria-hidden="true" className="text-or">
+                <path d="M5 3l14 8-14 8z" />
+              </svg>
+              Vidéo
+            </div>
+          )}
           {/* Badge palier — visible seulement pour premium/cercle_pro
               (le standard est le défaut, on ne badge pas pour ne pas
               surcharger la liste). */}

--- a/components/v2/UploadVideo.tsx
+++ b/components/v2/UploadVideo.tsx
@@ -1,0 +1,426 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { nanoid } from 'nanoid'
+import { createClient } from '@/lib/supabase/client'
+
+/**
+ * Composant client pour uploader une vidéo MP4 vers Supabase Storage,
+ * avec compression côté client via ffmpeg.wasm (lazy import) et
+ * génération automatique d'un thumbnail JPEG.
+ *
+ * FLOW (séquentiel pour éviter les orphelins en cas de fail partiel) :
+ *   1. Pre-check côté client (file.size <= 100 MB d'input, MIME vidéo)
+ *   2. Lazy import @ffmpeg/ffmpeg + @ffmpeg/util (~25 MB, 1ère fois ~30s)
+ *   3. Compression H.264 1080p 2 Mbps + AAC 128 kbps (-t maxDurationSeconds
+ *      pour cropper si > cap palier)
+ *   4. Génération thumbnail JPEG 720p à 1s
+ *   5. Upload vidéo Supabase Storage → {user_id}/{nanoid}.mp4
+ *   6. Upload thumbnail Storage → {user_id}/{nanoid}.jpg (best-effort)
+ *   7. POST /api/videos/upload (validation palier server + INSERT BDD)
+ *   8. onUploadComplete() callback pour refresh la liste UI
+ *
+ * Threading ffmpeg.wasm :
+ *   Les routes où ce composant est monté (/dashboard/prestataire/fiche
+ *   et /dashboard/lieu/[placeId]) ont les headers COOP/COEP scopés
+ *   activés (cf next.config.js). ffmpeg.wasm utilise donc le mode
+ *   multi-thread (3-5× plus rapide). Sur les browsers où
+ *   crossOriginIsolated=false (Safari iOS < 16.4 par exemple), fallback
+ *   single-thread automatique.
+ *
+ * ⚠️ Cap durée + count par palier sont validés CÔTÉ SERVEUR par
+ * /api/videos/upload (defense in depth). Le client check juste le cap
+ * durée pour cropper la vidéo avant compression — pas de validation
+ * count côté client (pas critique, le serveur tranche).
+ */
+
+interface Props {
+  /** XOR avec placeId : exactement un des deux. */
+  profileId?: string
+  placeId?: string
+  /** UUID owner du fichier Storage (storage_owner_from_path mig 08). */
+  userId: string
+  /** Durée max autorisée pour cette fiche (60 Premium, 90 Cercle Pro). */
+  maxDurationSeconds: number
+  /** Callback après INSERT BDD réussie — la page parent rafraîchit la liste. */
+  onUploadComplete?: () => void
+  /** Callback en cas d'erreur (affichage UI à la page parent). */
+  onError?: (message: string) => void
+}
+
+type UploadState =
+  | { phase: 'idle' }
+  | { phase: 'loading-ffmpeg'; firstTime: boolean }
+  | { phase: 'compressing'; progress: number }
+  | { phase: 'thumbnailing' }
+  | { phase: 'uploading-video' }
+  | { phase: 'uploading-thumbnail' }
+  | { phase: 'inserting-db' }
+  | { phase: 'done' }
+  | { phase: 'error'; message: string }
+
+const MAX_INPUT_BYTES = 100 * 1024 * 1024 // 100 MB hard limit côté client
+const ACCEPTED_MIMES = ['video/mp4', 'video/quicktime', 'video/webm']
+
+// Cache partagé de ffmpeg pour éviter le recharger à chaque upload
+// (lifetime = vie de la page React, reset au refresh).
+let cachedFFmpeg: unknown = null
+
+export function UploadVideo({
+  profileId,
+  placeId,
+  userId,
+  maxDurationSeconds,
+  onUploadComplete,
+  onError,
+}: Props) {
+  const [state, setState] = useState<UploadState>({ phase: 'idle' })
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  // XOR runtime check (TS ne peut pas l'imposer)
+  if ((profileId && placeId) || (!profileId && !placeId)) {
+    return (
+      <p className="text-[12px] text-red-900">
+        Erreur configuration UploadVideo : profile_id OU place_id requis.
+      </p>
+    )
+  }
+
+  const isUploading = state.phase !== 'idle' && state.phase !== 'error' && state.phase !== 'done'
+
+  const reportError = (msg: string) => {
+    setState({ phase: 'error', message: msg })
+    onError?.(msg)
+  }
+
+  const handleFile = async (file: File) => {
+    // ─── 1. Pre-check côté client ───────────────────────────────────
+    if (!ACCEPTED_MIMES.includes(file.type)) {
+      reportError(
+        'Format non supporté. Utilise un .mp4, .mov ou .webm.',
+      )
+      return
+    }
+    if (file.size > MAX_INPUT_BYTES) {
+      reportError(
+        'Vidéo trop lourde (max 100 Mo en input). Compresse-la avant ou choisis un format plus court.',
+      )
+      return
+    }
+
+    try {
+      // ─── 2. Lazy import + load ffmpeg ──────────────────────────────
+      const isFirstTime = cachedFFmpeg === null
+      setState({ phase: 'loading-ffmpeg', firstTime: isFirstTime })
+
+      // Dynamic imports — ffmpeg.wasm core (~25 MB) chargé à la demande
+      const [{ FFmpeg }, { fetchFile, toBlobURL }] = await Promise.all([
+        import('@ffmpeg/ffmpeg'),
+        import('@ffmpeg/util'),
+      ])
+
+      type FFmpegInstance = InstanceType<typeof FFmpeg>
+      let ffmpeg: FFmpegInstance
+      if (cachedFFmpeg) {
+        ffmpeg = cachedFFmpeg as FFmpegInstance
+      } else {
+        ffmpeg = new FFmpeg()
+
+        // Charge le core depuis unpkg (CSP: connect-src étendu dans
+        // next.config.js pour autoriser unpkg.com). Single-thread par
+        // défaut — le multi-thread requiert @ffmpeg/core-mt qui n'est
+        // pas encore stable sur tous les navigateurs.
+        const baseURL = 'https://unpkg.com/@ffmpeg/core@0.12.10/dist/umd'
+        await ffmpeg.load({
+          coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, 'text/javascript'),
+          wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, 'application/wasm'),
+        })
+        cachedFFmpeg = ffmpeg
+      }
+
+      // ─── 3. Compression vidéo ──────────────────────────────────────
+      setState({ phase: 'compressing', progress: 0 })
+
+      const onProgress = (e: { progress: number }) => {
+        setState({
+          phase: 'compressing',
+          progress: Math.min(100, Math.max(0, Math.round(e.progress * 100))),
+        })
+      }
+      ffmpeg.on('progress', onProgress)
+
+      const inputName = `input.${file.name.split('.').pop()?.toLowerCase() || 'mp4'}`
+      const compressedName = 'output.mp4'
+      const thumbName = 'thumb.jpg'
+
+      await ffmpeg.writeFile(inputName, await fetchFile(file))
+
+      // -t = crop durée à maxDurationSeconds. -c:v libx264 -preset fast
+      // -b:v 2M = 2 Mbps video. -c:a aac -b:a 128k. -vf scale=-2:1080
+      // pour borner hauteur 1080p (largeur calculée en preserving ratio).
+      await ffmpeg.exec([
+        '-i', inputName,
+        '-t', String(maxDurationSeconds),
+        '-c:v', 'libx264',
+        '-preset', 'fast',
+        '-b:v', '2M',
+        '-vf', 'scale=-2:1080',
+        '-c:a', 'aac',
+        '-b:a', '128k',
+        '-movflags', '+faststart',
+        compressedName,
+      ])
+
+      // ─── 4. Génération thumbnail JPEG (frame à 1s, 720p) ──────────
+      setState({ phase: 'thumbnailing' })
+      try {
+        await ffmpeg.exec([
+          '-i', compressedName,
+          '-ss', '00:00:01',
+          '-frames:v', '1',
+          '-vf', 'scale=-2:720',
+          '-q:v', '4',
+          thumbName,
+        ])
+      } catch {
+        // Best-effort : si la génération thumbnail fail, on continue
+        // sans thumbnail (la vidéo reste utilisable).
+      }
+      ffmpeg.off('progress', onProgress)
+
+      // Lit les fichiers compressés depuis le FS virtuel ffmpeg
+      const compressedData = await ffmpeg.readFile(compressedName)
+      const compressedBlob = new Blob([compressedData as Uint8Array], {
+        type: 'video/mp4',
+      })
+
+      let thumbnailBlob: Blob | null = null
+      try {
+        const thumbData = await ffmpeg.readFile(thumbName)
+        thumbnailBlob = new Blob([thumbData as Uint8Array], { type: 'image/jpeg' })
+      } catch {
+        thumbnailBlob = null
+      }
+
+      // Récupère la durée réelle de la vidéo compressée (peut être
+      // < maxDurationSeconds si la source était plus courte).
+      const probedDuration = await probeVideoDuration(compressedBlob)
+      const finalDuration = Math.min(
+        Math.max(1, Math.round(probedDuration)),
+        maxDurationSeconds,
+      )
+
+      const finalSize = compressedBlob.size
+      if (finalSize > 50 * 1024 * 1024) {
+        reportError(
+          'La vidéo compressée dépasse 50 Mo. Choisis une vidéo plus courte ou de qualité plus basse.',
+        )
+        return
+      }
+
+      // ─── 5. Upload vidéo Supabase Storage ──────────────────────────
+      setState({ phase: 'uploading-video' })
+      const supabase = createClient()
+      const bucket = profileId ? 'profile-videos' : 'place-videos'
+      const videoNanoid = nanoid()
+      const thumbNanoid = nanoid()
+      const videoStoragePath = `${userId}/${videoNanoid}.mp4`
+      const thumbStoragePath = `${userId}/${thumbNanoid}.jpg`
+
+      const videoUpload = await supabase.storage
+        .from(bucket)
+        .upload(videoStoragePath, compressedBlob, {
+          cacheControl: '3600',
+          contentType: 'video/mp4',
+        })
+      if (videoUpload.error) {
+        reportError(`Upload vidéo échoué : ${videoUpload.error.message}`)
+        return
+      }
+
+      // ─── 6. Upload thumbnail (best-effort) ─────────────────────────
+      let thumbnailFinalPath: string | null = null
+      if (thumbnailBlob) {
+        setState({ phase: 'uploading-thumbnail' })
+        const thumbUpload = await supabase.storage
+          .from(bucket)
+          .upload(thumbStoragePath, thumbnailBlob, {
+            cacheControl: '3600',
+            contentType: 'image/jpeg',
+          })
+        if (!thumbUpload.error) {
+          thumbnailFinalPath = thumbStoragePath
+        }
+      }
+
+      // ─── 7. INSERT BDD via API route (validation palier server) ────
+      setState({ phase: 'inserting-db' })
+      const apiBody: Record<string, unknown> = {
+        storage_path: videoStoragePath,
+        thumbnail_storage_path: thumbnailFinalPath,
+        duration_seconds: finalDuration,
+        size_bytes: finalSize,
+      }
+      if (profileId) apiBody.profile_id = profileId
+      if (placeId) apiBody.place_id = placeId
+
+      const res = await fetch('/api/videos/upload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(apiBody),
+      })
+      const json = await res.json().catch(() => null)
+      if (!res.ok) {
+        reportError(
+          (json?.error as string) ||
+            "L'enregistrement de la vidéo a échoué. Réessaie.",
+        )
+        return
+      }
+
+      // ─── 8. Done ───────────────────────────────────────────────────
+      setState({ phase: 'done' })
+      onUploadComplete?.()
+
+      // Reset après 2s
+      setTimeout(() => setState({ phase: 'idle' }), 2000)
+
+      // Cleanup FS virtuel ffmpeg pour libérer mémoire
+      try {
+        await ffmpeg.deleteFile(inputName)
+        await ffmpeg.deleteFile(compressedName)
+        await ffmpeg.deleteFile(thumbName)
+      } catch {
+        // Best-effort
+      }
+    } catch (err) {
+      reportError(
+        err instanceof Error
+          ? `Erreur compression : ${err.message}`
+          : 'Erreur inattendue pendant la compression.',
+      )
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPTED_MIMES.join(',')}
+        className="hidden"
+        onChange={(e) => {
+          const f = e.target.files?.[0]
+          if (f) handleFile(f)
+          // Reset input pour permettre un re-upload du même fichier
+          if (e.target) e.target.value = ''
+        }}
+        disabled={isUploading}
+      />
+
+      {state.phase === 'idle' && (
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="inline-flex h-12 items-center gap-2 rounded-full border border-or/40 bg-blanc px-6 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-or hover:bg-creme-soft"
+        >
+          + Ajouter une vidéo
+          <span className="text-or" aria-hidden="true">→</span>
+        </button>
+      )}
+
+      {state.phase === 'loading-ffmpeg' && (
+        <div className="rounded-sm border border-or/30 bg-creme-soft px-4 py-3">
+          <p className="font-serif text-[15px] italic text-vert">
+            {state.firstTime
+              ? 'Première fois ? Hilmy charge l\'outil de compression vidéo (~30s)…'
+              : 'Préparation de la compression…'}
+          </p>
+          <div className="mt-2 h-1 w-full overflow-hidden rounded-full bg-or/20">
+            <div className="h-full w-1/3 animate-pulse bg-or" />
+          </div>
+        </div>
+      )}
+
+      {state.phase === 'compressing' && (
+        <div className="rounded-sm border border-or/30 bg-creme-soft px-4 py-3">
+          <p className="font-serif text-[15px] italic text-vert">
+            Compression en cours… {state.progress}%
+          </p>
+          <div className="mt-2 h-1 w-full overflow-hidden rounded-full bg-or/20">
+            <div
+              className="h-full bg-or transition-all duration-300"
+              style={{ width: `${state.progress}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {state.phase === 'thumbnailing' && (
+        <p className="text-[13px] italic text-texte-sec">
+          Préparation du visuel d&apos;aperçu…
+        </p>
+      )}
+
+      {state.phase === 'uploading-video' && (
+        <p className="text-[13px] italic text-texte-sec">
+          Envoi de la vidéo sur Hilmy…
+        </p>
+      )}
+
+      {state.phase === 'uploading-thumbnail' && (
+        <p className="text-[13px] italic text-texte-sec">
+          Envoi du visuel d&apos;aperçu…
+        </p>
+      )}
+
+      {state.phase === 'inserting-db' && (
+        <p className="text-[13px] italic text-texte-sec">
+          Finalisation…
+        </p>
+      )}
+
+      {state.phase === 'done' && (
+        <p className="rounded-sm border border-or/30 bg-or/10 px-3 py-2 text-[13px] text-vert">
+          ✓ Vidéo ajoutée. Elle apparaît sur ta fiche publique.
+        </p>
+      )}
+
+      {state.phase === 'error' && (
+        <div className="rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2">
+          <p className="text-[13px] text-red-900">{state.message}</p>
+          <button
+            type="button"
+            onClick={() => setState({ phase: 'idle' })}
+            className="mt-2 text-[11px] tracking-[0.22em] text-or-deep uppercase hover:text-or"
+          >
+            Réessayer →
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Probe la durée réelle d'une vidéo via un <video> element invisible.
+ * Plus rapide que de re-parser via ffmpeg, fonctionne en natif browser.
+ * Fallback à 0 si le probing fail (rare, mais possible).
+ */
+async function probeVideoDuration(blob: Blob): Promise<number> {
+  return new Promise<number>((resolve) => {
+    const url = URL.createObjectURL(blob)
+    const video = document.createElement('video')
+    video.preload = 'metadata'
+    video.onloadedmetadata = () => {
+      const d = video.duration
+      URL.revokeObjectURL(url)
+      resolve(Number.isFinite(d) ? d : 0)
+    }
+    video.onerror = () => {
+      URL.revokeObjectURL(url)
+      resolve(0)
+    }
+    video.src = url
+  })
+}

--- a/components/v2/VideoPlayer.tsx
+++ b/components/v2/VideoPlayer.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react'
 
+export type VideoPlayerSize = 'small' | 'medium' | 'large'
+
 interface Props {
   /** URL publique de la vidéo (Supabase Storage public bucket). */
   videoUrl: string
@@ -13,6 +15,16 @@ interface Props {
   ariaLabel?: string
   /** Couleur de fallback si pas de thumbnail (ex: '#D4C5B0'). */
   fallbackColor?: string
+  /**
+   * Taille du lecteur :
+   *   - 'small'  : dashboard owner (grille 2-cols, parent dicte largeur)
+   *   - 'medium' : fiche publique avec 2+ vidéos (max-w 600, mx-auto)
+   *   - 'large'  : fiche publique avec 1 seule vidéo (max-w 800, mx-auto,
+   *                aspect-ratio dicté par la vidéo elle-même → portrait
+   *                ou paysage rendus en intrinsic)
+   * Default 'medium' pour la rétrocompat.
+   */
+  size?: VideoPlayerSize
 }
 
 /**
@@ -32,6 +44,7 @@ export function VideoPlayer({
   durationSeconds,
   ariaLabel = 'Voir la vidéo',
   fallbackColor = '#D4C5B0',
+  size = 'medium',
 }: Props) {
   const [playing, setPlaying] = useState(false)
 
@@ -39,9 +52,34 @@ export function VideoPlayer({
   const seconds = Math.floor(durationSeconds % 60)
   const durationLabel = `${minutes}:${seconds.toString().padStart(2, '0')}`
 
+  const hasThumbnail = thumbnailUrl !== null && thumbnailUrl.length > 0
+
+  // Intrinsic = la vidéo/thumbnail dicte le ratio (size=large + thumbnail
+  // dispo). Sans thumbnail, on garde aspect-video pour ne pas avoir un
+  // bouton de hauteur 0 avant chargement.
+  const isIntrinsic = size === 'large' && hasThumbnail
+
+  const maxWidthClass =
+    size === 'small'
+      ? ''
+      : size === 'medium'
+        ? 'mx-auto max-w-[600px]'
+        : 'mx-auto max-w-[800px]'
+
+  // Container : aspect-video sauf en mode intrinsic (ratio dicté par
+  // l'image/vidéo elle-même via block + h-auto).
+  const aspectClass = isIntrinsic ? '' : 'aspect-video'
+
   if (playing) {
+    // En lecture : pareil — large + thumbnail = intrinsic, sinon
+    // aspect-video + object-contain pour letterbox propre.
+    const videoLayoutClass = isIntrinsic
+      ? 'block h-auto w-full'
+      : 'h-full w-full object-contain'
     return (
-      <div className="relative aspect-video w-full overflow-hidden rounded-sm bg-vert">
+      <div
+        className={`relative w-full ${maxWidthClass} ${aspectClass} overflow-hidden rounded-sm bg-vert`}
+      >
         {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
         <video
           src={videoUrl}
@@ -49,21 +87,23 @@ export function VideoPlayer({
           controls
           autoPlay
           playsInline
-          className="h-full w-full object-contain"
+          className={videoLayoutClass}
           aria-label={ariaLabel}
         />
       </div>
     )
   }
 
-  const hasThumbnail = thumbnailUrl !== null && thumbnailUrl.length > 0
+  const imgLayoutClass = isIntrinsic
+    ? 'block h-auto w-full transition-transform duration-700 group-hover:scale-[1.02]'
+    : 'absolute inset-0 h-full w-full object-contain transition-transform duration-700 group-hover:scale-[1.02]'
 
   return (
     <button
       type="button"
       onClick={() => setPlaying(true)}
       aria-label={ariaLabel}
-      className="group relative aspect-video w-full overflow-hidden rounded-sm bg-creme-deep transition-shadow hover:shadow-[0_30px_60px_-30px_rgba(15,61,46,0.35)]"
+      className={`group relative block w-full ${maxWidthClass} ${aspectClass} overflow-hidden rounded-sm bg-creme-deep transition-shadow hover:shadow-[0_30px_60px_-30px_rgba(15,61,46,0.35)]`}
       style={
         hasThumbnail
           ? undefined
@@ -77,7 +117,7 @@ export function VideoPlayer({
         <img
           src={thumbnailUrl as string}
           alt=""
-          className="absolute inset-0 h-full w-full object-contain transition-transform duration-700 group-hover:scale-[1.02]"
+          className={imgLayoutClass}
           loading="lazy"
         />
       )}

--- a/components/v2/VideoPlayer.tsx
+++ b/components/v2/VideoPlayer.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useState } from 'react'
+
+interface Props {
+  /** URL publique de la vidéo (Supabase Storage public bucket). */
+  videoUrl: string
+  /** URL publique du thumbnail JPEG. NULL = fallback couleur cover. */
+  thumbnailUrl: string | null
+  /** Durée en secondes (pour l'affichage "0:42"). */
+  durationSeconds: number
+  /** Aria label pour l'accessibilité. */
+  ariaLabel?: string
+  /** Couleur de fallback si pas de thumbnail (ex: '#D4C5B0'). */
+  fallbackColor?: string
+}
+
+/**
+ * Lecteur vidéo clic-to-play : affiche un thumbnail + overlay or rond
+ * avec icône ▶ et label "Voir la vidéo". Au clic, remplace par
+ * <video controls autoPlay> pour démarrer la lecture.
+ *
+ * Pas de auto-play sur mount (compatibilité iOS Safari + UX : la vidéo
+ * ne se lance que si la copine clique explicitement).
+ *
+ * Pas de tracking video_views dans cette PR (out of scope MVP). Voir
+ * tech-debt.md #8 pour la table à créer si on veut mesurer plus tard.
+ */
+export function VideoPlayer({
+  videoUrl,
+  thumbnailUrl,
+  durationSeconds,
+  ariaLabel = 'Voir la vidéo',
+  fallbackColor = '#D4C5B0',
+}: Props) {
+  const [playing, setPlaying] = useState(false)
+
+  const minutes = Math.floor(durationSeconds / 60)
+  const seconds = Math.floor(durationSeconds % 60)
+  const durationLabel = `${minutes}:${seconds.toString().padStart(2, '0')}`
+
+  if (playing) {
+    return (
+      <div className="relative aspect-video w-full overflow-hidden rounded-sm bg-vert">
+        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+        <video
+          src={videoUrl}
+          poster={thumbnailUrl ?? undefined}
+          controls
+          autoPlay
+          playsInline
+          className="h-full w-full object-cover"
+          aria-label={ariaLabel}
+        />
+      </div>
+    )
+  }
+
+  const hasThumbnail = thumbnailUrl !== null && thumbnailUrl.length > 0
+
+  return (
+    <button
+      type="button"
+      onClick={() => setPlaying(true)}
+      aria-label={ariaLabel}
+      className="group relative aspect-video w-full overflow-hidden rounded-sm bg-creme-deep transition-shadow hover:shadow-[0_30px_60px_-30px_rgba(15,61,46,0.35)]"
+      style={
+        hasThumbnail
+          ? undefined
+          : {
+              background: `linear-gradient(135deg, ${fallbackColor} 0%, ${fallbackColor} 100%)`,
+            }
+      }
+    >
+      {hasThumbnail && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={thumbnailUrl as string}
+          alt=""
+          className="absolute inset-0 h-full w-full object-cover transition-transform duration-700 group-hover:scale-[1.02]"
+          loading="lazy"
+        />
+      )}
+
+      {/* Overlay assombri pour lisibilité du label */}
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-vert/20 transition-opacity duration-300 group-hover:bg-vert/35"
+      />
+
+      {/* Cercle play centré + label */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-3">
+        <span
+          aria-hidden="true"
+          className="flex h-16 w-16 items-center justify-center rounded-full bg-or text-vert shadow-[0_8px_24px_-6px_rgba(201,169,97,0.7)] transition-transform duration-300 group-hover:scale-110 md:h-20 md:w-20"
+        >
+          <svg
+            width="22"
+            height="22"
+            viewBox="0 0 22 22"
+            fill="currentColor"
+            className="ml-[3px] md:h-7 md:w-7"
+          >
+            <path d="M5 3l14 8-14 8z" />
+          </svg>
+        </span>
+        <span className="font-serif text-[15px] italic text-creme drop-shadow-[0_1px_4px_rgba(15,61,46,0.6)] md:text-[17px]">
+          Voir la vidéo
+        </span>
+      </div>
+
+      {/* Durée bottom-right */}
+      <span className="absolute right-3 bottom-3 rounded-full bg-vert/85 px-2.5 py-1 text-[11px] font-medium tracking-wider text-creme backdrop-blur md:right-4 md:bottom-4">
+        {durationLabel}
+      </span>
+    </button>
+  )
+}

--- a/components/v2/VideoPlayer.tsx
+++ b/components/v2/VideoPlayer.tsx
@@ -49,7 +49,7 @@ export function VideoPlayer({
           controls
           autoPlay
           playsInline
-          className="h-full w-full object-cover"
+          className="h-full w-full object-contain"
           aria-label={ariaLabel}
         />
       </div>
@@ -77,7 +77,7 @@ export function VideoPlayer({
         <img
           src={thumbnailUrl as string}
           alt=""
-          className="absolute inset-0 h-full w-full object-cover transition-transform duration-700 group-hover:scale-[1.02]"
+          className="absolute inset-0 h-full w-full object-contain transition-transform duration-700 group-hover:scale-[1.02]"
           loading="lazy"
         />
       )}

--- a/components/v2/VideosManager.tsx
+++ b/components/v2/VideosManager.tsx
@@ -205,6 +205,7 @@ export function VideosManager(props: Props) {
                   videoUrl={videoUrl}
                   thumbnailUrl={thumbnailUrl}
                   durationSeconds={v.duration_seconds}
+                  size="small"
                 />
                 <div className="flex items-center justify-between gap-3">
                   <span className="text-[11px] text-texte-sec">

--- a/components/v2/VideosManager.tsx
+++ b/components/v2/VideosManager.tsx
@@ -1,0 +1,243 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import { UploadVideo } from '@/components/v2/UploadVideo'
+import { VideoPlayer } from '@/components/v2/VideoPlayer'
+import {
+  canUploadVideo,
+  canUploadPlaceVideo,
+  getVideoDurationCap,
+  getPlaceVideoDurationCap,
+  videoCountLabel,
+  placeVideoCountLabel,
+} from '@/lib/palier-limits'
+import type { Palier } from '@/app/tarifs/_lib/pricing'
+import type { LieuPalier } from '@/lib/permissions-lieux'
+
+type VideoRow = {
+  id: string
+  storage_path: string
+  thumbnail_storage_path: string | null
+  duration_seconds: number
+  size_bytes: number
+}
+
+interface BaseProps {
+  /** UUID owner du fichier Storage (= profile.user_id ou place.created_by_user_id). */
+  userId: string
+}
+
+type Props =
+  | (BaseProps & {
+      scope: 'prestataire'
+      profileId: string
+      palier: Palier
+    })
+  | (BaseProps & {
+      scope: 'lieu'
+      placeId: string
+      palier: LieuPalier
+    })
+
+/**
+ * Section UI "Mes vidéos" partagée entre dashboard prestataire fiche
+ * et dashboard lieu détail. Gère :
+ *   - Fetch initial des vidéos existantes
+ *   - Affichage VideoPlayer pour chacune
+ *   - Bouton "Supprimer" par vidéo
+ *   - Bouton UploadVideo si palier autorise + sous le cap count
+ *   - Mode "non autorisé" avec invitation à upgrader si palier=standard
+ *     ou palier=aucun
+ *
+ * Toutes les writes vidéo passent par les API routes /api/videos/*
+ * qui ré-valident palier + ownership server-side.
+ */
+export function VideosManager(props: Props) {
+  const [videos, setVideos] = useState<VideoRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  const isPresta = props.scope === 'prestataire'
+  const bucket = isPresta ? 'profile-videos' : 'place-videos'
+  const supabaseTable = isPresta ? 'profile_videos' : 'place_videos'
+  const fkColumn = isPresta ? 'profile_id' : 'place_id'
+  const fkValue = isPresta ? props.profileId : props.placeId
+
+  const fetchVideos = async () => {
+    const supabase = createClient()
+    const { data, error: fetchErr } = await supabase
+      .from(supabaseTable)
+      .select('id, storage_path, thumbnail_storage_path, duration_seconds, size_bytes')
+      .eq(fkColumn, fkValue)
+      .order('created_at', { ascending: true })
+    if (fetchErr) {
+      setError(fetchErr.message)
+      setLoading(false)
+      return
+    }
+    setVideos((data ?? []) as VideoRow[])
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    fetchVideos()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fkValue])
+
+  const handleDelete = async (videoId: string) => {
+    if (
+      typeof window !== 'undefined' &&
+      !window.confirm(
+        'Supprimer définitivement cette vidéo ? Cette action est irréversible.',
+      )
+    ) {
+      return
+    }
+    setDeletingId(videoId)
+    setError(null)
+    try {
+      const res = await fetch(
+        `/api/videos/${videoId}?type=${isPresta ? 'prestataire' : 'lieu'}`,
+        { method: 'DELETE' },
+      )
+      if (!res.ok) {
+        const json = await res.json().catch(() => null)
+        setError(json?.error || 'La suppression a échoué.')
+        setDeletingId(null)
+        return
+      }
+      setVideos((vs) => vs.filter((v) => v.id !== videoId))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur réseau.')
+    }
+    setDeletingId(null)
+  }
+
+  // Cap durée + count selon palier
+  const durationCap = isPresta
+    ? getVideoDurationCap(props.palier)
+    : getPlaceVideoDurationCap(props.palier)
+  const canUpload = isPresta
+    ? canUploadVideo(props.palier, videos.length)
+    : canUploadPlaceVideo(props.palier, videos.length)
+  const countLabel = isPresta
+    ? videoCountLabel(props.palier, videos.length)
+    : placeVideoCountLabel(props.palier, videos.length)
+
+  // Helper public URL Storage
+  const getPublicUrl = (path: string) => {
+    const supabase = createClient()
+    const { data } = supabase.storage.from(bucket).getPublicUrl(path)
+    return data.publicUrl
+  }
+
+  if (loading) {
+    return (
+      <div className="h-32 animate-pulse rounded-sm bg-creme-deep" />
+    )
+  }
+
+  // Mode "vidéo non incluse" : Standard / palier=aucun → upsell card,
+  // pas de upload possible.
+  if (durationCap === 0) {
+    const upsellTarget = isPresta
+      ? '/dashboard/prestataire/abonnement'
+      : '/tarifs#selection-hilmy'
+    const upsellLabel = isPresta ? 'Passer Premium' : 'Passer Sélection Hilmy'
+    return (
+      <div className="rounded-sm border border-or/30 bg-creme-soft p-6 md:p-7">
+        <p className="overline text-or">Vidéo · disponible avec l&apos;upgrade</p>
+        <p className="mt-2 font-serif text-[18px] italic leading-[1.4] text-vert md:text-[20px]">
+          Tu peux te montrer en mouvement avec une vidéo de 60 à 90 secondes.
+        </p>
+        <p className="mt-2 max-w-2xl text-[13px] leading-[1.6] text-texte-sec">
+          {isPresta
+            ? 'Une vidéo courte t\'aide à transmettre l\'ambiance de tes prestations — ce qui ne passe pas en photo. Disponible dès le palier Premium.'
+            : "Une vidéo courte montre l'ambiance du lieu. Disponible avec Sélection Hilmy."}
+        </p>
+        <a
+          href={upsellTarget}
+          className="mt-5 inline-flex h-11 items-center gap-2 rounded-full bg-vert px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+        >
+          {upsellLabel}
+          <span className="text-or-light" aria-hidden="true">→</span>
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[12px] tracking-[0.22em] text-texte-sec uppercase">
+          {countLabel}
+        </p>
+        {!canUpload && videos.length > 0 && (
+          <p className="text-[11px] italic text-texte-sec">
+            Limite atteinte sur ton palier.
+          </p>
+        )}
+      </div>
+
+      {error && (
+        <p className="rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[12px] text-red-900">
+          {error}
+        </p>
+      )}
+
+      {videos.length === 0 ? (
+        <p className="rounded-sm border border-dashed border-or/30 bg-blanc p-6 text-center text-[13px] italic text-texte-sec md:p-8">
+          Pas encore de vidéo. Une vidéo courte (60-90s) aide les copines
+          à sentir ton univers en quelques secondes.
+        </p>
+      ) : (
+        <ul className="grid gap-4 md:grid-cols-2">
+          {videos.map((v) => {
+            const videoUrl = getPublicUrl(v.storage_path)
+            const thumbnailUrl = v.thumbnail_storage_path
+              ? getPublicUrl(v.thumbnail_storage_path)
+              : null
+            return (
+              <li key={v.id} className="space-y-3">
+                <VideoPlayer
+                  videoUrl={videoUrl}
+                  thumbnailUrl={thumbnailUrl}
+                  durationSeconds={v.duration_seconds}
+                />
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-[11px] text-texte-sec">
+                    {(v.size_bytes / (1024 * 1024)).toFixed(1)} Mo · {v.duration_seconds}s
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(v.id)}
+                    disabled={deletingId === v.id}
+                    className="text-[11px] tracking-[0.22em] text-red-900 uppercase hover:text-red-700 disabled:opacity-60"
+                  >
+                    {deletingId === v.id ? 'Suppression…' : 'Supprimer'}
+                  </button>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+
+      {canUpload && (
+        <div className="pt-2">
+          <UploadVideo
+            {...(isPresta
+              ? { profileId: props.profileId }
+              : { placeId: props.placeId })}
+            userId={props.userId}
+            maxDurationSeconds={durationCap}
+            onUploadComplete={() => fetchVideos()}
+            onError={(msg) => setError(msg)}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -108,6 +108,9 @@ export type Prestataire = {
   telephone?: string;
   instagram?: string;
   palier?: 'standard' | 'premium' | 'cercle_pro';
+  /** Boolean flag pour le badge ▶ VIDÉO sur la card feed (PR-3 mig 43).
+   *  Pré-fetché côté server via `getProfileIdsWithVideos` pour éviter N+1. */
+  has_videos?: boolean;
 };
 
 export const prestataires: Prestataire[] = [
@@ -367,6 +370,9 @@ export type Lieu = {
   galerie: string[];
   recommandePar: { prenom: string; avatar: string; date: string }[];
   commentaires: { prenom: string; avatar: string; texte: string; date: string }[];
+  /** Boolean flag pour le badge ▶ VIDÉO sur la card feed (PR-3 mig 43).
+   *  Pré-fetché côté server via `getPlaceIdsWithVideos` pour éviter N+1. */
+  has_videos?: boolean;
 };
 
 export const lieux: Lieu[] = [

--- a/lib/supabase/queries/videos.ts
+++ b/lib/supabase/queries/videos.ts
@@ -1,0 +1,168 @@
+/**
+ * Queries vidéos prestataires + lieux (mig 43).
+ *
+ * Public read OK via RLS (`*_public_read TO anon, authenticated`).
+ * Owner write OK via RLS (`*_owner_write` qui filtre profile.user_id /
+ * places.created_by_user_id).
+ *
+ * Pour les writes server-side (API routes), on passe par admin client
+ * après validation owner manuelle — voir app/api/videos/upload/route.ts.
+ */
+
+import { createClient as createServerClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type {
+  PlaceVideo,
+  ProfileVideo,
+  QueryResult,
+} from "@/lib/supabase/types";
+
+const PROFILE_VIDEO_SELECT = `
+  id,
+  profile_id,
+  storage_path,
+  thumbnail_storage_path,
+  duration_seconds,
+  size_bytes,
+  created_at,
+  updated_at
+`;
+
+const PLACE_VIDEO_SELECT = `
+  id,
+  place_id,
+  storage_path,
+  thumbnail_storage_path,
+  duration_seconds,
+  size_bytes,
+  created_at,
+  updated_at
+`;
+
+/** Liste les vidéos d'un prestataire (server-side, public read). */
+export async function getProfileVideos(
+  profileId: string,
+): Promise<QueryResult<ProfileVideo[]>> {
+  try {
+    const supabase = await createServerClient();
+    const { data, error } = await supabase
+      .from("profile_videos")
+      .select(PROFILE_VIDEO_SELECT)
+      .eq("profile_id", profileId)
+      .order("created_at", { ascending: true });
+
+    if (error) return { data: null, error: error.message };
+    return { data: (data ?? []) as unknown as ProfileVideo[], error: null };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
+/** Liste les vidéos d'un lieu (server-side, public read). */
+export async function getPlaceVideos(
+  placeId: string,
+): Promise<QueryResult<PlaceVideo[]>> {
+  try {
+    const supabase = await createServerClient();
+    const { data, error } = await supabase
+      .from("place_videos")
+      .select(PLACE_VIDEO_SELECT)
+      .eq("place_id", placeId)
+      .order("created_at", { ascending: true });
+
+    if (error) return { data: null, error: error.message };
+    return { data: (data ?? []) as unknown as PlaceVideo[], error: null };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
+/**
+ * Pour un set de profile_id, retourne le sous-ensemble de ceux qui ont
+ * au moins une vidéo. Optimisé pour le badge ▶ VIDÉO sur les feed cards
+ * de l'annuaire (1 query batch au lieu de N+1).
+ */
+export async function getProfileIdsWithVideos(
+  profileIds: string[],
+): Promise<Set<string>> {
+  if (profileIds.length === 0) return new Set();
+  try {
+    const supabase = await createServerClient();
+    const { data } = await supabase
+      .from("profile_videos")
+      .select("profile_id")
+      .in("profile_id", profileIds);
+    return new Set(((data ?? []) as { profile_id: string }[]).map((r) => r.profile_id));
+  } catch {
+    return new Set();
+  }
+}
+
+/** Mirror getProfileIdsWithVideos pour les lieux. */
+export async function getPlaceIdsWithVideos(
+  placeIds: string[],
+): Promise<Set<string>> {
+  if (placeIds.length === 0) return new Set();
+  try {
+    const supabase = await createServerClient();
+    const { data } = await supabase
+      .from("place_videos")
+      .select("place_id")
+      .in("place_id", placeIds);
+    return new Set(((data ?? []) as { place_id: string }[]).map((r) => r.place_id));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * INSERT vidéo après validation owner + palier (à utiliser depuis API
+ * route seulement, jamais côté client). Bypass RLS via admin client
+ * — on a déjà validé l'ownership en amont.
+ */
+export async function insertProfileVideoAdmin(input: {
+  profile_id: string;
+  storage_path: string;
+  thumbnail_storage_path: string | null;
+  duration_seconds: number;
+  size_bytes: number;
+}): Promise<QueryResult<ProfileVideo>> {
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("profile_videos")
+      .insert(input)
+      .select(PROFILE_VIDEO_SELECT)
+      .single();
+    if (error) return { data: null, error: error.message };
+    return { data: data as unknown as ProfileVideo, error: null };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
+export async function insertPlaceVideoAdmin(input: {
+  place_id: string;
+  storage_path: string;
+  thumbnail_storage_path: string | null;
+  duration_seconds: number;
+  size_bytes: number;
+}): Promise<QueryResult<PlaceVideo>> {
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("place_videos")
+      .insert(input)
+      .select(PLACE_VIDEO_SELECT)
+      .single();
+    if (error) return { data: null, error: error.message };
+    return { data: data as unknown as PlaceVideo, error: null };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/next.config.js
+++ b/next.config.js
@@ -61,16 +61,22 @@ const securityHeaders = [
  * uniquement sur les 2 routes où UploadVideo (ffmpeg.wasm) tourne. Permet
  * SharedArrayBuffer pour la compression multi-thread (3-5× plus rapide).
  *
- * NE PAS appliquer globalement : casserait potentiellement Stripe Checkout
- * futur, Google Maps embeds, YouTube iframes (require-corp bloque les
- * cross-origin sub-resources sans CORP header).
+ * COEP=credentialless (et NON require-corp) : require-corp bloquait les
+ * workers internes Turbopack/Next.js qui ne renvoient pas le header
+ * Cross-Origin-Resource-Policy. credentialless autorise les ressources
+ * cross-origin sans credentials (cookies/auth) sans opt-in CORP, tout en
+ * maintenant le cross-origin isolated state nécessaire pour SAB.
+ * Compat 2026 : Chrome/Edge 96+, Firefox 119+, Safari 17.4+.
+ *
+ * NE PAS appliquer globalement : maintient l'isolement Stripe Checkout
+ * futur, Google Maps embeds, YouTube iframes hors de ces routes.
  *
  * Vérifié à la création (sprint 3 PR-3 audit) : ces 2 routes n'utilisent
  * NI Maps NI Google Places NI iframes externes — safe.
  */
 const crossOriginIsolatedHeaders = [
   { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
-  { key: 'Cross-Origin-Embedder-Policy', value: 'require-corp' },
+  { key: 'Cross-Origin-Embedder-Policy', value: 'credentialless' },
 ]
 
 const nextConfig = {

--- a/next.config.js
+++ b/next.config.js
@@ -7,13 +7,23 @@
 // 'unsafe-inline' + 'unsafe-eval' restent nécessaires tant qu'on n'a pas
 // migré le rendu vers des nonces (Next 16 supporte les nonces via proxy.ts,
 // chantier ultérieur).
+// Note ffmpeg.wasm (PR-3 vidéo) :
+//   - script-src + connect-src incluent unpkg.com pour permettre le
+//     chargement du core ffmpeg-core.js + ffmpeg-core.wasm.
+//   - worker-src 'self' blob: pour le Web Worker créé par toBlobURL().
+//   - L'exécution multi-thread (si crossOriginIsolated=true) requiert
+//     COOP+COEP, ajoutés en headers SCOPÉS sur les routes dashboard
+//     /dashboard/prestataire/fiche et /dashboard/lieu/[placeId] (cf
+//     headers() ci-dessous), pas globalement (sinon casse Maps + iframes).
 const cspDirectives = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://maps.googleapis.com https://www.googletagmanager.com https://va.vercel-scripts.com",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://maps.googleapis.com https://www.googletagmanager.com https://va.vercel-scripts.com https://unpkg.com",
+  "worker-src 'self' blob:",
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "font-src 'self' data: https://fonts.gstatic.com",
   "img-src 'self' data: blob: https:",
-  "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://maps.googleapis.com https://places.googleapis.com https://va.vercel-scripts.com",
+  "media-src 'self' blob: https://*.supabase.co",
+  "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://maps.googleapis.com https://places.googleapis.com https://va.vercel-scripts.com https://unpkg.com",
   "frame-src 'self' https://www.google.com https://www.youtube.com",
   "object-src 'none'",
   "base-uri 'self'",
@@ -46,12 +56,40 @@ const securityHeaders = [
   { key: 'Content-Security-Policy-Report-Only', value: cspDirectives },
 ]
 
+/**
+ * Headers COOP + COEP scopés (PR-3 vidéo) — activent crossOriginIsolated=true
+ * uniquement sur les 2 routes où UploadVideo (ffmpeg.wasm) tourne. Permet
+ * SharedArrayBuffer pour la compression multi-thread (3-5× plus rapide).
+ *
+ * NE PAS appliquer globalement : casserait potentiellement Stripe Checkout
+ * futur, Google Maps embeds, YouTube iframes (require-corp bloque les
+ * cross-origin sub-resources sans CORP header).
+ *
+ * Vérifié à la création (sprint 3 PR-3 audit) : ces 2 routes n'utilisent
+ * NI Maps NI Google Places NI iframes externes — safe.
+ */
+const crossOriginIsolatedHeaders = [
+  { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+  { key: 'Cross-Origin-Embedder-Policy', value: 'require-corp' },
+]
+
 const nextConfig = {
   eslint: { ignoreDuringBuilds: true },
   typescript: { ignoreBuildErrors: true },
 
   async headers() {
     return [
+      {
+        // Routes dashboard avec UploadVideo : ajoute COOP/COEP en plus
+        // des headers de sécurité globaux. Doit venir AVANT le bloc
+        // global pour que Next.js merge les arrays correctement.
+        source: '/dashboard/prestataire/fiche/:path*',
+        headers: [...securityHeaders, ...crossOriginIsolatedHeaders],
+      },
+      {
+        source: '/dashboard/lieu/:placeId/:path*',
+        headers: [...securityHeaders, ...crossOriginIsolatedHeaders],
+      },
       {
         source: '/:path*',
         headers: securityHeaders,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@ffmpeg/ffmpeg": "^0.12.15",
+        "@ffmpeg/util": "^0.12.2",
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.103.0",
         "@types/nodemailer": "^8.0.0",
@@ -18,6 +20,7 @@
         "lru-cache": "^11.3.5",
         "lucide-react": "^1.8.0",
         "motion": "^12.38.0",
+        "nanoid": "^5.1.11",
         "next": "16.2.3",
         "nodemailer": "^8.0.5",
         "react": "19.2.4",
@@ -901,6 +904,36 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@ffmpeg/ffmpeg": {
+      "version": "0.12.15",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.12.15.tgz",
+      "integrity": "sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ffmpeg/types": "^0.12.4"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
+    },
+    "node_modules/@ffmpeg/types": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/types/-/types-0.12.4.tgz",
+      "integrity": "sha512-k9vJQNBGTxE5AhYDtOYR5rO5fKsspbg51gbcwtbkw2lCdoIILzklulcjJfIDwrtn7XhDeF2M+THwJ2FGrLeV6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/@ffmpeg/util": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/util/-/util-0.12.2.tgz",
+      "integrity": "sha512-ouyoW+4JB7WxjeZ2y6KpRvB+dLp7Cp4ro8z0HIVpZVCM7AwFlHa0c4R8Y/a4M3wMqATpYKhC7lSFHQ0T11MEDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.x"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -7638,9 +7671,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
       "funding": [
         {
           "type": "github",
@@ -7649,10 +7682,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/napi-postinstall": {
@@ -7738,6 +7771,24 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -8360,6 +8411,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/powershell-utils": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@ffmpeg/ffmpeg": "^0.12.15",
+    "@ffmpeg/util": "^0.12.2",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.0",
     "@types/nodemailer": "^8.0.0",
@@ -19,6 +21,7 @@
     "lru-cache": "^11.3.5",
     "lucide-react": "^1.8.0",
     "motion": "^12.38.0",
+    "nanoid": "^5.1.11",
     "next": "16.2.3",
     "nodemailer": "^8.0.5",
     "react": "19.2.4",


### PR DESCRIPTION
## Quoi

UI vidéo complète (MP4) pour prestataires (Premium+) et lieux (Sélection Hilmy) — fait suite à PR-2 (mig 43 + helpers TS).

**3 composants nouveaux :**
- `UploadVideo` — flow client-side avec ffmpeg.wasm (lazy import), compression auto si >25 MB ou >cap, upload séquentiel vidéo → thumbnail → BDD via API route, message Sara première fois ("Hilmy charge l'outil de compression vidéo (~30s)…")
- `VideoPlayer` — lecture click-to-play, thumbnail full-size + overlay or rond ▶ + label durée
- `VideosManager` — section dashboard partagée (scope `prestataire` | `lieu`) : fetch + liste + delete + bouton upload

**2 API routes nouvelles :**
- `POST /api/videos/upload` — auth + ownership + palier (durée + count) + INSERT admin + rate-limit 10/min
- `DELETE /api/videos/[id]` — auth + ownership via JOIN inner + Storage cleanup best-effort

**Intégrations :**
- Dashboard prestataire fiche : group "Mes vidéos" (Premium voit lock 0/0, Cercle Pro voit 0/2)
- Dashboard lieu détail : section "Mes vidéos" (Sélection Hilmy voit 0/2)
- Page publique prestataire : section "Découvre {nom} en vidéo" avant la galerie
- Page publique recommandation : section vidéo après le hero, sur fond crème
- Annuaire + recommandations : badge "▶ VIDÉO" top-right sur les cards (pré-fetch batch)

**Headers HTTP :**
- COOP/COEP scopés sur `/dashboard/prestataire/fiche/:path*` + `/dashboard/lieu/:placeId/:path*` (requis pour SharedArrayBuffer ffmpeg.wasm multi-thread)
- CSP étendue : unpkg.com (ffmpeg core), worker-src 'self' blob:, media-src 'self' blob: https://*.supabase.co

## Pourquoi

Phase 2 du module vidéo (suite mig 43 PR-2). Les prestataires Premium/Cercle Pro et les lieux Sélection Hilmy ont besoin de pouvoir uploader des vidéos courtes (60-90s) qui transmettent l'ambiance — ce qui ne passe pas en photo.

Décisions actées par Jiji :
- A(a) séquentiel (vidéo → thumbnail → BDD) — plus simple, moins de races
- B(a) `has_videos: boolean` pour badge — pas de count
- C OK API routes (auth + ownership server-side)
- D click-to-play (pas autoplay)
- E placement validé (avant galerie pour prestas, après hero pour recos)
- F sections dashboard validé
- G COOP/COEP scopés (pas global, sécurité Maps/Stripe préservée)
- H pas de tabs Photos/Vidéos (sections empilées)

## Comment tester

**Prérequis :** mig 43 déjà appliquée en prod (PR-2 mergée).

**Test prestataire Premium (cap 0 vidéos) :**
1. Login user prestataire palier=premium
2. Aller sur `/dashboard/prestataire/fiche`
3. Scroll jusqu'à "Mes vidéos" → doit afficher upsell "Disponible avec Cercle Pro"
4. Pas de bouton upload

**Test prestataire Cercle Pro (cap 2 vidéos, 90s) :**
1. Login user prestataire palier=cercle_pro
2. `/dashboard/prestataire/fiche` → section "Mes vidéos" affiche "0 / 2 vidéos · jusqu'à 90s"
3. Click "Ajouter une vidéo" → première fois, message "Hilmy charge l'outil de compression vidéo (~30s)…"
4. Upload MP4 30s 50MB → compression progress bar → thumbnail extrait → upload Storage → INSERT BDD
5. Vidéo apparaît dans la liste avec player click-to-play
6. Aller sur `/prestataire-v2/{slug}` → section "Découvre {nom} en vidéo" avant galerie
7. Aller sur `/annuaire` → badge "▶ VIDÉO" sur la card
8. Test delete : click "Supprimer" → confirm → vidéo disparaît, Storage cleanup en background

**Test lieu Sélection Hilmy (cap 2 vidéos, 60s) :**
1. Login user owner lieu palier=selection_hilmy
2. `/dashboard/lieu/{placeId}` → section "Mes vidéos" affiche "0 / 2 vidéos · jusqu'à 60s"
3. Same flow upload
4. Page publique `/recommandation/{slug}` → section vidéo sur bg-creme-soft
5. `/recommandations` → badge VIDÉO

**Tests defense-in-depth :**
- Upload via API route directement avec `profile_id` d'un autre user → 403
- Upload vidéo 120s sur Cercle Pro (cap 90s) → 400 "durée dépasse cap"
- Upload 3e vidéo sur Cercle Pro (cap 2) → 400 "limite atteinte"
- Upload simultané 11 fois en <1min → 429 rate-limit

## Risques

**ffmpeg.wasm :**
- Premier upload : load ~25 MB depuis unpkg.com (~30s sur 4G). UX Sara message anticipé.
- Multi-thread (mt) requiert SharedArrayBuffer + COOP/COEP. Fallback single-thread si headers absents (ne devrait pas arriver vu scope routes).
- Cache navigator persistent : module-level `cachedFFmpeg` evite reload entre uploads dans même session.

**COOP/COEP scopés :**
- Vérifié que `/dashboard/prestataire/fiche` et `/dashboard/lieu/[placeId]` ne font pas appel à Maps/Stripe/iframes externes — safe.
- Si on rajoute un widget tiers sur ces routes plus tard, vérifier compatibilité crossOriginIsolated.

**Storage cleanup orphans :**
- Si DELETE BDD success mais Storage delete fail → fichier orphan reste. Tracé via tech-debt #7 (cleanup automatique cron Vercel à venir).

**Edge cases :**
- Vidéo source corrompue / codec exotique → ffmpeg throw → erreur affichée user "Format non supporté".
- User upgrade Premium → Cercle Pro pendant session → reload page nécessaire pour voir le bouton upload.

## Sécurité

✅ Auth check sur les 2 API routes (cookie session Supabase via `createClient`).
✅ Ownership check server-side : `profile.user_id === auth.uid()` ou `place.created_by_user_id === auth.uid()`.
✅ Validation palier server-side : durée + count caps re-checked dans API route (defense in depth vs gating client).
✅ INSERT via admin client (service_role) — RLS bypass justifié car ownership déjà vérifié manuellement.
✅ Storage path conforme `{user_id}/{nanoid}.mp4` — passe `storage_owner_from_path()` policy mig 43.
✅ Rate-limit 10 uploads/min/user pour anti-abuse.
✅ Pas de PII dans logs (juste video_id + user_id).
✅ Service_role key jamais dans bundle client (server-side only via API routes).
✅ Headers COOP/COEP scopés (pas global) — n'impacte pas les autres routes.

## Stats diff

- 18 files changed, 1647 insertions(+), 13 deletions(-)
- 8 nouveaux fichiers (3 components, 2 API routes, 1 queries lib, 1 next.config patch, 1 mock-data extension)
- 10 modifs (cards, listings, dashboards, pages publiques)
- 3 npm deps ajoutées : `@ffmpeg/ffmpeg ^0.12.15`, `@ffmpeg/util ^0.12.2`, `nanoid ^5.1.11`

## Tech-debt anticipée

- **#7** Cleanup automatique fichiers orphelins Storage (cron Vercel hebdo, scan profile-videos + place-videos vs BDD)
- **#8** Table `video_views` pour tracking lectures vidéo (futur, pas dans ce PR)
