### PR TITLE
feat(boost): auto-boost saisonnier prestataires (mig 44 PR-D Sprint 4)

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -72,6 +72,11 @@ export default async function AdminLayout({
       label: 'Signalements Je cherche',
       badge: jeChercheSignalementsCount.count ?? 0,
     },
+    {
+      href: '/admin/seasonal-windows',
+      label: 'Fenêtres saisonnières',
+      badge: undefined,
+    },
   ]
 
   return (

--- a/app/admin/seasonal-windows/actions.ts
+++ b/app/admin/seasonal-windows/actions.ts
@@ -1,0 +1,115 @@
+'use server'
+
+/**
+ * Server actions admin pour les fenêtres saisonnières (PR-D mig 44).
+ *
+ * Toutes les actions :
+ *  - vérifient is_admin via JWT (defense in depth — le layout admin gate déjà)
+ *  - utilisent createAdminClient() pour bypass RLS
+ *  - revalident la page admin après chaque mutation
+ *  - retournent { ok: true } ou { ok: false, error: string }
+ */
+
+import { revalidatePath } from 'next/cache'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { requireUser } from '@/lib/supabase/session'
+
+type ActionResult = { ok: true } | { ok: false; error: string }
+
+async function ensureAdmin(): Promise<{ ok: true } | { ok: false; error: string }> {
+  const user = await requireUser()
+  if (!user.user_metadata?.is_admin) {
+    return { ok: false, error: 'Accès admin requis' }
+  }
+  return { ok: true }
+}
+
+function parseDateInput(raw: FormDataEntryValue | null): string | null {
+  if (typeof raw !== 'string' || raw.trim() === '') return null
+  return new Date(raw).toISOString()
+}
+
+function parseTextInput(raw: FormDataEntryValue | null, max = 200): string | null {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (trimmed === '') return null
+  return trimmed.slice(0, max)
+}
+
+export async function createSeasonalWindow(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureAdmin()
+  if (!auth.ok) return auth
+
+  const slug = parseTextInput(formData.get('slug'), 64)
+  const label = parseTextInput(formData.get('label'), 120)
+  const emoji = parseTextInput(formData.get('emoji'), 8) ?? '🎁'
+  const starts_at = parseDateInput(formData.get('starts_at'))
+  const ends_at = parseDateInput(formData.get('ends_at'))
+
+  if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
+    return { ok: false, error: 'Slug requis (kebab-case, a-z 0-9 -)' }
+  }
+  if (!label) {
+    return { ok: false, error: 'Label requis' }
+  }
+  if (starts_at && ends_at && starts_at > ends_at) {
+    return { ok: false, error: 'starts_at doit être <= ends_at' }
+  }
+
+  const admin = createAdminClient()
+  const { error } = await admin
+    .from('seasonal_event_windows')
+    .insert({ slug, label, emoji, starts_at, ends_at, is_active: true })
+  if (error) return { ok: false, error: error.message }
+
+  revalidatePath('/admin/seasonal-windows')
+  return { ok: true }
+}
+
+export async function updateSeasonalWindow(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureAdmin()
+  if (!auth.ok) return auth
+
+  const id = parseTextInput(formData.get('id'), 64)
+  if (!id) return { ok: false, error: 'ID manquant' }
+
+  const label = parseTextInput(formData.get('label'), 120)
+  const emoji = parseTextInput(formData.get('emoji'), 8) ?? '🎁'
+  const starts_at = parseDateInput(formData.get('starts_at'))
+  const ends_at = parseDateInput(formData.get('ends_at'))
+  const is_active = formData.get('is_active') === 'on'
+
+  if (!label) return { ok: false, error: 'Label requis' }
+  if (starts_at && ends_at && starts_at > ends_at) {
+    return { ok: false, error: 'starts_at doit être <= ends_at' }
+  }
+
+  const admin = createAdminClient()
+  const { error } = await admin
+    .from('seasonal_event_windows')
+    .update({ label, emoji, starts_at, ends_at, is_active })
+    .eq('id', id)
+  if (error) return { ok: false, error: error.message }
+
+  revalidatePath('/admin/seasonal-windows')
+  return { ok: true }
+}
+
+export async function deleteSeasonalWindow(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureAdmin()
+  if (!auth.ok) return auth
+
+  const id = parseTextInput(formData.get('id'), 64)
+  if (!id) return { ok: false, error: 'ID manquant' }
+
+  // CASCADE supprime aussi les profile_seasonal_boosts liés (FK ON DELETE CASCADE).
+  const admin = createAdminClient()
+  const { error } = await admin
+    .from('seasonal_event_windows')
+    .delete()
+    .eq('id', id)
+  if (error) return { ok: false, error: error.message }
+
+  revalidatePath('/admin/seasonal-windows')
+  return { ok: true }
+}

--- a/app/admin/seasonal-windows/page.tsx
+++ b/app/admin/seasonal-windows/page.tsx
@@ -1,0 +1,208 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+import {
+  createSeasonalWindow,
+  updateSeasonalWindow,
+  deleteSeasonalWindow,
+} from './actions'
+import type { SeasonalEventWindow } from '@/lib/supabase/types'
+
+/**
+ * Admin page /admin/seasonal-windows (PR-D mig 44).
+ *
+ * Liste les fenêtres calendrier + form de création + form édition par row
+ * + delete. Layout admin gate déjà via app/admin/layout.tsx (is_admin).
+ *
+ * Pas d'optimistic UI — on revalidate la page après chaque action via
+ * revalidatePath() côté server action. Sufficient pour un panel admin
+ * faible-trafic (Jiji = unique admin actuelle).
+ */
+
+function toDateInputValue(iso: string | null): string {
+  if (!iso) return ''
+  // Format requis par <input type="date"> : YYYY-MM-DD
+  return new Date(iso).toISOString().slice(0, 10)
+}
+
+export default async function SeasonalWindowsAdminPage() {
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from('seasonal_event_windows')
+    .select('id, slug, label, emoji, starts_at, ends_at, is_active, created_at, updated_at')
+    .order('starts_at', { ascending: true, nullsFirst: false })
+
+  const windows = (data ?? []) as SeasonalEventWindow[]
+
+  return (
+    <section className="px-6 py-10 md:px-12 md:py-14">
+      <header className="border-b border-or/15 pb-6">
+        <p className="overline text-or">Config · auto-boost saisonnier</p>
+        <h1 className="mt-3 font-serif text-3xl font-light text-vert md:text-4xl">
+          Fenêtres saisonnières.
+        </h1>
+        <p className="mt-3 max-w-2xl text-[13px] leading-[1.6] text-texte-sec">
+          Les prestataires Premium et Cercle Pro cochent ces fenêtres pour
+          remonter automatiquement en haut de l&apos;annuaire pendant la période.
+          Slug en kebab-case (distinct du snake_case des events lieux).
+        </p>
+      </header>
+
+      {error && (
+        <p className="mt-6 rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[12px] text-red-900">
+          {error.message}
+        </p>
+      )}
+
+      {/* Form création */}
+      <div className="mt-8 rounded-sm border border-or/20 bg-blanc p-6">
+        <h2 className="font-serif text-xl font-light text-vert">+ Nouvelle fenêtre</h2>
+        <form action={createSeasonalWindow} className="mt-4 grid gap-3 md:grid-cols-2">
+          <label className="block">
+            <span className="block text-[11px] tracking-[0.18em] text-texte-sec uppercase">Slug</span>
+            <input
+              name="slug"
+              required
+              pattern="[a-z0-9\-]+"
+              placeholder="black-friday"
+              className="mt-1 w-full rounded-sm border border-or/30 bg-creme px-3 py-2 text-[14px] text-vert"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-[11px] tracking-[0.18em] text-texte-sec uppercase">Label</span>
+            <input
+              name="label"
+              required
+              placeholder="Black Friday"
+              className="mt-1 w-full rounded-sm border border-or/30 bg-creme px-3 py-2 text-[14px] text-vert"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-[11px] tracking-[0.18em] text-texte-sec uppercase">Emoji</span>
+            <input
+              name="emoji"
+              maxLength={8}
+              defaultValue="🎁"
+              className="mt-1 w-full rounded-sm border border-or/30 bg-creme px-3 py-2 text-[14px] text-vert"
+            />
+          </label>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="block">
+              <span className="block text-[11px] tracking-[0.18em] text-texte-sec uppercase">Début</span>
+              <input
+                type="date"
+                name="starts_at"
+                className="mt-1 w-full rounded-sm border border-or/30 bg-creme px-3 py-2 text-[14px] text-vert"
+              />
+            </label>
+            <label className="block">
+              <span className="block text-[11px] tracking-[0.18em] text-texte-sec uppercase">Fin</span>
+              <input
+                type="date"
+                name="ends_at"
+                className="mt-1 w-full rounded-sm border border-or/30 bg-creme px-3 py-2 text-[14px] text-vert"
+              />
+            </label>
+          </div>
+          <div className="md:col-span-2">
+            <button
+              type="submit"
+              className="inline-flex h-11 items-center gap-2 rounded-full bg-vert px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+            >
+              Créer
+            </button>
+          </div>
+        </form>
+      </div>
+
+      {/* Liste + édition par row */}
+      <div className="mt-10">
+        <h2 className="font-serif text-xl font-light text-vert">
+          Fenêtres existantes ({windows.length})
+        </h2>
+        <ul className="mt-4 grid gap-3">
+          {windows.map((w) => (
+            <li
+              key={w.id}
+              className={`rounded-sm border bg-blanc p-5 ${
+                w.is_active ? 'border-or/20' : 'border-or/10 opacity-60'
+              }`}
+            >
+              <form action={updateSeasonalWindow} className="grid gap-3 md:grid-cols-[auto_1fr_auto_auto_auto_auto]">
+                <input type="hidden" name="id" value={w.id} />
+                <div className="flex items-center gap-2">
+                  <span className="text-[11px] tracking-[0.18em] text-texte-sec uppercase">{w.slug}</span>
+                </div>
+                <label className="block">
+                  <span className="block text-[10px] tracking-[0.18em] text-texte-sec uppercase">Label</span>
+                  <input
+                    name="label"
+                    required
+                    defaultValue={w.label}
+                    className="mt-1 w-full rounded-sm border border-or/30 bg-creme px-2 py-1.5 text-[13px] text-vert"
+                  />
+                </label>
+                <label className="block">
+                  <span className="block text-[10px] tracking-[0.18em] text-texte-sec uppercase">Emoji</span>
+                  <input
+                    name="emoji"
+                    maxLength={8}
+                    defaultValue={w.emoji}
+                    className="mt-1 w-20 rounded-sm border border-or/30 bg-creme px-2 py-1.5 text-center text-[14px] text-vert"
+                  />
+                </label>
+                <label className="block">
+                  <span className="block text-[10px] tracking-[0.18em] text-texte-sec uppercase">Début</span>
+                  <input
+                    type="date"
+                    name="starts_at"
+                    defaultValue={toDateInputValue(w.starts_at)}
+                    className="mt-1 rounded-sm border border-or/30 bg-creme px-2 py-1.5 text-[13px] text-vert"
+                  />
+                </label>
+                <label className="block">
+                  <span className="block text-[10px] tracking-[0.18em] text-texte-sec uppercase">Fin</span>
+                  <input
+                    type="date"
+                    name="ends_at"
+                    defaultValue={toDateInputValue(w.ends_at)}
+                    className="mt-1 rounded-sm border border-or/30 bg-creme px-2 py-1.5 text-[13px] text-vert"
+                  />
+                </label>
+                <label className="flex items-center gap-2 self-end pb-1.5">
+                  <input
+                    type="checkbox"
+                    name="is_active"
+                    defaultChecked={w.is_active}
+                    className="h-4 w-4 cursor-pointer accent-or"
+                  />
+                  <span className="text-[11px] tracking-[0.18em] text-texte-sec uppercase">Actif</span>
+                </label>
+                <div className="flex items-center gap-2 md:col-span-6 md:justify-end">
+                  <button
+                    type="submit"
+                    className="inline-flex h-9 items-center rounded-full bg-vert px-4 text-[10px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+                  >
+                    Enregistrer
+                  </button>
+                </div>
+              </form>
+              <form action={deleteSeasonalWindow} className="mt-2 flex justify-end">
+                <input type="hidden" name="id" value={w.id} />
+                <button
+                  type="submit"
+                  className="text-[10px] tracking-[0.22em] text-red-900 uppercase hover:text-red-700"
+                >
+                  Supprimer
+                </button>
+              </form>
+            </li>
+          ))}
+          {windows.length === 0 && (
+            <li className="rounded-sm border border-dashed border-or/30 p-6 text-center text-[13px] italic text-texte-sec">
+              Aucune fenêtre. Crée la première ci-dessus.
+            </li>
+          )}
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/app/annuaire/page.tsx
+++ b/app/annuaire/page.tsx
@@ -7,13 +7,15 @@ import {
 } from '@/lib/mock-data'
 import { getAllPrestataires } from '@/lib/supabase/queries/prestataires'
 import { getProfileIdsWithVideos } from '@/lib/supabase/queries/videos'
+import { getActiveSeasonalLabelsBatch } from '@/lib/supabase/queries/seasonal-boosts'
 import type { Prestataire as DbPrestataire } from '@/lib/supabase/types'
 import { AnnuaireClient } from './AnnuaireClient'
 
 /**
- * Tri prioritaire annuaire (Cercle Pro 99€/mois — feature "Mise en avant prio").
- * Cercle Pro apparaît avant Premium qui apparaît avant Standard.
- * À tier égal, on conserve l'ordre serveur (approved_at desc, déterministe).
+ * Tri prioritaire annuaire :
+ *  1. Boostés (auto-boost saisonnier actif PR-D mig 44) en haut
+ *  2. Puis Cercle Pro avant Premium avant Standard
+ *  3. À tier égal, ordre serveur (approved_at desc, déterministe)
  *
  * Le palier reçu ici est déjà le palier EFFECTIF (founders mappées à
  * cercle_pro côté server query helper) — donc les founders rankent
@@ -28,8 +30,13 @@ const PALIER_RANK: Record<string, number> = {
   standard: 2,
 }
 
-function sortByPalierThenServerOrder(list: MockPrestataire[]): MockPrestataire[] {
+function sortByBoostThenPalier(list: MockPrestataire[]): MockPrestataire[] {
   return [...list].sort((a, b) => {
+    // Boostés (active_boost non null) en haut
+    const aBoosted = a.active_boost ? 0 : 1
+    const bBoosted = b.active_boost ? 0 : 1
+    if (aBoosted !== bBoosted) return aBoosted - bBoosted
+    // Tie-break sur palier
     const ra = PALIER_RANK[a.palier ?? 'standard'] ?? 2
     const rb = PALIER_RANK[b.palier ?? 'standard'] ?? 2
     return ra - rb
@@ -90,15 +97,21 @@ export default async function AnnuairePage() {
 
   const rows = data ?? []
 
-  // Pré-fetch en batch des IDs prestataires qui ont au moins 1 vidéo
-  // (évite N+1 sur le badge ▶ VIDÉO côté card). Mig 43 PR-3.
-  const idsWithVideos = await getProfileIdsWithVideos(rows.map((p) => p.id))
+  // Pré-fetch batch (évite N+1) :
+  //  - vidéos → badge ▶ VIDÉO (PR-3 mig 43)
+  //  - active boost → badge saisonnier top-left (PR-D mig 44)
+  const ids = rows.map((p) => p.id)
+  const [idsWithVideos, activeBoosts] = await Promise.all([
+    getProfileIdsWithVideos(ids),
+    getActiveSeasonalLabelsBatch(ids),
+  ])
 
   const adapted = rows.map((p) => ({
     ...adaptPrestataireFromDb(p),
     has_videos: idsWithVideos.has(p.id),
+    active_boost: activeBoosts.get(p.id) ?? null,
   }))
-  const sorted = sortByPalierThenServerOrder(adapted)
+  const sorted = sortByBoostThenPalier(adapted)
 
   return <AnnuaireClient prestataires={sorted} />
 }

--- a/app/api/seasonal-boosts/route.ts
+++ b/app/api/seasonal-boosts/route.ts
@@ -1,0 +1,154 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { enforceRateLimit } from '@/lib/rate-limit'
+import { isValidUuid } from '@/lib/tracking'
+import { getEffectivePalier } from '@/lib/permissions'
+import {
+  SEASONAL_BOOST_COUNT_MAX,
+  canSelectSeasonalBoost,
+} from '@/lib/palier-limits'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/seasonal-boosts
+ *
+ * Body: {
+ *   profile_id: string (uuid),
+ *   window_ids: string[] (uuid[])  // sélection complète, replace mode
+ * }
+ *
+ * Replace-all : on supprime toutes les rows existantes pour ce profile
+ * et on insère les nouvelles. Plus simple qu'un diff côté client.
+ *
+ * Validations server-side (defense in depth — le client a son propre cap) :
+ *   1. Auth (session Supabase)
+ *   2. Ownership : auth.uid() === profile.user_id
+ *   3. Palier check : standard refusé, premium <= 1, cercle_pro illimité
+ *      (founder mappé cercle_pro via getEffectivePalier)
+ *   4. Window IDs valides (existent + is_active)
+ *
+ * Rate-limit : 20 calls / minute / utilisateur (cap modeste, save = bouton).
+ */
+export async function POST(request: Request) {
+  const limited = enforceRateLimit(request, {
+    tag: 'seasonal-boosts',
+    max: 20,
+    windowMs: 60 * 1000,
+  })
+  if (limited) return limited
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Non authentifiée' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'JSON invalide' }, { status: 400 })
+  }
+
+  const b = body as { profile_id?: unknown; window_ids?: unknown }
+  const profileId = b.profile_id
+  const windowIds = b.window_ids
+
+  if (!isValidUuid(profileId)) {
+    return NextResponse.json({ error: 'profile_id invalide' }, { status: 400 })
+  }
+  if (!Array.isArray(windowIds)) {
+    return NextResponse.json({ error: 'window_ids doit être un tableau' }, { status: 400 })
+  }
+  if (windowIds.some((id) => !isValidUuid(id))) {
+    return NextResponse.json({ error: 'window_ids contient un UUID invalide' }, { status: 400 })
+  }
+  // Dédup (sécurité)
+  const uniqueIds = Array.from(new Set(windowIds as string[]))
+
+  // 1. Récupérer profile + check ownership + palier
+  const admin = createAdminClient()
+  const { data: profile, error: profErr } = await admin
+    .from('profiles')
+    .select('id, user_id, palier, is_founder')
+    .eq('id', profileId as string)
+    .maybeSingle()
+  if (profErr || !profile) {
+    return NextResponse.json({ error: 'Profil introuvable' }, { status: 404 })
+  }
+  if (profile.user_id !== user.id) {
+    return NextResponse.json({ error: 'Accès refusé' }, { status: 403 })
+  }
+
+  const eff = getEffectivePalier({
+    palier: profile.palier as 'standard' | 'premium' | 'cercle_pro' | null,
+    is_founder: profile.is_founder as boolean | null,
+  })
+
+  if (uniqueIds.length > 0) {
+    const max = SEASONAL_BOOST_COUNT_MAX[eff]
+    if (max === 0) {
+      return NextResponse.json(
+        { error: 'Le boost saisonnier nécessite Premium ou Cercle Pro.' },
+        { status: 403 },
+      )
+    }
+    if (max !== null && uniqueIds.length > max) {
+      return NextResponse.json(
+        {
+          error: `Avec ${eff === 'premium' ? 'Premium' : 'ton palier'}, tu peux cocher ${max} fenêtre${max > 1 ? 's' : ''} maximum.`,
+        },
+        { status: 400 },
+      )
+    }
+  }
+
+  // 2. Valider que les window_ids existent et sont actives
+  if (uniqueIds.length > 0) {
+    const { data: wins, error: winErr } = await admin
+      .from('seasonal_event_windows')
+      .select('id')
+      .in('id', uniqueIds)
+      .eq('is_active', true)
+    if (winErr) {
+      return NextResponse.json({ error: winErr.message }, { status: 500 })
+    }
+    if ((wins?.length ?? 0) !== uniqueIds.length) {
+      return NextResponse.json(
+        { error: 'Certaines fenêtres sont inactives ou inexistantes.' },
+        { status: 400 },
+      )
+    }
+  }
+
+  // 3. Replace-all : DELETE existing puis INSERT new
+  // (pas de transaction explicite côté Supabase JS — risque limité car le
+  // worst case est "DELETE OK + INSERT fail" = 0 boost actif, juste à
+  // re-cocher. Pas de corruption data.)
+  const { error: delErr } = await admin
+    .from('profile_seasonal_boosts')
+    .delete()
+    .eq('profile_id', profileId as string)
+  if (delErr) {
+    return NextResponse.json({ error: delErr.message }, { status: 500 })
+  }
+
+  if (uniqueIds.length > 0) {
+    const rows = uniqueIds.map((wid) => ({
+      profile_id: profileId as string,
+      window_id: wid,
+    }))
+    const { error: insErr } = await admin
+      .from('profile_seasonal_boosts')
+      .insert(rows)
+    if (insErr) {
+      return NextResponse.json({ error: insErr.message }, { status: 500 })
+    }
+  }
+
+  return NextResponse.json({ ok: true, count: uniqueIds.length }, { status: 200 })
+}

--- a/app/dashboard/prestataire/fiche/page.tsx
+++ b/app/dashboard/prestataire/fiche/page.tsx
@@ -6,6 +6,7 @@ import { motion, AnimatePresence } from 'motion/react'
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
 import { GoldLine } from '@/components/ui/GoldLine'
 import { VideosManager } from '@/components/v2/VideosManager'
+import { SeasonalBoostsSection } from '@/components/v2/SeasonalBoostsSection'
 import { createClient } from '@/lib/supabase/client'
 import { CATEGORIES_MAP } from '@/lib/constants'
 import {
@@ -674,6 +675,18 @@ export default function MaFichePage() {
                       scope="prestataire"
                       profileId={profileId}
                       userId={userId}
+                      palier={palier}
+                    />
+                  </Group>
+                )}
+
+                {/* Section Tes périodes — auto-boost saisonnier (PR-D mig 44).
+                    Standard = upsell, Premium = 1 fenêtre, Cercle Pro = illimité.
+                    Gating + cap revalidé server-side dans /api/seasonal-boosts. */}
+                {profileId && (
+                  <Group kicker="Tes périodes">
+                    <SeasonalBoostsSection
+                      profileId={profileId}
                       palier={palier}
                     />
                   </Group>

--- a/components/v2/PrestataireCard.tsx
+++ b/components/v2/PrestataireCard.tsx
@@ -50,8 +50,19 @@ export function PrestataireCard({ p, index = 0 }: Props) {
             />
           )}
           <div className="absolute inset-0 bg-grain opacity-[0.08]" />
-          <div className="absolute left-5 top-5 inline-flex max-w-[60%] items-center gap-2 truncate rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
-            {categorieLabel(p.categorie)}
+          <div className="absolute left-5 top-5 flex max-w-[60%] flex-col items-start gap-1.5">
+            {p.active_boost && (
+              <span
+                className="inline-flex items-center gap-1.5 rounded-full bg-or/95 px-2.5 py-1 text-[10px] font-medium tracking-[0.22em] text-vert backdrop-blur uppercase"
+                aria-label={`Boost saisonnier actif : ${p.active_boost.label}`}
+              >
+                <span aria-hidden="true">{p.active_boost.emoji}</span>
+                {p.active_boost.label}
+              </span>
+            )}
+            <span className="inline-flex max-w-full items-center gap-2 truncate rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
+              {categorieLabel(p.categorie)}
+            </span>
           </div>
           {p.lesAvis && p.lesAvis.length > 0 && (
             <div className="absolute right-5 top-5 inline-flex shrink-0 items-center gap-1.5 rounded-full bg-vert/85 px-3 py-1 text-[11px] text-creme backdrop-blur">

--- a/components/v2/SeasonalBoostsSection.tsx
+++ b/components/v2/SeasonalBoostsSection.tsx
@@ -1,0 +1,241 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import {
+  SEASONAL_BOOST_COUNT_MAX,
+  canSelectSeasonalBoost,
+  seasonalBoostCountLabel,
+} from '@/lib/palier-limits'
+import type { Palier } from '@/app/tarifs/_lib/pricing'
+import type { SeasonalEventWindow } from '@/lib/supabase/types'
+
+interface Props {
+  /** UUID du profile prestataire (déjà chargé par la page dashboard). */
+  profileId: string
+  /** Palier effectif (founders mappés cercle_pro) — drive le cap + le copy. */
+  palier: Palier
+}
+
+function dateRangeLabel(starts: string | null, ends: string | null): string {
+  if (!starts || !ends) return ''
+  const s = new Date(starts)
+  const e = new Date(ends)
+  const fmt = new Intl.DateTimeFormat('fr-FR', {
+    day: 'numeric',
+    month: 'short',
+  })
+  return `${fmt.format(s)} → ${fmt.format(e)}`
+}
+
+/**
+ * Section "Tes périodes" du dashboard prestataire fiche (PR-D mig 44).
+ *
+ * 3 modes selon palier :
+ *  - standard   : upsell card (boost non inclus)
+ *  - premium    : 1 fenêtre cochable maximum
+ *  - cercle_pro : illimité
+ *
+ * Voix Sara : "On te met devant les copines pendant ces périodes-là."
+ *
+ * Persistence via API route /api/seasonal-boosts (POST = replace all).
+ * Le cap palier est revalidé server-side dans l'API route — pas de
+ * trigger BDD pour rester souple sur les changements de palier.
+ */
+export function SeasonalBoostsSection({ profileId, palier }: Props) {
+  const [windows, setWindows] = useState<SeasonalEventWindow[]>([])
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [savedAt, setSavedAt] = useState<number | null>(null)
+
+  useEffect(() => {
+    const run = async () => {
+      const supabase = createClient()
+      const [winsRes, boostsRes] = await Promise.all([
+        supabase
+          .from('seasonal_event_windows')
+          .select('id, slug, label, emoji, starts_at, ends_at, is_active, created_at, updated_at')
+          .eq('is_active', true)
+          .order('starts_at', { ascending: true, nullsFirst: false }),
+        supabase
+          .from('profile_seasonal_boosts')
+          .select('window_id')
+          .eq('profile_id', profileId),
+      ])
+      if (winsRes.error) {
+        setError(winsRes.error.message)
+        setLoading(false)
+        return
+      }
+      setWindows((winsRes.data ?? []) as SeasonalEventWindow[])
+      const ids = (boostsRes.data ?? []).map((r: { window_id: string }) => r.window_id)
+      setSelectedIds(new Set(ids))
+      setLoading(false)
+    }
+    run()
+  }, [profileId])
+
+  const cap = SEASONAL_BOOST_COUNT_MAX[palier]
+  const isCercle = cap === null
+  const isPremium = cap === 1
+  const isStandard = cap === 0
+
+  // Mode Standard : upsell card, pas de form
+  if (isStandard) {
+    return (
+      <div className="rounded-sm border border-or/30 bg-creme-soft p-6 md:p-7">
+        <p className="overline text-or">Boost saisonnier · disponible avec Premium</p>
+        <p className="mt-2 font-serif text-[18px] italic leading-[1.4] text-vert md:text-[20px]">
+          Pendant tes périodes clés, ta fiche remonte automatiquement en haut de l&apos;annuaire.
+        </p>
+        <p className="mt-2 max-w-2xl text-[13px] leading-[1.6] text-texte-sec">
+          Ramadan, Saint-Valentin, saison mariage, rentrée… Tu coches une fois,
+          ça tourne tout seul pendant la fenêtre. Disponible dès le palier Premium.
+        </p>
+        <a
+          href="/dashboard/prestataire/abonnement"
+          className="mt-5 inline-flex h-11 items-center gap-2 rounded-full bg-vert px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+        >
+          Passer Premium
+          <span className="text-or-light" aria-hidden="true">→</span>
+        </a>
+      </div>
+    )
+  }
+
+  if (loading) {
+    return <div className="h-32 animate-pulse rounded-sm bg-creme-deep" />
+  }
+
+  const toggle = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        // Cap check côté UI (l'API route revalide server-side)
+        if (!canSelectSeasonalBoost(palier, next.size)) {
+          setError(
+            `Avec ton palier ${isPremium ? 'Premium' : ''}, tu peux cocher 1 fenêtre. Décoche celle en cours pour en choisir une autre.`,
+          )
+          return prev
+        }
+        next.add(id)
+      }
+      setError(null)
+      return next
+    })
+  }
+
+  const save = async () => {
+    setSaving(true)
+    setError(null)
+    setSavedAt(null)
+    try {
+      const res = await fetch('/api/seasonal-boosts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profile_id: profileId,
+          window_ids: Array.from(selectedIds),
+        }),
+      })
+      if (!res.ok) {
+        const json = (await res.json().catch(() => null)) as { error?: string } | null
+        setError(json?.error || 'Échec de la sauvegarde.')
+        setSaving(false)
+        return
+      }
+      setSavedAt(Date.now())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur réseau.')
+    }
+    setSaving(false)
+  }
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <p className="font-serif text-[18px] italic leading-[1.4] text-vert md:text-[20px]">
+          On te met devant les copines pendant ces périodes-là.
+        </p>
+        <p className="mt-2 max-w-2xl text-[13px] leading-[1.6] text-texte-sec">
+          Tu paramètres une fois, ça tourne. Pendant chaque fenêtre cochée, ta
+          fiche remonte automatiquement en haut de l&apos;annuaire avec un badge
+          dédié.
+        </p>
+        <p className="mt-3 text-[12px] tracking-[0.22em] text-texte-sec uppercase">
+          {seasonalBoostCountLabel(palier, selectedIds.size)}
+        </p>
+      </div>
+
+      {error && (
+        <p className="rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[12px] text-red-900">
+          {error}
+        </p>
+      )}
+
+      <ul className="grid gap-3 sm:grid-cols-2">
+        {windows.map((w) => {
+          const checked = selectedIds.has(w.id)
+          const disabled =
+            !checked && !canSelectSeasonalBoost(palier, selectedIds.size)
+          return (
+            <li key={w.id}>
+              <label
+                className={`group flex cursor-pointer items-start gap-3 rounded-sm border bg-blanc p-4 transition-all ${
+                  checked
+                    ? 'border-or/60 shadow-[0_4px_16px_-8px_rgba(201,169,97,0.4)]'
+                    : 'border-or/15 hover:border-or/40'
+                } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  disabled={disabled}
+                  onChange={() => toggle(w.id)}
+                  className="mt-1 h-4 w-4 cursor-pointer accent-or disabled:cursor-not-allowed"
+                  aria-label={`Boost ${w.label}`}
+                />
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <span aria-hidden="true" className="text-[18px]">{w.emoji}</span>
+                    <span className="font-serif text-[16px] text-vert">{w.label}</span>
+                  </div>
+                  {w.starts_at && w.ends_at && (
+                    <p className="mt-1 text-[11px] tracking-[0.18em] text-texte-sec uppercase">
+                      {dateRangeLabel(w.starts_at, w.ends_at)}
+                    </p>
+                  )}
+                </div>
+              </label>
+            </li>
+          )
+        })}
+      </ul>
+
+      <div className="flex items-center gap-4 pt-2">
+        <button
+          type="button"
+          onClick={save}
+          disabled={saving}
+          className="inline-flex h-11 items-center gap-2 rounded-full bg-vert px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark disabled:opacity-60"
+        >
+          {saving ? 'Enregistrement…' : 'Enregistrer mes périodes'}
+          <span className="text-or-light" aria-hidden="true">→</span>
+        </button>
+        {savedAt && Date.now() - savedAt < 5000 && (
+          <span className="text-[11px] italic text-vert">Enregistré ✓</span>
+        )}
+      </div>
+
+      {isCercle && (
+        <p className="text-[11px] italic text-texte-sec">
+          Avec Cercle Pro, tu peux cocher autant de périodes que tu veux.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -111,6 +111,10 @@ export type Prestataire = {
   /** Boolean flag pour le badge ▶ VIDÉO sur la card feed (PR-3 mig 43).
    *  Pré-fetché côté server via `getProfileIdsWithVideos` pour éviter N+1. */
   has_videos?: boolean;
+  /** Fenêtre saisonnière active du prestataire (PR-D mig 44).
+   *  Pré-fetché batch via `getActiveSeasonalLabelsBatch`. Affiché en
+   *  badge top-left sur PrestataireCard si défini. */
+  active_boost?: { label: string; emoji: string } | null;
 };
 
 export const prestataires: Prestataire[] = [

--- a/lib/palier-limits.ts
+++ b/lib/palier-limits.ts
@@ -205,3 +205,49 @@ export function placeVideoCountLabel(
   }
   return `${currentCount} / ${max} vidéo${max > 1 ? 's' : ''}`
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   AUTO-BOOST SAISONNIER PRESTATAIRES (mig 44 PR-D Sprint 4)
+   ═══════════════════════════════════════════════════════════════════ */
+
+/**
+ * Nombre maximum de fenêtres saisonnières qu'un prestataire peut cocher
+ * pour son auto-boost annuaire.
+ *  - standard   : 0  → boost non inclus (upsell vers Premium)
+ *  - premium    : 1  → 1 fenêtre principale (Ramadan OU Saison mariage…)
+ *  - cercle_pro : illimité (matérialisé par null)
+ *
+ * Founders bénéficient comme cercle_pro (cf lib/permissions.ts).
+ *
+ * Pas de trigger SQL pour ce cap : validé côté API route avant insert
+ * (même pattern que les vidéos PR-3, plus souple sur les changements
+ * de palier).
+ */
+export const SEASONAL_BOOST_COUNT_MAX: Record<Palier, number | null> = {
+  standard: 0,
+  premium: 1,
+  cercle_pro: null,
+}
+
+/** Helper boolean : peut-on cocher 1 fenêtre supplémentaire ? */
+export function canSelectSeasonalBoost(
+  palier: Palier,
+  currentCount: number,
+): boolean {
+  const max = SEASONAL_BOOST_COUNT_MAX[palier]
+  if (max === 0) return false
+  return max === null || currentCount < max
+}
+
+/** Libellé compteur UI ("0 / 1 fenêtre", "3 fenêtres · illimité"). */
+export function seasonalBoostCountLabel(
+  palier: Palier,
+  currentCount: number,
+): string {
+  const max = SEASONAL_BOOST_COUNT_MAX[palier]
+  if (max === 0) return 'Boost saisonnier non inclus dans ton palier'
+  if (max === null) {
+    return `${currentCount} fenêtre${currentCount > 1 ? 's' : ''} · illimité`
+  }
+  return `${currentCount} / ${max} fenêtre${max > 1 ? 's' : ''}`
+}

--- a/lib/supabase/queries/seasonal-boosts.ts
+++ b/lib/supabase/queries/seasonal-boosts.ts
@@ -1,0 +1,176 @@
+/**
+ * Queries auto-boost saisonnier prestataires (mig 44 PR-D Sprint 4).
+ *
+ * Tables : seasonal_event_windows + profile_seasonal_boosts (M:N)
+ * Fonctions SQL : is_profile_seasonally_boosted, get_profile_active_seasonal_window
+ *
+ * RLS appliquée :
+ *  - seasonal_event_windows  : public read, admin write
+ *  - profile_seasonal_boosts : public read, owner write, admin all
+ *
+ * Le cap palier (Standard 0 / Premium 1 / Cercle Pro illimité) est revalidé
+ * server-side dans setProfileSeasonalBoosts via API route — pas de trigger
+ * BDD pour rester souple sur les downgrades de palier.
+ */
+
+import { createClient } from "@/lib/supabase/server";
+import type {
+  ActiveSeasonalBoost,
+  ProfileSeasonalBoost,
+  QueryResult,
+  SeasonalEventWindow,
+} from "@/lib/supabase/types";
+
+const WINDOW_SELECT = `
+  id,
+  slug,
+  label,
+  emoji,
+  starts_at,
+  ends_at,
+  is_active,
+  created_at,
+  updated_at
+`;
+
+/** Liste toutes les fenêtres calendrier. activeOnly filtre is_active=true. */
+export async function listSeasonalWindows(
+  activeOnly = false
+): Promise<QueryResult<SeasonalEventWindow[]>> {
+  try {
+    const supabase = await createClient();
+    const query = supabase
+      .from("seasonal_event_windows")
+      .select(WINDOW_SELECT)
+      .order("starts_at", { ascending: true, nullsFirst: false });
+    const { data, error } = activeOnly
+      ? await query.eq("is_active", true)
+      : await query;
+
+    if (error) return { data: null, error: error.message };
+    return {
+      data: (data ?? []) as unknown as SeasonalEventWindow[],
+      error: null,
+    };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
+/** Récupère les boosts actuels d'un prestataire avec le détail des windows. */
+export async function getProfileSeasonalBoosts(
+  profileId: string
+): Promise<QueryResult<(ProfileSeasonalBoost & { window: SeasonalEventWindow })[]>> {
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from("profile_seasonal_boosts")
+      .select(`id, profile_id, window_id, created_at, window:seasonal_event_windows(${WINDOW_SELECT})`)
+      .eq("profile_id", profileId);
+
+    if (error) return { data: null, error: error.message };
+    return {
+      data: (data ?? []) as unknown as (ProfileSeasonalBoost & {
+        window: SeasonalEventWindow;
+      })[],
+      error: null,
+    };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
+/**
+ * Retourne le label+emoji de la fenêtre active actuelle d'un profile, ou null.
+ * Wrap de la fonction SQL get_profile_active_seasonal_window — inclut le filtre
+ * palier server-side (premium/cercle_pro/founder uniquement).
+ */
+export async function getActiveSeasonalLabel(
+  profileId: string
+): Promise<QueryResult<ActiveSeasonalBoost | null>> {
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .rpc("get_profile_active_seasonal_window", { p_profile_id: profileId });
+
+    if (error) return { data: null, error: error.message };
+    const row = (data ?? [])[0] as
+      | { window_label: string; window_emoji: string }
+      | undefined;
+    if (!row) return { data: null, error: null };
+    return {
+      data: { label: row.window_label, emoji: row.window_emoji },
+      error: null,
+    };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
+/**
+ * Batch fetch des labels+emojis actifs pour plusieurs profiles d'un coup.
+ * Utilisé par /annuaire pour pré-fetch sans N+1 RPC. Côté SQL on aurait pu
+ * faire une fonction set-returning, mais ici on lit les rows boost directement
+ * et on joint window dans la query — la fonction RPC retourne 1 row max
+ * par profile, mais en cas de plusieurs boosts actifs simultanément (Ramadan
+ * + Saison mariage), on prend le 1er par starts_at ASC, comme la fonction SQL.
+ */
+export async function getActiveSeasonalLabelsBatch(
+  profileIds: string[]
+): Promise<Map<string, ActiveSeasonalBoost>> {
+  if (profileIds.length === 0) return new Map();
+  try {
+    const supabase = await createClient();
+    const nowIso = new Date().toISOString();
+    const { data, error } = await supabase
+      .from("profile_seasonal_boosts")
+      .select(
+        `profile_id, profiles!inner(id, palier, is_founder), window:seasonal_event_windows!inner(id, label, emoji, starts_at, ends_at, is_active)`
+      )
+      .in("profile_id", profileIds)
+      .eq("seasonal_event_windows.is_active", true)
+      .lte("seasonal_event_windows.starts_at", nowIso)
+      .gte("seasonal_event_windows.ends_at", nowIso);
+
+    if (error || !data) return new Map();
+
+    type Row = {
+      profile_id: string;
+      profiles: { palier: string | null; is_founder: boolean | null };
+      window: {
+        label: string;
+        emoji: string;
+        starts_at: string | null;
+      };
+    };
+
+    // 1 profile peut avoir N boosts actifs simultanément → on garde le 1er
+    // par starts_at ASC pour matcher la logique de get_profile_active_seasonal_window.
+    const byProfile = new Map<string, Row>();
+    for (const r of data as unknown as Row[]) {
+      const effPalier = r.profiles.is_founder ? "cercle_pro" : (r.profiles.palier ?? "standard");
+      if (effPalier !== "premium" && effPalier !== "cercle_pro") continue;
+      const existing = byProfile.get(r.profile_id);
+      if (!existing) {
+        byProfile.set(r.profile_id, r);
+      } else {
+        const a = r.window.starts_at ?? "";
+        const b = existing.window.starts_at ?? "";
+        if (a < b) byProfile.set(r.profile_id, r);
+      }
+    }
+
+    const out = new Map<string, ActiveSeasonalBoost>();
+    for (const [pid, row] of byProfile) {
+      out.set(pid, { label: row.window.label, emoji: row.window.emoji });
+    }
+    return out;
+  } catch {
+    return new Map();
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -479,3 +479,35 @@ export interface PlaceVideo {
 export type QueryResult<T> =
   | { data: T; error: null }
   | { data: null; error: string };
+
+
+/* ─────────────────────────────────────────────────────────────
+   Auto-boost saisonnier prestataires (mig 44 PR-D Sprint 4)
+   ───────────────────────────────────────────────────────────── */
+
+/** Fenêtre calendrier admin-CRUD (Ramadan, Aïd, Saint-Valentin, etc.). */
+export interface SeasonalEventWindow {
+  id: string;
+  slug: string;
+  label: string;
+  emoji: string;
+  starts_at: string | null;
+  ends_at: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/** M:N sélection prestataire ↔ fenêtre. */
+export interface ProfileSeasonalBoost {
+  id: string;
+  profile_id: string;
+  window_id: string;
+  created_at: string;
+}
+
+/** Retour de get_profile_active_seasonal_window() — label+emoji ou null. */
+export interface ActiveSeasonalBoost {
+  label: string;
+  emoji: string;
+}

--- a/supabase/migrations/44_seasonal_boosts_prestataires.sql
+++ b/supabase/migrations/44_seasonal_boosts_prestataires.sql
@@ -1,0 +1,308 @@
+-- =====================================================================
+-- HILMY · 44 — Auto-boost saisonnier prestataires (PR-D Sprint 4)
+--
+-- Phase 2A · PR-D. Mécanique de boost calendrier pour Premium + Cercle Pro :
+-- pendant des fenêtres saisonnières fixes (Ramadan, Aïd, Saint-Valentin,
+-- Noël, etc.), les fiches des prestataires qui ont coché ces fenêtres
+-- remontent en tête de l'annuaire avec un badge "🌙 Ramadan" sur la card.
+--
+-- Justifie 49€ (Premium = 1 fenêtre) et 99€ (Cercle Pro = illimité).
+--
+-- ⚠️ Système distinct du boost LIEU mig 41 (`events.boost_event_type`,
+-- 25 slugs snake_case basés sur des events réels). Ici : 12 fenêtres
+-- calendrier kebab-case basées sur dates fixes, sans event physique.
+-- Les 2 systèmes coexistent — pas de couplage.
+--
+-- Tables créées :
+--   1. seasonal_event_windows     — 12 fenêtres calendrier (admin CRUD)
+--   2. profile_seasonal_boosts    — M:N profile ↔ window (owner CRUD)
+--
+-- Fonctions :
+--   - is_profile_seasonally_boosted(uuid)        → boolean
+--   - get_profile_active_seasonal_window(uuid)   → table(label, emoji)
+--
+-- Founder mapping : `is_founder = true` → considéré comme cercle_pro
+-- pour le check palier, conformément à lib/permissions.ts. Centralisé
+-- dans une CTE locale aux 2 fonctions pour éviter le double CASE.
+--
+-- Idempotente. Voir bas de fichier pour le rollback.
+-- ⚠️ Application en prod : SUR DEMANDE EXPLICITE de Jiji uniquement.
+-- =====================================================================
+
+
+-- =====================================================================
+-- 1. seasonal_event_windows  (ref data, 12 fenêtres calendrier)
+-- =====================================================================
+
+create table if not exists public.seasonal_event_windows (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  label text not null,
+  emoji text not null default '🎁',
+  starts_at timestamptz,
+  ends_at timestamptz,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint seasonal_event_windows_dates_order
+    check (starts_at is null or ends_at is null or starts_at <= ends_at)
+);
+
+create index if not exists seasonal_event_windows_active_window_idx
+  on public.seasonal_event_windows (is_active, starts_at, ends_at);
+
+comment on table public.seasonal_event_windows is
+  'Fenêtres calendrier pour le boost saisonnier prestataires (PR-D mig 44). '
+  'Distinct de events.boost_event_type qui drive le boost lieu via events réels.';
+
+comment on column public.seasonal_event_windows.slug is
+  'Identifiant kebab-case stable (ex: ramadan, aid-fitr, saint-valentin). '
+  'Distinct du snake_case des slugs events lieux.';
+
+
+-- ─── Trigger updated_at ──────────────────────────────────────────────
+
+create or replace function public.bump_seasonal_event_windows_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists seasonal_event_windows_updated_at_trg
+  on public.seasonal_event_windows;
+create trigger seasonal_event_windows_updated_at_trg
+  before update on public.seasonal_event_windows
+  for each row execute function public.bump_seasonal_event_windows_updated_at();
+
+
+-- ─── RLS seasonal_event_windows ──────────────────────────────────────
+-- Public read (anon + auth) : alimente le form prestataire dashboard
+-- + le badge card annuaire. Aucune donnée sensible.
+-- Admin write (insert/update/delete) via JWT user_metadata.is_admin
+-- (pattern aligné mig 41).
+
+alter table public.seasonal_event_windows enable row level security;
+
+drop policy if exists "seasonal_event_windows_public_read"
+  on public.seasonal_event_windows;
+create policy "seasonal_event_windows_public_read"
+  on public.seasonal_event_windows
+  for select
+  to anon, authenticated
+  using (true);
+
+drop policy if exists "seasonal_event_windows_admin_write"
+  on public.seasonal_event_windows;
+create policy "seasonal_event_windows_admin_write"
+  on public.seasonal_event_windows
+  for all
+  to authenticated
+  using (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  )
+  with check (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+
+-- =====================================================================
+-- 2. Seed initial — 12 fenêtres 2026-2027
+-- =====================================================================
+-- Dates indicatives, ajustables via /admin/seasonal-windows.
+-- ON CONFLICT DO NOTHING : si la mig est ré-appliquée, on ne touche pas
+-- aux modifs admin déjà faites en prod.
+
+insert into public.seasonal_event_windows (slug, label, emoji, starts_at, ends_at) values
+  ('ramadan',        'Ramadan',         '🌙', '2026-02-17 00:00+00', '2026-03-19 23:59+00'),
+  ('aid-fitr',       'Aïd al-Fitr',     '✨', '2026-03-20 00:00+00', '2026-03-22 23:59+00'),
+  ('aid-adha',       'Aïd al-Adha',     '🐑', '2026-05-26 00:00+00', '2026-05-28 23:59+00'),
+  ('fete-meres',     'Fête des mères',  '🌸', '2026-05-25 00:00+00', '2026-05-31 23:59+00'),
+  ('fete-peres',     'Fête des pères',  '👔', '2026-06-15 00:00+00', '2026-06-21 23:59+00'),
+  ('mariage-saison', 'Saison mariage',  '💍', '2026-05-01 00:00+00', '2026-09-30 23:59+00'),
+  ('rentree',        'Rentrée',         '📚', '2026-08-15 00:00+00', '2026-09-15 23:59+00'),
+  ('halloween',      'Halloween',       '🎃', '2026-10-25 00:00+00', '2026-10-31 23:59+00'),
+  ('noel',           'Noël',            '🎄', '2026-12-01 00:00+00', '2026-12-26 23:59+00'),
+  ('nouvel-an',      'Nouvel an',       '🥂', '2026-12-27 00:00+00', '2027-01-02 23:59+00'),
+  ('saint-valentin', 'Saint-Valentin',  '💕', '2027-02-07 00:00+00', '2027-02-14 23:59+00'),
+  ('paques',         'Pâques',          '🐰', '2027-03-28 00:00+00', '2027-04-04 23:59+00')
+on conflict (slug) do nothing;
+
+
+-- =====================================================================
+-- 3. profile_seasonal_boosts  (M:N profile ↔ window, owner CRUD)
+-- =====================================================================
+
+create table if not exists public.profile_seasonal_boosts (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  window_id uuid not null references public.seasonal_event_windows(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique (profile_id, window_id)
+);
+
+create index if not exists profile_seasonal_boosts_profile_idx
+  on public.profile_seasonal_boosts (profile_id);
+
+create index if not exists profile_seasonal_boosts_window_idx
+  on public.profile_seasonal_boosts (window_id);
+
+comment on table public.profile_seasonal_boosts is
+  'Sélections boost saisonnier par prestataire. Standard = 0 row, Premium '
+  '= max 1 row, Cercle Pro/founder = illimité. Cap appliqué côté client + '
+  'API route — pas de trigger BDD pour rester souple sur les changements '
+  'de palier (downgrade Premium→Standard ne supprime pas les rows).';
+
+
+-- ─── RLS profile_seasonal_boosts ─────────────────────────────────────
+-- Public read : alimente le tri annuaire + badge card.
+-- Owner write : un user ne peut écrire que sur ses propres profile_id.
+-- Admin write : pour debug/cleanup éventuel.
+
+alter table public.profile_seasonal_boosts enable row level security;
+
+drop policy if exists "profile_seasonal_boosts_public_read"
+  on public.profile_seasonal_boosts;
+create policy "profile_seasonal_boosts_public_read"
+  on public.profile_seasonal_boosts
+  for select
+  to anon, authenticated
+  using (true);
+
+drop policy if exists "profile_seasonal_boosts_owner_write"
+  on public.profile_seasonal_boosts;
+create policy "profile_seasonal_boosts_owner_write"
+  on public.profile_seasonal_boosts
+  for all
+  to authenticated
+  using (
+    profile_id in (
+      select id from public.profiles where user_id = auth.uid()
+    )
+  )
+  with check (
+    profile_id in (
+      select id from public.profiles where user_id = auth.uid()
+    )
+  );
+
+drop policy if exists "profile_seasonal_boosts_admin_all"
+  on public.profile_seasonal_boosts;
+create policy "profile_seasonal_boosts_admin_all"
+  on public.profile_seasonal_boosts
+  for all
+  to authenticated
+  using (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  )
+  with check (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+
+-- =====================================================================
+-- 4. Fonction is_profile_seasonally_boosted(uuid)
+-- =====================================================================
+-- Retourne true ssi :
+--   - le profile a au moins 1 boost saisonnier
+--   - dont la window est is_active = true
+--   - dont la fenêtre [starts_at, ends_at] englobe now()
+--   - ET le palier effectif du profile est premium ou cercle_pro
+--     (founders mappés cercle_pro via la même règle que lib/permissions.ts)
+--
+-- STABLE : permet aux planners PostgREST/SQL de cacher le résultat dans
+-- le scope de la requête (1 call par profile par requête, pas par row).
+
+create or replace function public.is_profile_seasonally_boosted(p_profile_id uuid)
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from public.profile_seasonal_boosts pb
+    join public.seasonal_event_windows w on w.id = pb.window_id
+    join public.profiles p on p.id = pb.profile_id
+    where pb.profile_id = p_profile_id
+      and w.is_active = true
+      and w.starts_at is not null
+      and w.ends_at is not null
+      and now() between w.starts_at and w.ends_at
+      and (case when p.is_founder = true then 'cercle_pro'
+                else p.palier
+           end) in ('premium', 'cercle_pro')
+  );
+$$;
+
+comment on function public.is_profile_seasonally_boosted is
+  'PR-D mig 44 — true ssi le prestataire a un boost saisonnier actif et '
+  'son palier effectif est premium/cercle_pro (founders inclus).';
+
+
+-- =====================================================================
+-- 5. Fonction get_profile_active_seasonal_window(uuid)
+-- =====================================================================
+-- Retourne label + emoji de la 1ère fenêtre active du profile (ordre
+-- starts_at ASC). NULL si aucun boost actif ou palier insuffisant.
+-- Utilisé par le badge card annuaire.
+
+create or replace function public.get_profile_active_seasonal_window(p_profile_id uuid)
+returns table (window_label text, window_emoji text)
+language sql
+stable
+as $$
+  select w.label, w.emoji
+  from public.profile_seasonal_boosts pb
+  join public.seasonal_event_windows w on w.id = pb.window_id
+  join public.profiles p on p.id = pb.profile_id
+  where pb.profile_id = p_profile_id
+    and w.is_active = true
+    and w.starts_at is not null
+    and w.ends_at is not null
+    and now() between w.starts_at and w.ends_at
+    and (case when p.is_founder = true then 'cercle_pro'
+              else p.palier
+         end) in ('premium', 'cercle_pro')
+  order by w.starts_at asc
+  limit 1;
+$$;
+
+comment on function public.get_profile_active_seasonal_window is
+  'PR-D mig 44 — label+emoji de la fenêtre saisonnière active (1ère par '
+  'starts_at ASC). NULL si pas de boost ou palier insuffisant.';
+
+
+-- =====================================================================
+-- 6. NOTIFY PostgREST — recharger le schéma exposé par l''API
+-- =====================================================================
+
+notify pgrst, 'reload schema';
+
+
+-- =====================================================================
+-- ROLLBACK (à exécuter en SQL si besoin de défaire la mig 44)
+-- =====================================================================
+-- drop function if exists public.get_profile_active_seasonal_window(uuid);
+-- drop function if exists public.is_profile_seasonally_boosted(uuid);
+--
+-- drop policy if exists "profile_seasonal_boosts_admin_all"
+--   on public.profile_seasonal_boosts;
+-- drop policy if exists "profile_seasonal_boosts_owner_write"
+--   on public.profile_seasonal_boosts;
+-- drop policy if exists "profile_seasonal_boosts_public_read"
+--   on public.profile_seasonal_boosts;
+-- drop table if exists public.profile_seasonal_boosts;
+--
+-- drop policy if exists "seasonal_event_windows_admin_write"
+--   on public.seasonal_event_windows;
+-- drop policy if exists "seasonal_event_windows_public_read"
+--   on public.seasonal_event_windows;
+-- drop trigger if exists seasonal_event_windows_updated_at_trg
+--   on public.seasonal_event_windows;
+-- drop function if exists public.bump_seasonal_event_windows_updated_at();
+-- drop table if exists public.seasonal_event_windows;
+--
+-- notify pgrst, 'reload schema';


### PR DESCRIPTION
## Quoi

Sprint 4 / PR-D — Auto-boost saisonnier prestataires.

Mécanique de boost calendrier pour Premium + Cercle Pro : pendant des fenêtres saisonnières fixes (Ramadan, Aïd, Saint-Valentin, Saison mariage, Noël…), les fiches qui ont coché ces fenêtres remontent en tête de l'annuaire avec un badge dédié. Justifie 49€ et 99€ avec une vraie valeur perçue.

**Système distinct du boost LIEU mig 41** (`events.boost_event_type`, 25 slugs snake_case basés sur events réels). Ici 12 fenêtres calendrier kebab-case basées sur dates fixes. Les 2 systèmes coexistent — pas de couplage. Slugs prestataires en kebab-case pour distinction visuelle.

## Pourquoi

Phase 2A core déjà livrée (mig 41/42/43, PR-1/2/3/B1/B2/C). Maintenant on monte la mécanique de boost auto :
- Premium 49€ → 1 fenêtre principale ("Pendant Ramadan, je remonte")
- Cercle Pro 99€ → illimité ("Toutes mes saisons clés")
- Founders bénéficient comme Cercle Pro (cf `lib/permissions.ts`)
- Standard → upsell card "Disponible avec Premium"

## Migration 44 — déjà appliquée prod, smoke tests OK

**Tables** (idempotentes, RLS, comments) :
- `seasonal_event_windows` ref data, 12 fenêtres seedées (Ramadan, Aïd Fitr/Adha, Fête mères/pères, Saison mariage, Rentrée, Halloween, Noël, Nouvel an, Saint-Valentin, Pâques)
- `profile_seasonal_boosts` M:N profile↔window (CASCADE delete)

**Fonctions SQL** (STABLE) :
- `is_profile_seasonally_boosted(uuid) → bool` — true ssi window active + palier effectif `IN ('premium','cercle_pro')` (founder mappé via `CASE WHEN p.is_founder THEN 'cercle_pro' ELSE p.palier END`)
- `get_profile_active_seasonal_window(uuid) → table(label, emoji)` — 1ère fenêtre active par `starts_at ASC`, NULL si pas de boost ou palier insuffisant

**RLS** :
- `seasonal_event_windows` : public read, admin write (JWT `is_admin`)
- `profile_seasonal_boosts` : public read, owner write, admin all

**Smoke tests SQL post-mig (vérifiés)** :
- ✅ 12 windows seedées avec dates correctes
- ✅ 5 RLS policies présentes
- ✅ Functions `pg_proc` registered
- ✅ `is_profile_seasonally_boosted` retourne `true` quand cercle_pro + window active
- ✅ Même fonction retourne `false` quand palier downgradé vers standard (filtre palier fonctionne)
- ✅ `get_profile_active_seasonal_window` retourne label+emoji corrects
- ✅ Cleanup propre (0 leftover row)

## Côté code

**Nouveaux fichiers (6)** :
- `lib/supabase/queries/seasonal-boosts.ts` — 4 helpers (`listSeasonalWindows`, `getProfileSeasonalBoosts`, `getActiveSeasonalLabel`, `getActiveSeasonalLabelsBatch`)
- `components/v2/SeasonalBoostsSection.tsx` — form dashboard client component, 3 modes selon palier (standard upsell / premium 1 cap / cercle_pro illimité), voix Sara
- `app/api/seasonal-boosts/route.ts` — POST replace-all, auth + ownership + palier + cap revalidés server-side, rate-limit 20/min
- `app/admin/seasonal-windows/page.tsx` + `actions.ts` — CRUD admin (server actions, layout admin gate déjà via `is_admin`)

**Étendus (7)** :
- `lib/supabase/types.ts` — `SeasonalEventWindow`, `ProfileSeasonalBoost`, `ActiveSeasonalBoost`
- `lib/palier-limits.ts` — `SEASONAL_BOOST_COUNT_MAX` (0/1/null), `canSelectSeasonalBoost`, label helper
- `lib/mock-data.ts` — `Prestataire.active_boost?: { label, emoji } | null`
- `components/v2/PrestataireCard.tsx` — stack badge top-left ✨ saison + catégorie chip dessous (pattern PR-C)
- `app/annuaire/page.tsx` — pré-fetch batch `getActiveSeasonalLabelsBatch` + tri prio (boostés > palier > date)
- `app/dashboard/prestataire/fiche/page.tsx` — section `<Group kicker="Tes périodes">` entre Mes vidéos et Enregistrer
- `app/admin/layout.tsx` — nav link "Fenêtres saisonnières"

## Comment tester

**Sur Vercel preview** une fois Ready :

```sql
-- Étape 1 : push une fenêtre en active maintenant pour le test
UPDATE seasonal_event_windows
   SET starts_at = now() - interval '1 day',
       ends_at   = now() + interval '7 days'
 WHERE slug = 'ramadan';

-- Étape 2 : insert un boost row pour le profile demo Jiji (cercle_pro)
INSERT INTO profile_seasonal_boosts (profile_id, window_id)
SELECT '33ba949d-0283-441b-a178-1eaf017d5fa1', id
  FROM seasonal_event_windows
 WHERE slug = 'ramadan'
ON CONFLICT DO NOTHING;
```

**Tests à valider** :
- [ ] `/annuaire` : profile demo Jiji en HAUT du feed avec badge `🌙 RAMADAN` top-left + catégorie chip dessous
- [ ] Card peut aussi avoir le badge `★ note` (top-right) + `▶ Vidéo` (top-right stack) sans clash
- [ ] `/dashboard/prestataire/fiche` : section "Tes périodes" affiche checkbox "Ramadan" cochée + 11 autres décochées (cap illimité Cercle Pro)
- [ ] Test gating : downgrade Jiji `palier='standard'` → section affiche upsell "Disponible avec Premium" + badge annuaire disparaît
- [ ] Test gating : `palier='premium'` → section affiche cap "0 / 1 fenêtre", impossible d'en cocher 2
- [ ] `/admin/seasonal-windows` : liste 12 fenêtres + form création + edit inline + delete
- [ ] `npm run build` vert ✅ (vérifié local)

**Cleanup post-test** :
```sql
UPDATE seasonal_event_windows SET starts_at='2026-02-17 00:00+00', ends_at='2026-03-19 23:59+00' WHERE slug='ramadan';
DELETE FROM profile_seasonal_boosts WHERE profile_id='33ba949d-0283-441b-a178-1eaf017d5fa1';
```

## Risques

- **Replace-all sans transaction** : DELETE puis INSERT en 2 calls — si DELETE OK + INSERT fail, l'utilisatrice se retrouve avec 0 boost. Pas de corruption data, juste à re-cocher. Acceptable pour la fréquence d'usage (save = 1× par session).
- **Palier check côté API route** : revalidé via `getEffectivePalier` (founder→cercle_pro). Si une fonction de la chaîne change, vérifier que les 2 fonctions SQL et le helper TS restent synchros.
- **Tri JS client-side** : preserve l'ordre stable existant (cohérent pattern PR-C lieux). Si on ajoute beaucoup de prestataires (>1000), envisager le tri SQL natif.
- **Founder mapping in SQL function** : utilisé `CASE WHEN p.is_founder THEN 'cercle_pro' ELSE p.palier END` directement dans `is_profile_seasonally_boosted` et `get_profile_active_seasonal_window`. Si la logique founder évolue (ex. founder = premium au lieu de cercle_pro), 2 endroits à modifier.

## Sécurité

✅ RLS sur les 2 tables (public read, owner+admin write).
✅ API route auth + ownership check + palier validation server-side.
✅ Admin page gate via layout `is_admin` (defense in depth dans server actions aussi).
✅ Pas de PII dans logs.
✅ Service_role key seulement server-side (admin client + API route).
✅ Rate-limit 20/min sur l'API de save.
✅ FK CASCADE sur `profile_seasonal_boosts.window_id` → suppression d'une window cascade les boosts liés (admin doit confirmer en UI).

## Stats diff

- 13 files changed, +1336 / -10
- 6 nouveaux fichiers (1 mig SQL + 5 TS/TSX)
- 0 npm dep ajoutée
- 1 migration BDD (CREATE TABLE × 2 + 5 policies + 2 fonctions + seed 12 rows)
- Build vert local

## Déploiement post-merge

Migration **déjà appliquée en prod** (smoke tests passés avant push). Le merge déploie juste le code TS. Pas de cycle apply-mig-puis-merge nécessaire.
