### PR TITLE
feat(lieux): UI publique Sélection Hilmy — pastille hero + badge feed + tri prio (PR-C)

### DIFF
--- a/app/recommandation/[slug]/page.tsx
+++ b/app/recommandation/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/lib/supabase/queries/places'
 import { getRecommendationsByPlace } from '@/lib/supabase/queries/recommendations'
 import { getPlaceVideos } from '@/lib/supabase/queries/videos'
+import { isSelectionHilmy } from '@/lib/permissions-lieux'
 import { createClient } from '@/lib/supabase/server'
 import type { Place, Recommendation } from '@/lib/supabase/types'
 import { VideoPlayer } from '@/components/v2/VideoPlayer'
@@ -195,6 +196,15 @@ export default async function RecommandationPage({
               Retour aux recommandations
             </Link>
             <div className="mt-8 flex flex-wrap items-center gap-3">
+              {isSelectionHilmy(row) && (
+                <span
+                  className="inline-flex items-center gap-1.5 rounded-full bg-creme px-3 py-1.5 font-serif text-[11px] font-light italic tracking-[0.2em] text-or shadow-[0_2px_8px_-2px_rgba(15,61,46,0.25)] uppercase backdrop-blur"
+                  aria-label="Lieu Sélection Hilmy"
+                >
+                  <span aria-hidden="true">✨</span>
+                  Sélection Hilmy
+                </span>
+              )}
               <span className="inline-flex items-center gap-2 rounded-full bg-creme/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
                 {catLabel(l.categorie)}
               </span>

--- a/app/recommandations/page.tsx
+++ b/app/recommandations/page.tsx
@@ -40,6 +40,7 @@ function adaptPlaceFromDb(p: Place): MockLieu {
     galerie: photosArr,
     recommandePar: [],
     commentaires: [],
+    palier: p.palier ?? 'aucun',
   }
 }
 
@@ -62,8 +63,12 @@ export default function RecommandationsPage() {
         const { data, error: err } = await supabase
           .from('places')
           .select(
-            'id, google_place_id, name, slug, description, address, city, region, country, latitude, longitude, google_category, hilmy_category, main_photo_url, photos, created_at, updated_at',
+            'id, google_place_id, name, slug, description, address, city, region, country, latitude, longitude, google_category, hilmy_category, main_photo_url, photos, palier, created_at, updated_at',
           )
+          // Tri prio Sélection Hilmy : 'selection_hilmy' > 'aucun' en
+          // ordre alphabétique DESC. Les fiches payantes remontent en
+          // tête du feed avant le tri chronologique secondaire.
+          .order('palier', { ascending: false })
           .order('created_at', { ascending: false })
 
         if (cancelled) return

--- a/components/v2/LieuCard.tsx
+++ b/components/v2/LieuCard.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { motion } from 'framer-motion'
 import type { Lieu } from '@/lib/mock-data'
 import { categoriesLieux } from '@/lib/mock-data'
+import { isSelectionHilmy } from '@/lib/permissions-lieux'
 
 function catLabel(slug: string) {
   return categoriesLieux.find((c) => c.slug === slug)?.label ?? slug
@@ -57,8 +58,19 @@ export function LieuCard({ lieu, index = 0 }: Props) {
             />
           )}
           <div className="absolute inset-0 bg-grain opacity-[0.08]" />
-          <div className="absolute left-5 top-5 inline-flex max-w-[60%] items-center gap-2 truncate rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
-            {catLabel(lieu.categorie)}
+          <div className="absolute left-5 top-5 flex max-w-[60%] flex-col items-start gap-1.5">
+            {isSelectionHilmy(lieu) && (
+              <span
+                className="inline-flex items-center gap-1.5 rounded-full bg-or/95 px-2.5 py-1 text-[10px] font-medium tracking-[0.22em] text-vert backdrop-blur uppercase"
+                aria-label="Lieu Sélection Hilmy"
+              >
+                <span aria-hidden="true">✨</span>
+                Sélection Hilmy
+              </span>
+            )}
+            <span className="inline-flex max-w-full items-center gap-2 truncate rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
+              {catLabel(lieu.categorie)}
+            </span>
           </div>
           {lieu.has_videos && (
             <div

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -373,6 +373,10 @@ export type Lieu = {
   /** Boolean flag pour le badge ▶ VIDÉO sur la card feed (PR-3 mig 43).
    *  Pré-fetché côté server via `getPlaceIdsWithVideos` pour éviter N+1. */
   has_videos?: boolean;
+  /** Palier lieu (mig 41 places.palier). Lu par LieuCard via
+   *  isSelectionHilmy() pour afficher le badge ✨ SÉLECTION HILMY et
+   *  par le feed pour trier les fiches payantes en haut. */
+  palier?: 'aucun' | 'selection_hilmy' | null;
 };
 
 export const lieux: Lieu[] = [


### PR DESCRIPTION
## Quoi

Sprint 2 / PR-C — Rend la pastille **Sélection Hilmy** visible publiquement :
- Pastille hero sur fiche `/recommandation/[slug]`
- Badge sur cards feed `/recommandations`
- Tri prio server-side dans le feed (fiches payantes en haut)

Aucune migration BDD, que du UI. Helpers existants réutilisés (`isSelectionHilmy()` de mig 41 PR-A).

## Pourquoi

Phase 2A foundations livrée (PR-A migration, PR-B1 tracking, PR-B2 dashboard owner). Maintenant on rend la valeur Sélection Hilmy visible côté public — sinon les fiches payantes 39€/mois n'ont aucune différentiation visible pour la cliente qui scrolle le feed.

## Changements détaillés

**A. Pastille hero `/recommandation/[slug]`**
- 3e chip (1ère position) dans la rangée du hero, conditionnelle sur `isSelectionHilmy(row)`
- Style : `bg-creme` + `text-or` + `font-serif italic tracking-[0.2em] uppercase` + shadow douce pour relief sur cover sombre
- Texte : `✨ Sélection Hilmy`

**B. Badge sur LieuCard**
- Stack vertical top-left : badge SH au-dessus, catégorie chip en-dessous (gap-1.5)
- Style : `bg-or/95 text-vert tracking-[0.22em] uppercase` — cohérent avec vocabulaire visuel du badge ▶ VIDÉO (top-right) sans clash
- Si pas SH, comportement actuel intact (catégorie seule)

**C. Tri prio feed `/recommandations`**
- Server-side : `.order('palier', { ascending: false })` puis `.order('created_at', { ascending: false })`
- `'selection_hilmy' > 'aucun'` en string DESC → fiches payantes en haut, ordre chronologique secondaire
- `palier` ajouté au select supabase-js + propagé via `adaptPlaceFromDb()` vers MockLieu

**D. Photos illimitées Sélection Hilmy**
- No-op : mig 42 trigger BDD enforce déjà côté serveur, pas de form édition lieu (décision B(γ) défer)

**Type extension**
- `Lieu` (mock-data.ts) étendu avec `palier?: 'aucun' | 'selection_hilmy' | null` — cohérent avec pattern `has_videos?: boolean`
- Pas de prop séparée sur LieuCard, le card lit via `isSelectionHilmy(lieu)`

## Comment tester

**Prérequis** : 1 lieu palier='selection_hilmy' en BDD pour voir l'effet (Atelier Nouage à set temporairement).

```sql
-- Avant test
UPDATE places SET palier='selection_hilmy' WHERE id='2172c0a1-612a-4460-93ab-3b5298694e06';
-- Après test (cleanup)
UPDATE places SET palier='aucun' WHERE id='2172c0a1-612a-4460-93ab-3b5298694e06';
```

**Tests à valider** :

- [ ] Page `/recommandation/atelier-nouage-geneve` : pastille `✨ Sélection Hilmy` visible dans le hero (palier='selection_hilmy')
- [ ] Page `/recommandation/atelier-nouage-geneve` : pas de pastille (palier='aucun')
- [ ] Feed `/recommandations` : Atelier Nouage en HAUT du feed quand palier='selection_hilmy'
- [ ] Feed `/recommandations` : badge `✨ SÉLECTION HILMY` sur la card top-left
- [ ] Feed `/recommandations` : la card peut aussi avoir le badge ▶ VIDÉO (top-right) sans clash visuel
- [ ] Aucun lieu palier='aucun' n'a de pastille / badge
- [ ] `npm run build` vert ✅ (vérifié local)
- [ ] Vercel preview Ready

## Risques

- **Tri palier en string DESC** : repose sur l'ordre alphabétique inversé `'selection_hilmy' > 'aucun'`. Solide pour ces 2 valeurs. Si on ajoute un 3e palier lieu plus tard (ex. `'platine'` qui commence par 'p' > 'a' mais < 's'), le tri pourrait casser. À monitorer si on étend les paliers lieux. Solution propre future : ajouter un `palier_rank int` ou un CASE WHEN.
- **Adapter MockLieu** : 2 adapters existent (un dans `app/recommandations/page.tsx` côté feed, un dans `app/recommandation/[slug]/page.tsx` côté fiche). Cette PR n'a touché que le feed adapter. La fiche détail lit `palier` directement sur `row` (Place brute) avant l'adaptation — c'est OK pour ce PR mais l'adapter détail reste sans `palier` (pas requis ici).
- **CLS** : aucun changement de layout sur les cards palier='aucun'. Sur les cards SH, le stack ajoute ~24px de hauteur en top-left mais le `absolute` ne déplace pas le contenu de la card.

## Sécurité

✅ Aucun changement BDD, aucun changement RLS.
✅ Aucun secret modifié.
✅ Lecture `palier` est public — RLS places permet read-all (annuaire public).
✅ Pas de modif auth, pas de modif owner permissions.

## Stats diff

- 4 files changed, +34 / -3
- 0 nouveau fichier
- 0 npm dep
- 0 migration BDD
- Build vert local
