### PR TITLE
chore(boost): rollback PR-D + rename table → event_seasonal_categories (mig 45)

### DIFF
--- a/app/admin/event-seasonal-categories/actions.ts
+++ b/app/admin/event-seasonal-categories/actions.ts
@@ -1,0 +1,120 @@
+'use server'
+
+/**
+ * Server actions admin pour les catégories saisonnières (mig 44 + 45).
+ *
+ * Initialement créées par PR-D pour le boost prestataire (scope abandonné),
+ * la table `seasonal_event_windows` a été renommée `event_seasonal_categories`
+ * via mig 45 et sert désormais de référentiel pour les filtres saisonniers
+ * de la page /événements.
+ *
+ * Toutes les actions :
+ *  - vérifient is_admin via JWT (defense in depth — le layout admin gate déjà)
+ *  - utilisent createAdminClient() pour bypass RLS
+ *  - revalident la page admin après chaque mutation
+ *  - retournent { ok: true } ou { ok: false, error: string }
+ */
+
+import { revalidatePath } from 'next/cache'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { requireUser } from '@/lib/supabase/session'
+
+type ActionResult = { ok: true } | { ok: false; error: string }
+
+async function ensureAdmin(): Promise<{ ok: true } | { ok: false; error: string }> {
+  const user = await requireUser()
+  if (!user.user_metadata?.is_admin) {
+    return { ok: false, error: 'Accès admin requis' }
+  }
+  return { ok: true }
+}
+
+function parseDateInput(raw: FormDataEntryValue | null): string | null {
+  if (typeof raw !== 'string' || raw.trim() === '') return null
+  return new Date(raw).toISOString()
+}
+
+function parseTextInput(raw: FormDataEntryValue | null, max = 200): string | null {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (trimmed === '') return null
+  return trimmed.slice(0, max)
+}
+
+export async function createSeasonalCategory(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureAdmin()
+  if (!auth.ok) return auth
+
+  const slug = parseTextInput(formData.get('slug'), 64)
+  const label = parseTextInput(formData.get('label'), 120)
+  const emoji = parseTextInput(formData.get('emoji'), 8) ?? '🎁'
+  const starts_at = parseDateInput(formData.get('starts_at'))
+  const ends_at = parseDateInput(formData.get('ends_at'))
+
+  if (!slug || !/^[a-z0-9-]+$/.test(slug)) {
+    return { ok: false, error: 'Slug requis (kebab-case, a-z 0-9 -)' }
+  }
+  if (!label) {
+    return { ok: false, error: 'Label requis' }
+  }
+  if (starts_at && ends_at && starts_at > ends_at) {
+    return { ok: false, error: 'starts_at doit être <= ends_at' }
+  }
+
+  const admin = createAdminClient()
+  const { error } = await admin
+    .from('event_seasonal_categories')
+    .insert({ slug, label, emoji, starts_at, ends_at, is_active: true })
+  if (error) return { ok: false, error: error.message }
+
+  revalidatePath('/admin/event-seasonal-categories')
+  return { ok: true }
+}
+
+export async function updateSeasonalCategory(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureAdmin()
+  if (!auth.ok) return auth
+
+  const id = parseTextInput(formData.get('id'), 64)
+  if (!id) return { ok: false, error: 'ID manquant' }
+
+  const label = parseTextInput(formData.get('label'), 120)
+  const emoji = parseTextInput(formData.get('emoji'), 8) ?? '🎁'
+  const starts_at = parseDateInput(formData.get('starts_at'))
+  const ends_at = parseDateInput(formData.get('ends_at'))
+  const is_active = formData.get('is_active') === 'on'
+
+  if (!label) return { ok: false, error: 'Label requis' }
+  if (starts_at && ends_at && starts_at > ends_at) {
+    return { ok: false, error: 'starts_at doit être <= ends_at' }
+  }
+
+  const admin = createAdminClient()
+  const { error } = await admin
+    .from('event_seasonal_categories')
+    .update({ label, emoji, starts_at, ends_at, is_active })
+    .eq('id', id)
+  if (error) return { ok: false, error: error.message }
+
+  revalidatePath('/admin/event-seasonal-categories')
+  return { ok: true }
+}
+
+export async function deleteSeasonalCategory(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureAdmin()
+  if (!auth.ok) return auth
+
+  const id = parseTextInput(formData.get('id'), 64)
+  if (!id) return { ok: false, error: 'ID manquant' }
+
+  // CASCADE supprime aussi les profile_seasonal_boosts liés (FK ON DELETE CASCADE).
+  const admin = createAdminClient()
+  const { error } = await admin
+    .from('event_seasonal_categories')
+    .delete()
+    .eq('id', id)
+  if (error) return { ok: false, error: error.message }
+
+  revalidatePath('/admin/event-seasonal-categories')
+  return { ok: true }
+}

--- a/app/admin/event-seasonal-categories/page.tsx
+++ b/app/admin/event-seasonal-categories/page.tsx
@@ -1,0 +1,210 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+import {
+  createSeasonalCategory,
+  updateSeasonalCategory,
+  deleteSeasonalCategory,
+} from './actions'
+import type { EventSeasonalCategory } from '@/lib/supabase/types'
+
+/**
+ * Admin page /admin/event-seasonal-categories (mig 44 + 45).
+ *
+ * Liste les catégories saisonnières (Ramadan, Aïd, Saint-Valentin, Saison
+ * mariage, Noël…) qui alimentent les filtres de la page /événements.
+ * Form de création + form édition par row + delete. Layout admin gate
+ * déjà via app/admin/layout.tsx (is_admin).
+ *
+ * Pas d'optimistic UI — on revalidate la page après chaque action via
+ * revalidatePath() côté server action. Sufficient pour un panel admin
+ * faible-trafic (Jiji = unique admin actuelle).
+ */
+
+function toDateInputValue(iso: string | null): string {
+  if (!iso) return ''
+  // Format requis par <input type="date"> : YYYY-MM-DD
+  return new Date(iso).toISOString().slice(0, 10)
+}
+
+export default async function SeasonalWindowsAdminPage() {
+  const admin = createAdminClient()
+  const { data, error } = await admin
+    .from('event_seasonal_categories')
+    .select('id, slug, label, emoji, starts_at, ends_at, is_active, created_at, updated_at')
+    .order('starts_at', { ascending: true, nullsFirst: false })
+
+  const categories = (data ?? []) as EventSeasonalCategory[]
+
+  return (
+    <section className="px-6 py-10 md:px-12 md:py-14">
+      <header className="border-b border-or/15 pb-6">
+        <p className="overline text-or">Référentiel · catégories saisonnières</p>
+        <h1 className="mt-3 font-serif text-3xl font-light text-vert md:text-4xl">
+          Catégories saisonnières.
+        </h1>
+        <p className="mt-3 max-w-2xl text-[13px] leading-[1.6] text-texte-sec">
+          Ramadan, Aïd, Saint-Valentin, Saison mariage, Noël… Ces catégories
+          alimentent les filtres de la page /événements. Slug en kebab-case
+          (distinct du snake_case des events lieux).
+        </p>
+      </header>
+
+      {error && (
+        <p className="mt-6 rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[12px] text-red-900">
+          {error.message}
+        </p>
+      )}
+
+      {/* Form création */}
+      <div className="mt-8 rounded-sm border border-or/20 bg-blanc p-6">
+        <h2 className="font-serif text-xl font-light text-vert">+ Nouvelle catégorie</h2>
+        <form action={createSeasonalCategory} className="mt-4 grid gap-3 md:grid-cols-2">
+          <label className="block">
+            <span className="block text-[11px] tracking-[0.18em] text-texte-sec uppercase">Slug</span>
+            <input
+              name="slug"
+              required
+              pattern="[a-z0-9\-]+"
+              placeholder="black-friday"
+              className="mt-1 w-full rounded-sm border border-or/30 bg-creme px-3 py-2 text-[14px] text-vert"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-[11px] tracking-[0.18em] text-texte-sec uppercase">Label</span>
+            <input
+              name="label"
+              required
+              placeholder="Black Friday"
+              className="mt-1 w-full rounded-sm border border-or/30 bg-creme px-3 py-2 text-[14px] text-vert"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-[11px] tracking-[0.18em] text-texte-sec uppercase">Emoji</span>
+            <input
+              name="emoji"
+              maxLength={8}
+              defaultValue="🎁"
+              className="mt-1 w-full rounded-sm border border-or/30 bg-creme px-3 py-2 text-[14px] text-vert"
+            />
+          </label>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="block">
+              <span className="block text-[11px] tracking-[0.18em] text-texte-sec uppercase">Début</span>
+              <input
+                type="date"
+                name="starts_at"
+                className="mt-1 w-full rounded-sm border border-or/30 bg-creme px-3 py-2 text-[14px] text-vert"
+              />
+            </label>
+            <label className="block">
+              <span className="block text-[11px] tracking-[0.18em] text-texte-sec uppercase">Fin</span>
+              <input
+                type="date"
+                name="ends_at"
+                className="mt-1 w-full rounded-sm border border-or/30 bg-creme px-3 py-2 text-[14px] text-vert"
+              />
+            </label>
+          </div>
+          <div className="md:col-span-2">
+            <button
+              type="submit"
+              className="inline-flex h-11 items-center gap-2 rounded-full bg-vert px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+            >
+              Créer
+            </button>
+          </div>
+        </form>
+      </div>
+
+      {/* Liste + édition par row */}
+      <div className="mt-10">
+        <h2 className="font-serif text-xl font-light text-vert">
+          Catégories existantes ({categories.length})
+        </h2>
+        <ul className="mt-4 grid gap-3">
+          {categories.map((c) => (
+            <li
+              key={c.id}
+              className={`rounded-sm border bg-blanc p-5 ${
+                c.is_active ? 'border-or/20' : 'border-or/10 opacity-60'
+              }`}
+            >
+              <form action={updateSeasonalCategory} className="grid gap-3 md:grid-cols-[auto_1fr_auto_auto_auto_auto]">
+                <input type="hidden" name="id" value={c.id} />
+                <div className="flex items-center gap-2">
+                  <span className="text-[11px] tracking-[0.18em] text-texte-sec uppercase">{c.slug}</span>
+                </div>
+                <label className="block">
+                  <span className="block text-[10px] tracking-[0.18em] text-texte-sec uppercase">Label</span>
+                  <input
+                    name="label"
+                    required
+                    defaultValue={c.label}
+                    className="mt-1 w-full rounded-sm border border-or/30 bg-creme px-2 py-1.5 text-[13px] text-vert"
+                  />
+                </label>
+                <label className="block">
+                  <span className="block text-[10px] tracking-[0.18em] text-texte-sec uppercase">Emoji</span>
+                  <input
+                    name="emoji"
+                    maxLength={8}
+                    defaultValue={c.emoji}
+                    className="mt-1 w-20 rounded-sm border border-or/30 bg-creme px-2 py-1.5 text-center text-[14px] text-vert"
+                  />
+                </label>
+                <label className="block">
+                  <span className="block text-[10px] tracking-[0.18em] text-texte-sec uppercase">Début</span>
+                  <input
+                    type="date"
+                    name="starts_at"
+                    defaultValue={toDateInputValue(c.starts_at)}
+                    className="mt-1 rounded-sm border border-or/30 bg-creme px-2 py-1.5 text-[13px] text-vert"
+                  />
+                </label>
+                <label className="block">
+                  <span className="block text-[10px] tracking-[0.18em] text-texte-sec uppercase">Fin</span>
+                  <input
+                    type="date"
+                    name="ends_at"
+                    defaultValue={toDateInputValue(c.ends_at)}
+                    className="mt-1 rounded-sm border border-or/30 bg-creme px-2 py-1.5 text-[13px] text-vert"
+                  />
+                </label>
+                <label className="flex items-center gap-2 self-end pb-1.5">
+                  <input
+                    type="checkbox"
+                    name="is_active"
+                    defaultChecked={c.is_active}
+                    className="h-4 w-4 cursor-pointer accent-or"
+                  />
+                  <span className="text-[11px] tracking-[0.18em] text-texte-sec uppercase">Actif</span>
+                </label>
+                <div className="flex items-center gap-2 md:col-span-6 md:justify-end">
+                  <button
+                    type="submit"
+                    className="inline-flex h-9 items-center rounded-full bg-vert px-4 text-[10px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+                  >
+                    Enregistrer
+                  </button>
+                </div>
+              </form>
+              <form action={deleteSeasonalCategory} className="mt-2 flex justify-end">
+                <input type="hidden" name="id" value={c.id} />
+                <button
+                  type="submit"
+                  className="text-[10px] tracking-[0.22em] text-red-900 uppercase hover:text-red-700"
+                >
+                  Supprimer
+                </button>
+              </form>
+            </li>
+          ))}
+          {categories.length === 0 && (
+            <li className="rounded-sm border border-dashed border-or/30 p-6 text-center text-[13px] italic text-texte-sec">
+              Aucune catégorie. Crée la première ci-dessus.
+            </li>
+          )}
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -72,6 +72,11 @@ export default async function AdminLayout({
       label: 'Signalements Je cherche',
       badge: jeChercheSignalementsCount.count ?? 0,
     },
+    {
+      href: '/admin/event-seasonal-categories',
+      label: 'Catégories saisonnières',
+      badge: undefined,
+    },
   ]
 
   return (

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -479,3 +479,25 @@ export interface PlaceVideo {
 export type QueryResult<T> =
   | { data: T; error: null }
   | { data: null; error: string };
+
+
+/* ─────────────────────────────────────────────────────────────
+   Catégories saisonnières d'événements (mig 44 + 45)
+   ─────────────────────────────────────────────────────────────
+   Initialement créée par PR-D pour le boost prestataire (scope
+   abandonné). La table `seasonal_event_windows` est renommée
+   `event_seasonal_categories` via mig 45 et sert désormais de
+   référentiel pour les filtres saisonniers de la page /événements
+   (PR-F à venir). */
+
+export interface EventSeasonalCategory {
+  id: string;
+  slug: string;
+  label: string;
+  emoji: string;
+  starts_at: string | null;
+  ends_at: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}

--- a/supabase/migrations/44_seasonal_boosts_prestataires.sql
+++ b/supabase/migrations/44_seasonal_boosts_prestataires.sql
@@ -1,0 +1,308 @@
+-- =====================================================================
+-- HILMY · 44 — Auto-boost saisonnier prestataires (PR-D Sprint 4)
+--
+-- Phase 2A · PR-D. Mécanique de boost calendrier pour Premium + Cercle Pro :
+-- pendant des fenêtres saisonnières fixes (Ramadan, Aïd, Saint-Valentin,
+-- Noël, etc.), les fiches des prestataires qui ont coché ces fenêtres
+-- remontent en tête de l'annuaire avec un badge "🌙 Ramadan" sur la card.
+--
+-- Justifie 49€ (Premium = 1 fenêtre) et 99€ (Cercle Pro = illimité).
+--
+-- ⚠️ Système distinct du boost LIEU mig 41 (`events.boost_event_type`,
+-- 25 slugs snake_case basés sur des events réels). Ici : 12 fenêtres
+-- calendrier kebab-case basées sur dates fixes, sans event physique.
+-- Les 2 systèmes coexistent — pas de couplage.
+--
+-- Tables créées :
+--   1. seasonal_event_windows     — 12 fenêtres calendrier (admin CRUD)
+--   2. profile_seasonal_boosts    — M:N profile ↔ window (owner CRUD)
+--
+-- Fonctions :
+--   - is_profile_seasonally_boosted(uuid)        → boolean
+--   - get_profile_active_seasonal_window(uuid)   → table(label, emoji)
+--
+-- Founder mapping : `is_founder = true` → considéré comme cercle_pro
+-- pour le check palier, conformément à lib/permissions.ts. Centralisé
+-- dans une CTE locale aux 2 fonctions pour éviter le double CASE.
+--
+-- Idempotente. Voir bas de fichier pour le rollback.
+-- ⚠️ Application en prod : SUR DEMANDE EXPLICITE de Jiji uniquement.
+-- =====================================================================
+
+
+-- =====================================================================
+-- 1. seasonal_event_windows  (ref data, 12 fenêtres calendrier)
+-- =====================================================================
+
+create table if not exists public.seasonal_event_windows (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  label text not null,
+  emoji text not null default '🎁',
+  starts_at timestamptz,
+  ends_at timestamptz,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint seasonal_event_windows_dates_order
+    check (starts_at is null or ends_at is null or starts_at <= ends_at)
+);
+
+create index if not exists seasonal_event_windows_active_window_idx
+  on public.seasonal_event_windows (is_active, starts_at, ends_at);
+
+comment on table public.seasonal_event_windows is
+  'Fenêtres calendrier pour le boost saisonnier prestataires (PR-D mig 44). '
+  'Distinct de events.boost_event_type qui drive le boost lieu via events réels.';
+
+comment on column public.seasonal_event_windows.slug is
+  'Identifiant kebab-case stable (ex: ramadan, aid-fitr, saint-valentin). '
+  'Distinct du snake_case des slugs events lieux.';
+
+
+-- ─── Trigger updated_at ──────────────────────────────────────────────
+
+create or replace function public.bump_seasonal_event_windows_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists seasonal_event_windows_updated_at_trg
+  on public.seasonal_event_windows;
+create trigger seasonal_event_windows_updated_at_trg
+  before update on public.seasonal_event_windows
+  for each row execute function public.bump_seasonal_event_windows_updated_at();
+
+
+-- ─── RLS seasonal_event_windows ──────────────────────────────────────
+-- Public read (anon + auth) : alimente le form prestataire dashboard
+-- + le badge card annuaire. Aucune donnée sensible.
+-- Admin write (insert/update/delete) via JWT user_metadata.is_admin
+-- (pattern aligné mig 41).
+
+alter table public.seasonal_event_windows enable row level security;
+
+drop policy if exists "seasonal_event_windows_public_read"
+  on public.seasonal_event_windows;
+create policy "seasonal_event_windows_public_read"
+  on public.seasonal_event_windows
+  for select
+  to anon, authenticated
+  using (true);
+
+drop policy if exists "seasonal_event_windows_admin_write"
+  on public.seasonal_event_windows;
+create policy "seasonal_event_windows_admin_write"
+  on public.seasonal_event_windows
+  for all
+  to authenticated
+  using (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  )
+  with check (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+
+-- =====================================================================
+-- 2. Seed initial — 12 fenêtres 2026-2027
+-- =====================================================================
+-- Dates indicatives, ajustables via /admin/seasonal-windows.
+-- ON CONFLICT DO NOTHING : si la mig est ré-appliquée, on ne touche pas
+-- aux modifs admin déjà faites en prod.
+
+insert into public.seasonal_event_windows (slug, label, emoji, starts_at, ends_at) values
+  ('ramadan',        'Ramadan',         '🌙', '2026-02-17 00:00+00', '2026-03-19 23:59+00'),
+  ('aid-fitr',       'Aïd al-Fitr',     '✨', '2026-03-20 00:00+00', '2026-03-22 23:59+00'),
+  ('aid-adha',       'Aïd al-Adha',     '🐑', '2026-05-26 00:00+00', '2026-05-28 23:59+00'),
+  ('fete-meres',     'Fête des mères',  '🌸', '2026-05-25 00:00+00', '2026-05-31 23:59+00'),
+  ('fete-peres',     'Fête des pères',  '👔', '2026-06-15 00:00+00', '2026-06-21 23:59+00'),
+  ('mariage-saison', 'Saison mariage',  '💍', '2026-05-01 00:00+00', '2026-09-30 23:59+00'),
+  ('rentree',        'Rentrée',         '📚', '2026-08-15 00:00+00', '2026-09-15 23:59+00'),
+  ('halloween',      'Halloween',       '🎃', '2026-10-25 00:00+00', '2026-10-31 23:59+00'),
+  ('noel',           'Noël',            '🎄', '2026-12-01 00:00+00', '2026-12-26 23:59+00'),
+  ('nouvel-an',      'Nouvel an',       '🥂', '2026-12-27 00:00+00', '2027-01-02 23:59+00'),
+  ('saint-valentin', 'Saint-Valentin',  '💕', '2027-02-07 00:00+00', '2027-02-14 23:59+00'),
+  ('paques',         'Pâques',          '🐰', '2027-03-28 00:00+00', '2027-04-04 23:59+00')
+on conflict (slug) do nothing;
+
+
+-- =====================================================================
+-- 3. profile_seasonal_boosts  (M:N profile ↔ window, owner CRUD)
+-- =====================================================================
+
+create table if not exists public.profile_seasonal_boosts (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  window_id uuid not null references public.seasonal_event_windows(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique (profile_id, window_id)
+);
+
+create index if not exists profile_seasonal_boosts_profile_idx
+  on public.profile_seasonal_boosts (profile_id);
+
+create index if not exists profile_seasonal_boosts_window_idx
+  on public.profile_seasonal_boosts (window_id);
+
+comment on table public.profile_seasonal_boosts is
+  'Sélections boost saisonnier par prestataire. Standard = 0 row, Premium '
+  '= max 1 row, Cercle Pro/founder = illimité. Cap appliqué côté client + '
+  'API route — pas de trigger BDD pour rester souple sur les changements '
+  'de palier (downgrade Premium→Standard ne supprime pas les rows).';
+
+
+-- ─── RLS profile_seasonal_boosts ─────────────────────────────────────
+-- Public read : alimente le tri annuaire + badge card.
+-- Owner write : un user ne peut écrire que sur ses propres profile_id.
+-- Admin write : pour debug/cleanup éventuel.
+
+alter table public.profile_seasonal_boosts enable row level security;
+
+drop policy if exists "profile_seasonal_boosts_public_read"
+  on public.profile_seasonal_boosts;
+create policy "profile_seasonal_boosts_public_read"
+  on public.profile_seasonal_boosts
+  for select
+  to anon, authenticated
+  using (true);
+
+drop policy if exists "profile_seasonal_boosts_owner_write"
+  on public.profile_seasonal_boosts;
+create policy "profile_seasonal_boosts_owner_write"
+  on public.profile_seasonal_boosts
+  for all
+  to authenticated
+  using (
+    profile_id in (
+      select id from public.profiles where user_id = auth.uid()
+    )
+  )
+  with check (
+    profile_id in (
+      select id from public.profiles where user_id = auth.uid()
+    )
+  );
+
+drop policy if exists "profile_seasonal_boosts_admin_all"
+  on public.profile_seasonal_boosts;
+create policy "profile_seasonal_boosts_admin_all"
+  on public.profile_seasonal_boosts
+  for all
+  to authenticated
+  using (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  )
+  with check (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+
+-- =====================================================================
+-- 4. Fonction is_profile_seasonally_boosted(uuid)
+-- =====================================================================
+-- Retourne true ssi :
+--   - le profile a au moins 1 boost saisonnier
+--   - dont la window est is_active = true
+--   - dont la fenêtre [starts_at, ends_at] englobe now()
+--   - ET le palier effectif du profile est premium ou cercle_pro
+--     (founders mappés cercle_pro via la même règle que lib/permissions.ts)
+--
+-- STABLE : permet aux planners PostgREST/SQL de cacher le résultat dans
+-- le scope de la requête (1 call par profile par requête, pas par row).
+
+create or replace function public.is_profile_seasonally_boosted(p_profile_id uuid)
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from public.profile_seasonal_boosts pb
+    join public.seasonal_event_windows w on w.id = pb.window_id
+    join public.profiles p on p.id = pb.profile_id
+    where pb.profile_id = p_profile_id
+      and w.is_active = true
+      and w.starts_at is not null
+      and w.ends_at is not null
+      and now() between w.starts_at and w.ends_at
+      and (case when p.is_founder = true then 'cercle_pro'
+                else p.palier
+           end) in ('premium', 'cercle_pro')
+  );
+$$;
+
+comment on function public.is_profile_seasonally_boosted is
+  'PR-D mig 44 — true ssi le prestataire a un boost saisonnier actif et '
+  'son palier effectif est premium/cercle_pro (founders inclus).';
+
+
+-- =====================================================================
+-- 5. Fonction get_profile_active_seasonal_window(uuid)
+-- =====================================================================
+-- Retourne label + emoji de la 1ère fenêtre active du profile (ordre
+-- starts_at ASC). NULL si aucun boost actif ou palier insuffisant.
+-- Utilisé par le badge card annuaire.
+
+create or replace function public.get_profile_active_seasonal_window(p_profile_id uuid)
+returns table (window_label text, window_emoji text)
+language sql
+stable
+as $$
+  select w.label, w.emoji
+  from public.profile_seasonal_boosts pb
+  join public.seasonal_event_windows w on w.id = pb.window_id
+  join public.profiles p on p.id = pb.profile_id
+  where pb.profile_id = p_profile_id
+    and w.is_active = true
+    and w.starts_at is not null
+    and w.ends_at is not null
+    and now() between w.starts_at and w.ends_at
+    and (case when p.is_founder = true then 'cercle_pro'
+              else p.palier
+         end) in ('premium', 'cercle_pro')
+  order by w.starts_at asc
+  limit 1;
+$$;
+
+comment on function public.get_profile_active_seasonal_window is
+  'PR-D mig 44 — label+emoji de la fenêtre saisonnière active (1ère par '
+  'starts_at ASC). NULL si pas de boost ou palier insuffisant.';
+
+
+-- =====================================================================
+-- 6. NOTIFY PostgREST — recharger le schéma exposé par l''API
+-- =====================================================================
+
+notify pgrst, 'reload schema';
+
+
+-- =====================================================================
+-- ROLLBACK (à exécuter en SQL si besoin de défaire la mig 44)
+-- =====================================================================
+-- drop function if exists public.get_profile_active_seasonal_window(uuid);
+-- drop function if exists public.is_profile_seasonally_boosted(uuid);
+--
+-- drop policy if exists "profile_seasonal_boosts_admin_all"
+--   on public.profile_seasonal_boosts;
+-- drop policy if exists "profile_seasonal_boosts_owner_write"
+--   on public.profile_seasonal_boosts;
+-- drop policy if exists "profile_seasonal_boosts_public_read"
+--   on public.profile_seasonal_boosts;
+-- drop table if exists public.profile_seasonal_boosts;
+--
+-- drop policy if exists "seasonal_event_windows_admin_write"
+--   on public.seasonal_event_windows;
+-- drop policy if exists "seasonal_event_windows_public_read"
+--   on public.seasonal_event_windows;
+-- drop trigger if exists seasonal_event_windows_updated_at_trg
+--   on public.seasonal_event_windows;
+-- drop function if exists public.bump_seasonal_event_windows_updated_at();
+-- drop table if exists public.seasonal_event_windows;
+--
+-- notify pgrst, 'reload schema';

--- a/supabase/migrations/45_rollback_seasonal_boosts.sql
+++ b/supabase/migrations/45_rollback_seasonal_boosts.sql
@@ -1,0 +1,211 @@
+-- =====================================================================
+-- HILMY · 45 — Rollback partiel mig 44 (PR-D abandonnée, pivot scope)
+--
+-- Contexte (2026-05-10) : la mécanique "auto-boost saisonnier prestataire"
+-- introduite par mig 44 + PR-D était une mauvaise direction. Le vrai
+-- besoin = filtres saisonniers sur la page /événements (à venir PR-F).
+--
+-- PR-D #86 fermée sans merge. Mig 44 reste en historique pour audit
+-- trail (la table `seasonal_event_windows` existe en prod depuis le
+-- 2026-05-09). Cette mig 45 rollback ce qui n'est plus utile et
+-- renomme ce qu'on garde :
+--
+--   1. DROP table profile_seasonal_boosts (M:N inutile pour filtres)
+--   2. DROP fonctions is_profile_seasonally_boosted +
+--      get_profile_active_seasonal_window
+--   3. RENAME seasonal_event_windows → event_seasonal_categories
+--   4. RENAME trigger + function updated_at + policies + indexes
+--   5. RESTORE dates Ramadan modifiées pendant tests prod
+--
+-- Idempotente. La table renommée + ses 12 rows seedées sont préservées,
+-- réutilisables comme référentiel de filtres /événements (PR-F).
+--
+-- ⚠️ Application en prod : SUR DEMANDE EXPLICITE de Jiji, après backup
+-- Supabase manuel.
+-- =====================================================================
+
+
+-- =====================================================================
+-- 1. DROP fonctions devenues inutiles
+-- =====================================================================
+-- Aucun consumer en main (PR-D jamais mergée). Drop sans risque.
+
+drop function if exists public.get_profile_active_seasonal_window(uuid);
+drop function if exists public.is_profile_seasonally_boosted(uuid);
+
+
+-- =====================================================================
+-- 2. DROP table M:N profile_seasonal_boosts (CASCADE retire les FKs)
+-- =====================================================================
+-- Contient au moment de cette mig : 1 row de test (Jiji + Ramadan)
+-- créée pour le smoke test du 2026-05-09. Pas de prod data.
+
+drop table if exists public.profile_seasonal_boosts cascade;
+
+
+-- =====================================================================
+-- 3. Pré-rename : drop policies + trigger + function bump
+-- =====================================================================
+-- PostgreSQL ne RENAME pas les policies attachées automatiquement avec
+-- la table. On les recréera proprement après le rename. Idem pour le
+-- trigger updated_at et sa fonction qui portent l'ancien nom.
+
+drop policy if exists "seasonal_event_windows_admin_write"
+  on public.seasonal_event_windows;
+drop policy if exists "seasonal_event_windows_public_read"
+  on public.seasonal_event_windows;
+
+drop trigger if exists seasonal_event_windows_updated_at_trg
+  on public.seasonal_event_windows;
+drop function if exists public.bump_seasonal_event_windows_updated_at();
+
+
+-- =====================================================================
+-- 4. RENAME table + index (idempotent via DO block)
+-- =====================================================================
+
+do $$
+begin
+  if exists (
+    select 1 from pg_class
+    where relname = 'seasonal_event_windows'
+      and relnamespace = (select oid from pg_namespace where nspname = 'public')
+  ) then
+    alter table public.seasonal_event_windows rename to event_seasonal_categories;
+  end if;
+
+  if exists (
+    select 1 from pg_class
+    where relname = 'seasonal_event_windows_active_window_idx'
+      and relnamespace = (select oid from pg_namespace where nspname = 'public')
+  ) then
+    alter index public.seasonal_event_windows_active_window_idx
+      rename to event_seasonal_categories_active_window_idx;
+  end if;
+
+  if exists (
+    select 1 from pg_constraint
+    where conname = 'seasonal_event_windows_dates_order'
+  ) then
+    alter table public.event_seasonal_categories
+      rename constraint seasonal_event_windows_dates_order
+      to event_seasonal_categories_dates_order;
+  end if;
+
+  -- PRIMARY KEY + UNIQUE constraints sont auto-nommés par PostgreSQL
+  -- (`<table>_pkey` / `<table>_<col>_key`) et le rename de la table
+  -- ne les renomme pas. On les rebaptise pour cohérence — renommer la
+  -- constraint renomme aussi son index sous-jacent.
+  if exists (
+    select 1 from pg_constraint where conname = 'seasonal_event_windows_pkey'
+  ) then
+    alter table public.event_seasonal_categories
+      rename constraint seasonal_event_windows_pkey
+      to event_seasonal_categories_pkey;
+  end if;
+
+  if exists (
+    select 1 from pg_constraint where conname = 'seasonal_event_windows_slug_key'
+  ) then
+    alter table public.event_seasonal_categories
+      rename constraint seasonal_event_windows_slug_key
+      to event_seasonal_categories_slug_key;
+  end if;
+end $$;
+
+
+-- =====================================================================
+-- 5. Recréer trigger updated_at avec nouveau nom
+-- =====================================================================
+
+create or replace function public.bump_event_seasonal_categories_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists event_seasonal_categories_updated_at_trg
+  on public.event_seasonal_categories;
+create trigger event_seasonal_categories_updated_at_trg
+  before update on public.event_seasonal_categories
+  for each row execute function public.bump_event_seasonal_categories_updated_at();
+
+
+-- =====================================================================
+-- 6. Recréer RLS + policies avec nouveaux noms
+-- =====================================================================
+-- Public read (filtres /événements seront publics) + admin write (panel
+-- /admin/event-seasonal-categories). Pattern identique à mig 44.
+
+alter table public.event_seasonal_categories enable row level security;
+
+drop policy if exists "event_seasonal_categories_public_read"
+  on public.event_seasonal_categories;
+create policy "event_seasonal_categories_public_read"
+  on public.event_seasonal_categories
+  for select
+  to anon, authenticated
+  using (true);
+
+drop policy if exists "event_seasonal_categories_admin_write"
+  on public.event_seasonal_categories;
+create policy "event_seasonal_categories_admin_write"
+  on public.event_seasonal_categories
+  for all
+  to authenticated
+  using (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  )
+  with check (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+
+-- =====================================================================
+-- 7. Update commentaires de la table renommée
+-- =====================================================================
+
+comment on table public.event_seasonal_categories is
+  'Catégories saisonnières d''événements (Ramadan, Aïd, Saint-Valentin, '
+  'Saison mariage, Noël…). Alimente les filtres de la page /événements '
+  '(PR-F). Renommée depuis seasonal_event_windows post-pivot scope PR-D.';
+
+comment on column public.event_seasonal_categories.slug is
+  'Identifiant kebab-case stable (ex: ramadan, saint-valentin). '
+  'Distinct du snake_case des slugs events lieux (mig 41).';
+
+
+-- =====================================================================
+-- 8. Restaurer les dates Ramadan modifiées pendant les smoke tests
+-- =====================================================================
+-- Le 2026-05-09 on a UPDATE starts_at=now-1d, ends_at=now+7d sur la row
+-- 'ramadan' pour valider la fonction is_profile_seasonally_boosted.
+-- On restore aux dates seed originales (Ramadan 2026 : 17 fév → 19 mar).
+
+update public.event_seasonal_categories
+   set starts_at = '2026-02-17 00:00+00',
+       ends_at   = '2026-03-19 23:59+00'
+ where slug = 'ramadan';
+
+
+-- =====================================================================
+-- 9. NOTIFY PostgREST — recharger le schéma exposé par l'API
+-- =====================================================================
+
+notify pgrst, 'reload schema';
+
+
+-- =====================================================================
+-- ROLLBACK ROLLBACK (= revert mig 45 → revenir à l'état post-mig 44)
+-- À exécuter en SQL si besoin
+-- =====================================================================
+-- alter table public.event_seasonal_categories rename to seasonal_event_windows;
+-- alter index public.event_seasonal_categories_active_window_idx
+--   rename to seasonal_event_windows_active_window_idx;
+-- (recréer policies + trigger + function avec ancien nom)
+-- (recréer profile_seasonal_boosts + ses 5 policies + 2 fonctions SQL)
+-- → en pratique : ré-exécuter mig 44 dans son intégralité.


### PR DESCRIPTION
## Quoi

Rollback partiel de PR-D (#86, fermée) + rename de la table conservée pour la suite.

PR #86 (auto-boost saisonnier prestataire) était une mauvaise direction. Le vrai besoin = filtres saisonniers sur la page `/événements` (PR-F à venir), pas un boost calendrier prestataire.

**Migration 45** :
- DROP `profile_seasonal_boosts` (M:N inutile, contenait juste 1 row de test)
- DROP fonctions `is_profile_seasonally_boosted` + `get_profile_active_seasonal_window`
- RENAME `seasonal_event_windows` → `event_seasonal_categories` (table conservée + 12 rows seedées préservées)
- RENAME index, contraintes (PK, UNIQUE slug, CHECK dates_order), trigger, fonction bump, 2 policies RLS
- RESTORE dates Ramadan modifiées pendant les smoke tests prod (`2026-02-17 → 2026-03-19`)

**Côté code** :
- Page admin renommée `/admin/event-seasonal-categories` (CRUD préservé, copy voix Sara)
- Type TS `SeasonalEventWindow` renommé `EventSeasonalCategory`
- Nav link admin "Catégories saisonnières"
- Mig 44 SQL conservée en historique (audit trail — la table existe en prod depuis le 2026-05-09)

**Supprimé** (via fermeture PR #86, jamais mergé donc rien à delete dans main) :
- `SeasonalBoostsSection` form dashboard prestataire
- `lib/supabase/queries/seasonal-boosts.ts`
- `app/api/seasonal-boosts/route.ts`
- `PrestataireCard` badge stack top-left
- Tri annuaire boosts-first
- Extensions `Prestataire.active_boost` + types `ProfileSeasonalBoost`

## Pourquoi

Le scope de PR-D était mal posé. La mécanique "le prestataire coche Ramadan dans son dashboard et sa fiche remonte automatiquement dans l'annuaire" est une feature de positioning artificielle. Ce qui sert vraiment les copines : **trouver des événements en lien avec une saison** ("je cherche un événement pour le Ramadan", "un atelier Saint-Valentin") via filtres sur `/événements`.

Les 12 fenêtres calendrier seedées (Ramadan, Aïd, Saint-Valentin, Saison mariage, Fête mères/pères, Rentrée, Halloween, Noël, Nouvel an, Pâques) sont parfaites pour ce use case réel — donc on garde la table, on la renomme proprement.

## État BDD post-mig 45 — smoke tests

| Check | Résultat |
|---|---|
| `to_regclass('event_seasonal_categories')` | ✅ exists |
| `to_regclass('seasonal_event_windows')` | ✅ NULL (renamed) |
| `to_regclass('profile_seasonal_boosts')` | ✅ NULL (dropped) |
| `count(*) event_seasonal_categories` | ✅ 12 |
| Ramadan `starts_at`, `ends_at` | ✅ `2026-02-17`, `2026-03-19` |
| RLS policies | ✅ 2 (public_read + admin_write) |
| Trigger | ✅ `event_seasonal_categories_updated_at_trg` |
| Indexes | ✅ 3 propres (pkey, slug_key, active_window_idx) |
| Backup auto Supabase | ✅ `09 May 2026 00:28 UTC` dispo |

## Comment tester

**Pré-requis** : mig 45 déjà appliquée en prod ✅, smoke tests passés.

**Tests UI sur Vercel preview** :
- [ ] `/admin/event-seasonal-categories` charge la liste des 12 catégories
- [ ] Form création nouvelle catégorie (slug kebab-case + label + emoji + dates) → INSERT OK
- [ ] Edit inline d'une row (modifier label/emoji/dates/is_active) → UPDATE OK
- [ ] Delete une row → row disparaît
- [ ] Nav link admin "Catégories saisonnières" présent dans la sidebar
- [ ] L'ancienne URL `/admin/seasonal-windows` retourne 404 (slug renommé)
- [ ] `npm run build` vert ✅ (vérifié local)

## Risques

- **Race condition mig 45 ↔ déploiement code** : mig 45 déjà appliquée AVANT push (pattern PR-2). Le code post-merge référence `event_seasonal_categories` qui existe déjà en prod. Pas de fenêtre cassée.
- **Backup Supabase** : auto-backup nightly du 2026-05-09 00:28 UTC dispo en filet de sécurité. Mig 45 n'a touché que 1 row de test (Jiji boost) + dates Ramadan modifiées par tests — aucune prod data utilisateur.
- **Audit trail** : mig 44 conservée dans `supabase/migrations/` même si PR-D a été fermée — trace ce qui a été en prod entre le 2026-05-09 et today. Si quelqu'un re-run les migrations from scratch, mig 44 puis mig 45 reproduisent l'état actuel correctement.

## Sécurité

✅ RLS sur `event_seasonal_categories` (public read, admin write JWT `is_admin`).
✅ Server actions admin auth-checked via `requireUser` + `is_admin` (defense in depth).
✅ Aucune PII dans les rows (slugs publics).
✅ Backup pré-mig disponible (filet de sécurité).
✅ Pas de modif auth, pas de webhook touch.

## Stats diff

- 6 files changed, +1199 / -0 (mig 44 cherry-picked = 308 lignes audit, mig 45 = 211, admin page/actions = 330, types = 22, layout = 5)
- 0 npm dep
- 2 migrations BDD (44 conservée, 45 nouvelle)
- Build vert local

## Suite

PR-F à venir : filtres saisonniers `/événements`. Plan brut :
- Mig 46 : ajout colonne `events.event_seasonal_category_id` (FK nullable vers `event_seasonal_categories`)
- Form création event : select catégorie saisonnière (optionnel)
- `/événements` : FiltersBar étendu avec catégorie saisonnière
