### PR TITLE
feat(events): filtres saisonniers /événements (PR-F mig 46)

### DIFF
--- a/app/dashboard/utilisatrice/evenements/nouveau/page.tsx
+++ b/app/dashboard/utilisatrice/evenements/nouveau/page.tsx
@@ -60,6 +60,12 @@ export default function NouveauEvenementPage() {
   const [endDate, setEndDate] = useState('')
   const [endTime, setEndTime] = useState('')
 
+  // Catégorie saisonnière (mig 46 PR-F) — optionnel, alimentée depuis BDD
+  const [seasonalCategoryId, setSeasonalCategoryId] = useState<string>('')
+  const [seasonalCategories, setSeasonalCategories] = useState<
+    { id: string; slug: string; label: string; emoji: string }[]
+  >([])
+
   useEffect(() => {
     const run = async () => {
       const {
@@ -70,6 +76,17 @@ export default function NouveauEvenementPage() {
         return
       }
       setUserId(user.id)
+      // Pré-fetch des catégories saisonnières actives (mig 46 PR-F).
+      // Ordre starts_at ASC pour que les fenêtres prochaines arrivent
+      // en premier dans le select.
+      const { data: cats } = await supabase
+        .from('event_seasonal_categories')
+        .select('id, slug, label, emoji')
+        .eq('is_active', true)
+        .order('starts_at', { ascending: true, nullsFirst: false })
+      setSeasonalCategories(
+        (cats ?? []) as { id: string; slug: string; label: string; emoji: string }[],
+      )
       setChecking(false)
     }
     run()
@@ -172,6 +189,7 @@ export default function NouveauEvenementPage() {
       price_currency: priceType === 'payant' ? priceCurrency : null,
       places_max:
         placesMax && Number(placesMax) > 0 ? Number(placesMax) : null,
+      event_seasonal_category_id: seasonalCategoryId || null,
       status: 'published' as const,
       // quartier non stocké en DB pour Stage 2A — privacy gérée côté UI :
       // l'adresse précise est masquée publiquement, on n'affiche que ville
@@ -267,6 +285,30 @@ export default function NouveauEvenementPage() {
               </select>
             </Field>
           </div>
+
+          {seasonalCategories.length > 0 && (
+            <div className="mt-6 grid gap-2 md:grid-cols-2">
+              <Field label="Catégorie saisonnière">
+                <select
+                  value={seasonalCategoryId}
+                  onChange={(e) => setSeasonalCategoryId(e.target.value)}
+                  className="line"
+                >
+                  <option value="">Aucune (par défaut)</option>
+                  {seasonalCategories.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.emoji} {c.label}
+                    </option>
+                  ))}
+                </select>
+              </Field>
+              <p className="self-end pb-1 text-[12px] italic leading-[1.5] text-texte-sec md:pl-2">
+                Optionnel. Ton événement tombe pendant le Ramadan ? La
+                Saint-Valentin ? Choisis la période — les copines te
+                trouveront plus facilement.
+              </p>
+            </div>
+          )}
 
           <div className="mt-6">
             <p className="overline text-or">Format</p>

--- a/app/evenements-v2/page.tsx
+++ b/app/evenements-v2/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { Suspense, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import { PageShell } from '@/components/v2/PageShell'
 import { PageHero } from '@/components/v2/PageHero'
@@ -56,7 +57,17 @@ function relativeFr(iso: string): string {
   return `dans ${Math.round(diffDays / 30)} mois`
 }
 
-function adaptEvenementFromDb(e: HilmyEvent): MockEvenement {
+type DbEventWithCategory = HilmyEvent & {
+  event_seasonal_category?: {
+    id: string
+    slug: string
+    label: string
+    emoji: string
+  } | null
+}
+
+function adaptEvenementFromDb(e: DbEventWithCategory): MockEvenement {
+  const seasonal = e.event_seasonal_category
   return {
     slug: e.slug ?? e.id,
     titre: e.title,
@@ -71,12 +82,35 @@ function adaptEvenementFromDb(e: HilmyEvent): MockEvenement {
     flyer: e.flyer_url ?? null,
     places: e.places_max ?? 20,
     inscrites: e.inscrites_count ?? 0,
+    seasonal_category: seasonal
+      ? { slug: seasonal.slug, label: seasonal.label, emoji: seasonal.emoji }
+      : null,
   }
 }
 
-export default function EvenementsV2Page() {
+function EvenementsV2PageInner() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
   const [categorie, setCategorie] = useState('all')
   const [ville, setVille] = useState('all')
+  const [seasonalSlug, setSeasonalSlug] = useState<string>(
+    searchParams.get('seasonal') ?? 'all',
+  )
+
+  // Keep URL ?seasonal=... synced with state for deep-link partage
+  // (use case Hilmy : whatsapp share "events Ramadan").
+  const updateSeasonalSlug = (next: string) => {
+    setSeasonalSlug(next)
+    const params = new URLSearchParams(searchParams.toString())
+    if (next === 'all') {
+      params.delete('seasonal')
+    } else {
+      params.set('seasonal', next)
+    }
+    const qs = params.toString()
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+  }
 
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -94,7 +128,10 @@ export default function EvenementsV2Page() {
         const { data, error: err } = await supabase
           .from('events')
           .select(
-            'id, user_id, prestataire_id, title, slug, description, event_type, format, visibility, start_date, end_date, country, region, city, address, online_link, flyer_url, external_signup_url, price_type, price_amount, price_currency, places_max, inscrites_count, status, created_at, updated_at',
+            // mig 46 PR-F : event_seasonal_category_id + LEFT JOIN
+            // event_seasonal_categories (relation auto-détectée par PostgREST
+            // via la FK). Le LEFT JOIN renvoie null si pas de catégorie.
+            'id, user_id, prestataire_id, title, slug, description, event_type, format, visibility, start_date, end_date, country, region, city, address, online_link, flyer_url, external_signup_url, price_type, price_amount, price_currency, places_max, inscrites_count, status, created_at, updated_at, event_seasonal_category_id, event_seasonal_category:event_seasonal_categories(id, slug, label, emoji)',
           )
           .eq('status', 'published')
           .gte('start_date', now)
@@ -107,7 +144,7 @@ export default function EvenementsV2Page() {
           return
         }
         const adapted = (data ?? []).map((row) =>
-          adaptEvenementFromDb(row as unknown as HilmyEvent),
+          adaptEvenementFromDb(row as unknown as DbEventWithCategory),
         )
         setLiveEvents(adapted)
         setLoading(false)
@@ -130,16 +167,42 @@ export default function EvenementsV2Page() {
     return dataSource.filter((e) => {
       if (categorie !== 'all' && e.categorie !== categorie) return false
       if (ville !== 'all' && e.ville !== ville) return false
+      if (
+        seasonalSlug !== 'all' &&
+        e.seasonal_category?.slug !== seasonalSlug
+      )
+        return false
       return true
     })
-  }, [dataSource, categorie, ville])
+  }, [dataSource, categorie, ville, seasonalSlug])
 
   const categories = Array.from(new Set(dataSource.map((e) => e.categorie)))
   const villesPresentes = Array.from(new Set(dataSource.map((e) => e.ville)))
 
+  // Pré-filtre dynamique : afficher uniquement les catégories saisonnières
+  // qui ont des events à venir (pattern villes — évite "Halloween" en mai).
+  // Map clé→{label,emoji} pour dédupliquer + préserver l'affichage.
+  const seasonalsPresent = useMemo(() => {
+    const m = new Map<string, { label: string; emoji: string }>()
+    for (const e of dataSource) {
+      if (e.seasonal_category) {
+        m.set(e.seasonal_category.slug, {
+          label: e.seasonal_category.label,
+          emoji: e.seasonal_category.emoji,
+        })
+      }
+    }
+    return Array.from(m.entries()).map(([slug, v]) => ({
+      slug,
+      label: v.label,
+      emoji: v.emoji,
+    }))
+  }, [dataSource])
+
   const reset = () => {
     setCategorie('all')
     setVille('all')
+    updateSeasonalSlug('all')
   }
 
   const featured = filtered[0]
@@ -222,6 +285,23 @@ export default function EvenementsV2Page() {
         resultCount={filtered.length}
         onReset={reset}
         groups={[
+          ...(seasonalsPresent.length > 0
+            ? [
+                {
+                  id: 'seasonal',
+                  label: 'Période',
+                  value: seasonalSlug,
+                  onChange: updateSeasonalSlug,
+                  options: [
+                    { value: 'all', label: 'Toutes' },
+                    ...seasonalsPresent.map((s) => ({
+                      value: s.slug,
+                      label: `${s.emoji} ${s.label}`,
+                    })),
+                  ],
+                },
+              ]
+            : []),
           {
             id: 'categorie',
             label: 'Catégorie',
@@ -311,5 +391,27 @@ export default function EvenementsV2Page() {
         </div>
       </section>
     </PageShell>
+  )
+}
+
+// useSearchParams() requiert un boundary <Suspense> côté Next 14 app router
+// pour la pre-render statique. Wrap minimal — le contenu reste rendu côté
+// client après hydration.
+export default function EvenementsV2Page() {
+  return (
+    <Suspense
+      fallback={
+        <PageShell>
+          <PageHero
+            number="03"
+            kicker="Les événements"
+            titre={<>Les moments qu&apos;on vit ensemble.</>}
+          />
+          <SkeletonListGrid count={4} />
+        </PageShell>
+      }
+    >
+      <EvenementsV2PageInner />
+    </Suspense>
   )
 }

--- a/app/evenements-v2/page.tsx
+++ b/app/evenements-v2/page.tsx
@@ -115,6 +115,12 @@ function EvenementsV2PageInner() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [liveEvents, setLiveEvents] = useState<MockEvenement[]>([])
+  // Liste complète des 12 catégories actives — affichées en chips même
+  // si aucun event taggé. Permet de communiquer la dimension saisonnière
+  // de Hilmy au lancement (au lieu d'une barre vide).
+  const [allSeasonals, setAllSeasonals] = useState<
+    { slug: string; label: string; emoji: string }[]
+  >([])
 
   useEffect(() => {
     let cancelled = false
@@ -125,28 +131,45 @@ function EvenementsV2PageInner() {
         setError(null)
         const supabase = createClient()
         const now = new Date().toISOString()
-        const { data, error: err } = await supabase
-          .from('events')
-          .select(
-            // mig 46 PR-F : event_seasonal_category_id + LEFT JOIN
-            // event_seasonal_categories (relation auto-détectée par PostgREST
-            // via la FK). Le LEFT JOIN renvoie null si pas de catégorie.
-            'id, user_id, prestataire_id, title, slug, description, event_type, format, visibility, start_date, end_date, country, region, city, address, online_link, flyer_url, external_signup_url, price_type, price_amount, price_currency, places_max, inscrites_count, status, created_at, updated_at, event_seasonal_category_id, event_seasonal_category:event_seasonal_categories(id, slug, label, emoji)',
-          )
-          .eq('status', 'published')
-          .gte('start_date', now)
-          .order('start_date', { ascending: true })
+        // Fetch parallèle : events à venir + catalogue des 12 catégories
+        // saisonnières actives (toujours affichées en chips, même si
+        // aucun event taggé).
+        const [eventsRes, categoriesRes] = await Promise.all([
+          supabase
+            .from('events')
+            .select(
+              // mig 46 PR-F : event_seasonal_category_id + LEFT JOIN
+              // event_seasonal_categories (relation auto-détectée par PostgREST
+              // via la FK). Le LEFT JOIN renvoie null si pas de catégorie.
+              'id, user_id, prestataire_id, title, slug, description, event_type, format, visibility, start_date, end_date, country, region, city, address, online_link, flyer_url, external_signup_url, price_type, price_amount, price_currency, places_max, inscrites_count, status, created_at, updated_at, event_seasonal_category_id, event_seasonal_category:event_seasonal_categories(id, slug, label, emoji)',
+            )
+            .eq('status', 'published')
+            .gte('start_date', now)
+            .order('start_date', { ascending: true }),
+          supabase
+            .from('event_seasonal_categories')
+            .select('slug, label, emoji')
+            .eq('is_active', true)
+            .order('label', { ascending: true }),
+        ])
 
         if (cancelled) return
-        if (err) {
-          setError(err.message)
+        if (eventsRes.error) {
+          setError(eventsRes.error.message)
           setLoading(false)
           return
         }
-        const adapted = (data ?? []).map((row) =>
+        const adapted = (eventsRes.data ?? []).map((row) =>
           adaptEvenementFromDb(row as unknown as DbEventWithCategory),
         )
         setLiveEvents(adapted)
+        // Catalogue catégories : tolère un échec silencieux (la barre
+        // affichera quand même les events s'ils existent, juste sans chips).
+        if (!categoriesRes.error && categoriesRes.data) {
+          setAllSeasonals(
+            categoriesRes.data as { slug: string; label: string; emoji: string }[],
+          )
+        }
         setLoading(false)
       } catch (e) {
         if (cancelled) return
@@ -179,25 +202,16 @@ function EvenementsV2PageInner() {
   const categories = Array.from(new Set(dataSource.map((e) => e.categorie)))
   const villesPresentes = Array.from(new Set(dataSource.map((e) => e.ville)))
 
-  // Pré-filtre dynamique : afficher uniquement les catégories saisonnières
-  // qui ont des events à venir (pattern villes — évite "Halloween" en mai).
-  // Map clé→{label,emoji} pour dédupliquer + préserver l'affichage.
-  const seasonalsPresent = useMemo(() => {
-    const m = new Map<string, { label: string; emoji: string }>()
-    for (const e of dataSource) {
-      if (e.seasonal_category) {
-        m.set(e.seasonal_category.slug, {
-          label: e.seasonal_category.label,
-          emoji: e.seasonal_category.emoji,
-        })
-      }
-    }
-    return Array.from(m.entries()).map(([slug, v]) => ({
-      slug,
-      label: v.label,
-      emoji: v.emoji,
-    }))
-  }, [dataSource])
+  // Empty state spécifique quand une catégorie saisonnière est sélectionnée
+  // mais que zéro event ne lui correspond — on encourage l'utilisatrice à
+  // créer le premier event de cette période.
+  const isEmptyForSelectedSeason =
+    seasonalSlug !== 'all' &&
+    !dataSource.some((e) => e.seasonal_category?.slug === seasonalSlug)
+  const selectedSeasonalLabel =
+    seasonalSlug !== 'all'
+      ? allSeasonals.find((s) => s.slug === seasonalSlug)?.label ?? null
+      : null
 
   const reset = () => {
     setCategorie('all')
@@ -285,7 +299,7 @@ function EvenementsV2PageInner() {
         resultCount={filtered.length}
         onReset={reset}
         groups={[
-          ...(seasonalsPresent.length > 0
+          ...(allSeasonals.length > 0
             ? [
                 {
                   id: 'seasonal',
@@ -294,7 +308,12 @@ function EvenementsV2PageInner() {
                   onChange: updateSeasonalSlug,
                   options: [
                     { value: 'all', label: 'Toutes' },
-                    ...seasonalsPresent.map((s) => ({
+                    // Pas de pré-filtre dynamique : on affiche TOUJOURS les
+                    // 12 catégories actives (ORDER BY label) pour communiquer
+                    // la dimension saisonnière de Hilmy. Si la copine clique
+                    // sur une période sans events, on lui propose d'en créer
+                    // le premier (cf isEmptyForSelectedSeason ci-dessous).
+                    ...allSeasonals.map((s) => ({
                       value: s.slug,
                       label: `${s.emoji} ${s.label}`,
                     })),
@@ -361,12 +380,27 @@ function EvenementsV2PageInner() {
                 transition={{ duration: 0.4 }}
                 className="rounded-sm border border-dashed border-or/30 bg-blanc py-20 text-center"
               >
-                <p className="font-serif text-3xl font-light text-vert">
-                  Pas d&apos;événement qui colle.
-                </p>
-                <p className="mt-3 text-[14px] leading-[1.7] text-texte-sec">
-                  Enlève un filtre, ou organise-toi le tien.
-                </p>
+                {isEmptyForSelectedSeason ? (
+                  <>
+                    <p className="font-serif text-3xl font-light text-vert">
+                      Pas encore d&apos;événement pour
+                      {selectedSeasonalLabel ? ' ' : ' '}
+                      {selectedSeasonalLabel ?? 'cette période'}.
+                    </p>
+                    <p className="mt-3 text-[14px] leading-[1.7] text-texte-sec">
+                      Sois la première à en créer un !
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <p className="font-serif text-3xl font-light text-vert">
+                      Pas d&apos;événement qui colle.
+                    </p>
+                    <p className="mt-3 text-[14px] leading-[1.7] text-texte-sec">
+                      Enlève un filtre, ou organise-toi le tien.
+                    </p>
+                  </>
+                )}
                 <div className="mt-6 flex flex-wrap items-center justify-center gap-4">
                   <button
                     type="button"

--- a/components/v2/EvenementCard.tsx
+++ b/components/v2/EvenementCard.tsx
@@ -53,8 +53,19 @@ export function EvenementCard({ e, index = 0, variant = 'default' }: Props) {
             />
           )}
           <div className="absolute inset-0 bg-grain opacity-[0.08]" />
-          <div className="absolute left-5 top-5 inline-flex max-w-[60%] items-center gap-2 truncate rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
-            {e.categorie}
+          <div className="absolute left-5 top-5 flex max-w-[60%] flex-col items-start gap-1.5">
+            {e.seasonal_category && (
+              <span
+                className="inline-flex items-center gap-1.5 rounded-full bg-or/95 px-2.5 py-1 text-[10px] font-medium tracking-[0.22em] text-vert backdrop-blur uppercase"
+                aria-label={`Période ${e.seasonal_category.label}`}
+              >
+                <span aria-hidden="true">{e.seasonal_category.emoji}</span>
+                {e.seasonal_category.label}
+              </span>
+            )}
+            <span className="inline-flex max-w-full items-center gap-2 truncate rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
+              {e.categorie}
+            </span>
           </div>
           <div className="absolute bottom-5 left-5 rounded-sm bg-vert/85 px-4 py-3 text-center backdrop-blur">
             <p className="font-serif text-3xl font-light leading-none text-creme">{jour}</p>

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -506,6 +506,10 @@ export type Evenement = {
   flyer?: string | null;
   places: number;
   inscrites: number;
+  /** Catégorie saisonnière (mig 46 PR-F). Pré-fetché via LEFT JOIN
+   *  PostgREST sur event_seasonal_categories. Drive le badge card +
+   *  filtre chips /evenements-v2. */
+  seasonal_category?: { slug: string; label: string; emoji: string } | null;
 };
 
 export const evenements: Evenement[] = [

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -219,6 +219,18 @@ export interface HilmyEvent {
   registration_mode: EventRegistrationMode;
   created_at: string;
   updated_at: string;
+
+  /** FK optionnelle vers event_seasonal_categories (mig 46 PR-F).
+   *  Drive les filtres saisonniers /événements + badge card. */
+  event_seasonal_category_id?: string | null;
+  /** Pré-fetché via LEFT JOIN PostgREST quand utile (page feed
+   *  /evenements-v2). NULL si pas de catégorie saisonnière sélectionnée. */
+  event_seasonal_category?: {
+    id: string;
+    slug: string;
+    label: string;
+    emoji: string;
+  } | null;
 }
 
 /* ─────────────────────────────────────────────────────────────

--- a/supabase/migrations/46_events_seasonal_category.sql
+++ b/supabase/migrations/46_events_seasonal_category.sql
@@ -1,0 +1,64 @@
+-- =====================================================================
+-- HILMY · 46 — Filtres saisonniers /événements (PR-F)
+--
+-- Ajoute la colonne `event_seasonal_category_id` sur la table events,
+-- FK optionnelle vers event_seasonal_categories (mig 44 + 45). Drive :
+--   1. Le select "Catégorie saisonnière" dans le form de création event
+--      (/dashboard/utilisatrice/evenements/nouveau)
+--   2. Les filtres chips de la page publique /evenements-v2
+--   3. Le badge "🌙 RAMADAN" sur EvenementCard
+--
+-- ⚠️ Distinct de events.boost_event_type (mig 41) : ce dernier reste en
+-- place pour le boost lieu Sélection Hilmy (25 slugs snake_case CHECK
+-- constraint, basés sur events réels). Cette colonne-ci utilise des
+-- slugs kebab-case (ramadan, saint-valentin, fete-meres…) référencés
+-- comme FK uuid → naming distinct, pas de couplage.
+--
+-- Idempotente. ALTER TABLE ADD COLUMN nullable + INDEX partial +
+-- COMMENT. Aucun impact sur les rows existantes (NULL par défaut).
+-- =====================================================================
+
+
+-- =====================================================================
+-- 1. Colonne FK nullable
+-- =====================================================================
+
+alter table public.events
+  add column if not exists event_seasonal_category_id uuid
+  references public.event_seasonal_categories(id) on delete set null;
+
+
+-- =====================================================================
+-- 2. Index partial (lookup filtre + jointure feed page)
+-- =====================================================================
+-- Partial index : seules les rows avec une catégorie sont indexées.
+-- Compact + efficace pour le filtre "?seasonal=ramadan" du feed.
+
+create index if not exists idx_events_seasonal_category
+  on public.events(event_seasonal_category_id)
+  where event_seasonal_category_id is not null;
+
+
+-- =====================================================================
+-- 3. Comment de doc
+-- =====================================================================
+
+comment on column public.events.event_seasonal_category_id is
+  'FK optionnelle vers event_seasonal_categories (mig 44/45). Drive les '
+  'filtres saisonniers /événements et le badge card (PR-F mig 46). '
+  'Distinct de boost_event_type (mig 41, 25 slugs snake_case lieu).';
+
+
+-- =====================================================================
+-- 4. NOTIFY PostgREST — recharger le schéma exposé par l''API
+-- =====================================================================
+
+notify pgrst, 'reload schema';
+
+
+-- =====================================================================
+-- ROLLBACK (à exécuter en SQL si besoin de défaire la mig 46)
+-- =====================================================================
+-- drop index if exists public.idx_events_seasonal_category;
+-- alter table public.events drop column if exists event_seasonal_category_id;
+-- notify pgrst, 'reload schema';


### PR DESCRIPTION
## Quoi

PR-F — Filtres saisonniers sur `/événements`.

Ajoute la possibilité d'attacher un événement à une **catégorie saisonnière** (Ramadan, Aïd, Saint-Valentin, Saison mariage, Noël…) à la création + filtrer le feed public `/evenements-v2` par période. Deep-link partage : `?seasonal=ramadan`.

**Système distinct** de `events.boost_event_type` (mig 41, 25 slugs snake_case lieu) — ici 12 catégories kebab-case (FK uuid) issues de `event_seasonal_categories` (mig 44/45).

## Pourquoi

Use case copine : *"je cherche un événement pour le Ramadan"* / partage WhatsApp d'un lien filtré. Pas un boost prestataire (cf rollback PR-D #87) — juste de la navigation/découverte.

## Migration 46 — déjà appliquée prod, smoke tests OK

```sql
ALTER TABLE events ADD COLUMN event_seasonal_category_id uuid
  REFERENCES event_seasonal_categories(id) ON DELETE SET NULL;
CREATE INDEX idx_events_seasonal_category ON events(event_seasonal_category_id)
  WHERE event_seasonal_category_id IS NOT NULL;
```

**Smoke tests post-apply (vérifiés)** :
- ✅ Column `event_seasonal_category_id` (uuid, nullable)
- ✅ FK `events_event_seasonal_category_id_fkey` ON DELETE SET NULL
- ✅ Partial index `idx_events_seasonal_category` (WHERE NOT NULL)
- ✅ 10 events existants intacts (categorized=0 par défaut)

**Ultra-safe** : ALTER ADD COLUMN nullable + INDEX partial + COMMENT. Aucune row touchée.

## Côté code

**Étendus (5)** :
- `lib/supabase/types.ts` — `HilmyEvent.event_seasonal_category_id` + jointure denormalized `event_seasonal_category?: { id, slug, label, emoji } | null`
- `lib/mock-data.ts` — `Evenement.seasonal_category?: { slug, label, emoji } | null`
- `app/dashboard/utilisatrice/evenements/nouveau/page.tsx` — Field "Catégorie saisonnière" `<select>` après "Type d'événement", optionnel, copy voix Sara, fetch catégories actives au mount, payload INSERT enrichi
- `app/evenements-v2/page.tsx` — SELECT étendu LEFT JOIN PostgREST, adapter propage `seasonal_category`, URL sync `?seasonal=slug` via `useSearchParams` + `router.replace`, 3e group "Période" dans `FiltersBar` (pré-filtre dynamique catégories ayant events à venir, pattern villes), wrap `<Suspense>` Next 14
- `components/v2/EvenementCard.tsx` — Stack badge top-left `🌙 RAMADAN` au-dessus de la chip catégorie (pattern PR-C/PR-D)

**Nouveau (1)** :
- `supabase/migrations/46_events_seasonal_category.sql`

## Comment tester

**Pré-requis** : mig 46 déjà appliquée en prod ✅, smoke tests passés.

### Test création (form `/dashboard/utilisatrice/evenements/nouveau`)

1. Login utilisatrice
2. Aller `/dashboard/utilisatrice/evenements/nouveau`
3. Champ **"Catégorie saisonnière"** présent après "Type d'événement", value initiale `Aucune (par défaut)`
4. Sélectionner `🌙 Ramadan` (ou autre)
5. Helper text voix Sara visible : *"Optionnel. Ton événement tombe pendant le Ramadan ?…"*
6. Remplir le reste + soumettre
7. Vérifier en BDD : `select event_seasonal_category_id from events where slug='…'` → uuid de la catégorie

### Test feed public `/evenements-v2`

1. Aller `/evenements-v2`
2. Si au moins un event a une `event_seasonal_category_id` : nouveau group **"Période"** dans la FiltersBar avec chips
3. Click `🌙 Ramadan` → URL devient `…/evenements-v2?seasonal=ramadan`
4. Feed filtré aux events Ramadan uniquement
5. Click `Toutes` (ou Tout réinitialiser) → URL revient à `/evenements-v2` sans param
6. Ouvrir directement `…/evenements-v2?seasonal=saint-valentin` (deep-link) → chip Saint-Valentin pré-sélectionnée + filtre actif

### Test card

- Event sans `seasonal_category` → comportement actuel (chip catégorie seule top-left)
- Event avec `seasonal_category` → stack vertical : badge `🌙 RAMADAN` en or au-dessus + chip catégorie blanche dessous
- Badge `Complet` top-right reste indépendant (pas de clash)

### Pour activer un test concret

```sql
-- Attacher Ramadan à un event existant pour voir l'UI fonctionner
update events
   set event_seasonal_category_id = (select id from event_seasonal_categories where slug='ramadan')
 where id = (select id from events where status='published' and start_date >= now() limit 1);
```

## Risques

- **`useSearchParams` requiert `<Suspense>` Next 14** : ajouté autour de `EvenementsV2PageInner`. Build passe localement, vérifier preview Vercel.
- **PostgREST LEFT JOIN syntax** : utilise `event_seasonal_category:event_seasonal_categories(id, slug, label, emoji)` qui auto-détecte la FK. Si PostgREST schema cache pas rechargé : `notify pgrst, 'reload schema'` déjà fait dans mig 46.
- **Pas d'écran édition event utilisatrice** : actuellement les events sont créés en `status='published'` direct, modérés par admin. Si un event a été créé sans catégorie, il faut UPDATE direct via admin (ou attendre une feature édition utilisatrice plus tard).
- **`getUpcomingEvents()` helper toujours pas utilisé** : le feed continue d'utiliser le fetch direct supabase-js client (pattern divergent existant, signalé en tech-debt).

## Sécurité

✅ RLS events inchangée (status='published' visible public).
✅ FK ON DELETE SET NULL → si admin supprime une catégorie, les events restent (juste détachés).
✅ Index partial → pas d'overhead sur les events sans catégorie.
✅ Aucune PII ajoutée.

## Stats diff

- 6 files changed, +243 / -8
- 1 nouveau fichier (mig 46 SQL)
- 0 npm dep
- Build vert local
