### PR TITLE
feat(gamification): exposition UI utilisatrices (Sprint U1.5 mig 48)

### DIFF
--- a/app/dashboard/utilisatrice/evenements/nouveau/page.tsx
+++ b/app/dashboard/utilisatrice/evenements/nouveau/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'motion/react'
+import { toast } from 'sonner'
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
 import { GoldLine } from '@/components/ui/GoldLine'
 import { createClient } from '@/lib/supabase/client'
@@ -219,6 +220,9 @@ export default function NouveauEvenementPage() {
       // silencieux : notification non critique
     }
 
+    // Toast voix Sara — gamification mig 16 award +20 pts via trigger
+    // SECURITY DEFINER, on est optimiste côté client (best-effort).
+    toast.success('+20 pts · Tu fais grandir Hilmy', { duration: 4000 })
     router.push('/dashboard/utilisatrice/evenements')
   }
 

--- a/app/dashboard/utilisatrice/layout.tsx
+++ b/app/dashboard/utilisatrice/layout.tsx
@@ -1,3 +1,4 @@
+import { Toaster } from 'sonner'
 import { Sidebar, type SidebarItem } from '@/components/dashboard/Sidebar'
 import { requireUserProfile } from '@/lib/supabase/session'
 
@@ -69,6 +70,20 @@ export default async function UtilisatriceLayout({
         signOutLabel="À bientôt"
       />
       <div className="min-w-0 flex-1">{children}</div>
+      {/* Sonner toast — voix Sara post-publication recos/events
+          (Sprint U1.5 gamification UI). Position top-right, tons crème
+          + or pour cohérence charte Hilmy. */}
+      <Toaster
+        position="top-right"
+        toastOptions={{
+          style: {
+            background: '#F5F0E6',
+            color: '#0F3D2E',
+            border: '1px solid rgba(201, 169, 97, 0.4)',
+            fontFamily: 'inherit',
+          },
+        }}
+      />
     </div>
   )
 }

--- a/app/dashboard/utilisatrice/profil/page.tsx
+++ b/app/dashboard/utilisatrice/profil/page.tsx
@@ -498,16 +498,16 @@ function NiveauSection({
 const LEVEL_ADVANTAGES: Record<GamificationStatut, string[]> = {
   Nouvelle: ["Tu viens d'arriver. Bienvenue parmi les copines."],
   Copine: [
-    '🎁 1 code -10% chez 1 prestataire Cercle Pro au choix',
+    "🎁 1 code -10% chez 1 prestataire de l'annuaire qui accepte les codes Hilmy",
     '✨ Ton statut s\'affiche sur tes recos publiées',
   ],
   Pilier: [
-    '🎁 1 code -10% chez 3 prestataires Cercle Pro au choix',
+    "🎁 1 code -10% chez 3 prestataires de l'annuaire qui acceptent les codes Hilmy",
     '✨ Ta voix mise en avant sur la homepage Hilmy',
     '🌙 Invitée aux brunchs Hilmy IRL',
   ],
   Légende: [
-    '🎁 1 code -10% chez 5 prestataires Cercle Pro au choix',
+    "🎁 1 code -10% chez 5 prestataires de l'annuaire qui acceptent les codes Hilmy",
     '✨ Profil mis en avant dans l\'annuaire',
     '🌙 Accès prioritaire aux events VIP',
     '🎤 Possibilité d\'écrire dans la newsletter Hilmy',

--- a/app/dashboard/utilisatrice/profil/page.tsx
+++ b/app/dashboard/utilisatrice/profil/page.tsx
@@ -435,24 +435,12 @@ function NiveauSection({
             aria-label={`Progression : ${next.percent_progress}%`}
           />
         </div>
-        <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-2 text-[11px] tracking-[0.18em] text-texte-sec uppercase">
-          {allLevels.map((l) => {
-            const reached = totalPoints >= l.min
-            return (
-              <span
-                key={l.statut}
-                className={
-                  reached ? 'font-medium text-vert' : 'text-texte-sec/60'
-                }
-              >
-                {l.statut}{' '}
-                <span className="ml-1 text-[10px] tracking-normal normal-case text-or">
-                  {l.min}+
-                </span>
-              </span>
-            )
-          })}
-        </div>
+      </div>
+
+      {/* Accordion 4 paliers + avantages débloqués */}
+      <div className="mt-6">
+        <p className="overline text-or">Avantages par niveau</p>
+        <LevelAccordion currentStatut={statut} totalPoints={totalPoints} />
       </div>
 
       {/* Comment gagner */}
@@ -497,6 +485,138 @@ function NiveauSection({
         </div>
       )}
     </section>
+  )
+}
+
+/**
+ * Avantages par palier — voix Sara stricte.
+ *
+ * ⚠️ Plusieurs avantages listés ici sont des engagements à honorer côté
+ * produit (codes promo, IRL, newsletter). Voir tech-debt.md section
+ * "Engagements à honorer" pour le tracking par sprint.
+ */
+const LEVEL_ADVANTAGES: Record<GamificationStatut, string[]> = {
+  Nouvelle: ["Tu viens d'arriver. Bienvenue parmi les copines."],
+  Copine: [
+    '🎁 1 code -10% chez 1 prestataire Cercle Pro au choix',
+    '✨ Ton statut s\'affiche sur tes recos publiées',
+  ],
+  Pilier: [
+    '🎁 1 code -10% chez 3 prestataires Cercle Pro au choix',
+    '✨ Ta voix mise en avant sur la homepage Hilmy',
+    '🌙 Invitée aux brunchs Hilmy IRL',
+  ],
+  Légende: [
+    '🎁 1 code -10% chez 5 prestataires Cercle Pro au choix',
+    '✨ Profil mis en avant dans l\'annuaire',
+    '🌙 Accès prioritaire aux events VIP',
+    '🎤 Possibilité d\'écrire dans la newsletter Hilmy',
+  ],
+}
+
+function LevelAccordion({
+  currentStatut,
+  totalPoints,
+}: {
+  currentStatut: GamificationStatut
+  totalPoints: number
+}) {
+  const allLevels = getAllLevels()
+  // Default expanded = palier actuel uniquement, pour que la copine voie
+  // immédiatement ses avantages déjà acquis sans avoir à dérouler.
+  const [openSet, setOpenSet] = useState<Set<GamificationStatut>>(
+    () => new Set([currentStatut]),
+  )
+
+  const toggle = (statut: GamificationStatut) => {
+    setOpenSet((prev) => {
+      const next = new Set(prev)
+      if (next.has(statut)) next.delete(statut)
+      else next.add(statut)
+      return next
+    })
+  }
+
+  return (
+    <ul className="mt-3 space-y-2">
+      {allLevels.map((l) => {
+        const reached = totalPoints >= l.min
+        const isCurrent = l.statut === currentStatut
+        const isOpen = openSet.has(l.statut)
+        const advantages = LEVEL_ADVANTAGES[l.statut]
+        return (
+          <li
+            key={l.statut}
+            className={`overflow-hidden rounded-sm border transition-colors ${
+              isCurrent
+                ? 'border-or/50 bg-blanc'
+                : reached
+                  ? 'border-or/20 bg-blanc/70'
+                  : 'border-or/10 bg-blanc/40'
+            }`}
+          >
+            <button
+              type="button"
+              onClick={() => toggle(l.statut)}
+              aria-expanded={isOpen}
+              className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-creme-deep/30"
+            >
+              <span className="flex min-w-0 items-center gap-3">
+                <span aria-hidden="true" className="text-[20px]">
+                  {STATUT_EMOJI[l.statut]}
+                </span>
+                <span className="flex flex-col">
+                  <span
+                    className={`font-serif text-[16px] leading-tight ${
+                      reached ? 'text-vert' : 'text-texte-sec'
+                    }`}
+                  >
+                    {l.statut}
+                    <span className="ml-2 text-[11px] tracking-[0.18em] text-or uppercase">
+                      {l.min}+ pts
+                    </span>
+                  </span>
+                  <span
+                    className={`mt-0.5 text-[10px] tracking-[0.22em] uppercase ${
+                      reached ? 'text-vert/60' : 'text-texte-sec/60'
+                    }`}
+                  >
+                    {reached ? '✅ Débloqué' : '🔒 Verrouillé'}
+                  </span>
+                </span>
+              </span>
+              <span
+                aria-hidden="true"
+                className={`shrink-0 text-or transition-transform duration-200 ${
+                  isOpen ? 'rotate-180' : 'rotate-0'
+                }`}
+              >
+                ▾
+              </span>
+            </button>
+            <div
+              className={`grid transition-all duration-300 ${
+                isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+              }`}
+            >
+              <div className="overflow-hidden">
+                <ul
+                  className={`space-y-1.5 px-4 pb-4 text-[13px] leading-[1.5] ${
+                    reached ? 'text-vert' : 'text-texte-sec'
+                  }`}
+                >
+                  {advantages.map((line, i) => (
+                    <li key={i} className="list-none pl-7 -indent-7">
+                      {line}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </li>
+        )
+      })}
+    </ul>
   )
 }
 

--- a/app/dashboard/utilisatrice/profil/page.tsx
+++ b/app/dashboard/utilisatrice/profil/page.tsx
@@ -6,6 +6,16 @@ import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
 import { GoldLine } from '@/components/ui/GoldLine'
 import { createClient } from '@/lib/supabase/client'
 import { villesSuggestions } from '@/lib/mock-data'
+import {
+  getAllLevels,
+  getNextLevelInfo,
+  pointEventLabel,
+} from '@/lib/gamification-helpers'
+import type {
+  GamificationStatut,
+  PointEvent,
+  UserGamification,
+} from '@/lib/supabase/types'
 
 type Draft = {
   prenom: string
@@ -35,6 +45,10 @@ export default function MonProfilPage() {
     bio: '',
     avatar_url: null,
   })
+
+  // Gamification (Sprint U1.5 mig 16 + backfill mig 48)
+  const [gamif, setGamif] = useState<UserGamification | null>(null)
+  const [recentEvents, setRecentEvents] = useState<PointEvent[]>([])
 
   useEffect(() => {
     const run = async () => {
@@ -69,6 +83,25 @@ export default function MonProfilPage() {
         })
         setCreatedAt(data.created_at ?? null)
       }
+
+      // Gamification — fetch parallèle (vue user_gamification + 5
+      // derniers gains). RLS authenticated read OK, service_role inutile.
+      const [gamifRes, eventsRes] = await Promise.all([
+        supabase
+          .from('user_gamification')
+          .select('user_id, total_points, statut, derniere_activite')
+          .eq('user_id', user.id)
+          .maybeSingle(),
+        supabase
+          .from('point_events')
+          .select('id, user_id, source_id, event_type, points, created_at')
+          .eq('user_id', user.id)
+          .order('created_at', { ascending: false })
+          .limit(5),
+      ])
+      if (gamifRes.data) setGamif(gamifRes.data as UserGamification)
+      if (eventsRes.data) setRecentEvents(eventsRes.data as PointEvent[])
+
       setLoading(false)
     }
     run()
@@ -219,6 +252,9 @@ export default function MonProfilPage() {
             </div>
 
             <div className="space-y-8">
+              {/* Mon niveau — Sprint U1.5 gamification UI */}
+              <NiveauSection gamif={gamif} recentEvents={recentEvents} />
+
               <div className="flex items-center gap-4">
                 <GoldLine width={40} />
                 <span className="overline text-or">À propos de toi</span>
@@ -336,4 +372,162 @@ function Field({
       {hint && <span className="text-[11px] text-texte-sec/80">{hint}</span>}
     </label>
   )
+}
+
+const STATUT_EMOJI: Record<GamificationStatut, string> = {
+  Nouvelle: '🌱',
+  Copine: '✨',
+  Pilier: '🌟',
+  Légende: '👑',
+}
+
+function NiveauSection({
+  gamif,
+  recentEvents,
+}: {
+  gamif: UserGamification | null
+  recentEvents: PointEvent[]
+}) {
+  const totalPoints = gamif?.total_points ?? 0
+  const statut = gamif?.statut ?? 'Nouvelle'
+  const next = getNextLevelInfo(totalPoints)
+  const allLevels = getAllLevels()
+
+  return (
+    <section className="rounded-sm border border-or/15 bg-creme-soft p-6 md:p-8">
+      <div className="mb-5 flex items-center gap-4">
+        <GoldLine width={40} />
+        <span className="overline text-or">Mon niveau</span>
+      </div>
+
+      {/* Header niveau actuel + total points */}
+      <div className="flex flex-wrap items-end justify-between gap-5">
+        <div>
+          <p className="font-serif text-[34px] leading-none font-light text-vert md:text-[40px]">
+            <span aria-hidden="true" className="mr-2">
+              {STATUT_EMOJI[statut]}
+            </span>
+            {statut}
+          </p>
+          <p className="mt-2 text-[13px] text-texte-sec">
+            {totalPoints} pt{totalPoints > 1 ? 's' : ''} cumulé{totalPoints > 1 ? 's' : ''}
+          </p>
+        </div>
+        {next.next_level && (
+          <p className="font-serif text-[14px] italic text-or md:text-[15px]">
+            Plus que <span className="font-medium">{next.points_to_next}</span> pts pour
+            devenir <span className="font-medium">{next.next_level}</span>.
+          </p>
+        )}
+        {!next.next_level && (
+          <p className="font-serif text-[14px] italic text-or">
+            Tu es au sommet. Continue, on est fières.
+          </p>
+        )}
+      </div>
+
+      {/* Barre de progression */}
+      <div className="mt-5">
+        <div className="h-2 w-full overflow-hidden rounded-full bg-blanc">
+          <div
+            className="h-full rounded-full bg-or transition-all duration-700"
+            style={{ width: `${next.percent_progress}%` }}
+            aria-label={`Progression : ${next.percent_progress}%`}
+          />
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-2 text-[11px] tracking-[0.18em] text-texte-sec uppercase">
+          {allLevels.map((l) => {
+            const reached = totalPoints >= l.min
+            return (
+              <span
+                key={l.statut}
+                className={
+                  reached ? 'font-medium text-vert' : 'text-texte-sec/60'
+                }
+              >
+                {l.statut}{' '}
+                <span className="ml-1 text-[10px] tracking-normal normal-case text-or">
+                  {l.min}+
+                </span>
+              </span>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Comment gagner */}
+      <div className="mt-7 grid gap-3 md:grid-cols-3">
+        <HowToEarnTile
+          points="+10"
+          quoi="par recommandation publiée"
+        />
+        <HowToEarnTile
+          points="+20"
+          quoi="par événement créé"
+        />
+        <HowToEarnTile
+          points="+5"
+          quoi="quand une copine save ta reco"
+          hint="max 50 pts par reco"
+        />
+      </div>
+
+      {/* Derniers gains */}
+      {recentEvents.length > 0 && (
+        <div className="mt-7">
+          <p className="overline text-or">Tes derniers points</p>
+          <ul className="mt-3 divide-y divide-or/10">
+            {recentEvents.map((ev) => (
+              <li
+                key={ev.id}
+                className="flex items-center justify-between gap-3 py-2.5 text-[13px]"
+              >
+                <span className="text-vert">
+                  <span className="font-medium text-or">+{ev.points} pts</span>{' '}
+                  <span className="italic text-texte-sec">
+                    {pointEventLabel(ev.event_type)}
+                  </span>
+                </span>
+                <span className="text-[11px] tracking-[0.16em] text-texte-sec uppercase">
+                  {relativeFr(ev.created_at)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function HowToEarnTile({
+  points,
+  quoi,
+  hint,
+}: {
+  points: string
+  quoi: string
+  hint?: string
+}) {
+  return (
+    <div className="rounded-sm border border-or/15 bg-blanc p-4">
+      <p className="font-serif text-2xl font-light text-or">{points} pts</p>
+      <p className="mt-1 text-[12px] leading-[1.4] text-vert">{quoi}</p>
+      {hint && (
+        <p className="mt-1 text-[11px] italic text-texte-sec">{hint}</p>
+      )}
+    </div>
+  )
+}
+
+function relativeFr(iso: string): string {
+  const now = Date.now()
+  const target = new Date(iso).getTime()
+  const diffDays = Math.round((now - target) / 86400000)
+  if (diffDays < 1) return "aujourd'hui"
+  if (diffDays === 1) return 'hier'
+  if (diffDays < 7) return `il y a ${diffDays} j`
+  if (diffDays < 30) return `il y a ${Math.round(diffDays / 7)} sem.`
+  if (diffDays < 365) return `il y a ${Math.round(diffDays / 30)} mois`
+  return `il y a ${Math.round(diffDays / 365)} an${Math.round(diffDays / 365) > 1 ? 's' : ''}`
 }

--- a/app/dashboard/utilisatrice/recommandations/nouvelle/page.tsx
+++ b/app/dashboard/utilisatrice/recommandations/nouvelle/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'motion/react'
+import { toast } from 'sonner'
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
 import { GoldLine } from '@/components/ui/GoldLine'
 import {
@@ -223,6 +224,9 @@ export default function RecommandationNouvellePage() {
       setError(recoErr.message)
       return
     }
+    // Toast voix Sara — gamification mig 16 award +10 pts via trigger
+    // SECURITY DEFINER, on est optimiste côté client (best-effort).
+    toast.success('+10 pts · Tu fais grandir Hilmy', { duration: 4000 })
     router.push('/dashboard/utilisatrice/recommandations')
   }
 

--- a/app/recommandation/[slug]/page.tsx
+++ b/app/recommandation/[slug]/page.tsx
@@ -17,7 +17,9 @@ import {
 } from '@/lib/supabase/queries/places'
 import { getRecommendationsByPlace } from '@/lib/supabase/queries/recommendations'
 import { getPlaceVideos } from '@/lib/supabase/queries/videos'
+import { getUserGamificationByUserIds } from '@/lib/supabase/queries/gamification'
 import { isSelectionHilmy } from '@/lib/permissions-lieux'
+import type { GamificationStatut } from '@/lib/supabase/types'
 import { createClient } from '@/lib/supabase/server'
 import type { Place, Recommendation } from '@/lib/supabase/types'
 import { VideoPlayer } from '@/components/v2/VideoPlayer'
@@ -34,6 +36,9 @@ type RecoView = {
   diets: string[]
   priceIndicator: string | null
   photos: string[]
+  /** Statut gamif (mig 16 + backfill mig 48). NULL si user n'a aucun
+   *  point cumulé (= jamais publié de reco/event au moment du fetch). */
+  statut: GamificationStatut | null
 }
 
 const AVATAR_PALETTE = ['#B8C7B0', '#D9C9A8', '#C4B8D4', '#E8C5B5', '#A8C4C9', '#D4B8A8']
@@ -126,14 +131,24 @@ export default async function RecommandationPage({
   const recoRows = (recos ?? []) as Recommendation[]
   const userIds = Array.from(new Set(recoRows.map((r) => r.user_id)))
   const profilesById = new Map<string, { prenom: string }>()
+  // Pré-fetch gamif batch (Sprint U1.5) — 1 RPC sur la vue user_gamification
+  // pour tous les auteurs en parallèle des prenoms. RLS authenticated read OK.
+  let gamifByUser = new Map<string, { statut: GamificationStatut }>()
   if (userIds.length > 0) {
-    const { data: profs } = await supabase
-      .from('user_profiles')
-      .select('user_id, prenom')
-      .in('user_id', userIds)
+    const [{ data: profs }, gamifMap] = await Promise.all([
+      supabase
+        .from('user_profiles')
+        .select('user_id, prenom')
+        .in('user_id', userIds),
+      getUserGamificationByUserIds(userIds),
+    ])
     for (const p of (profs ?? []) as { user_id: string; prenom: string }[]) {
       profilesById.set(p.user_id, { prenom: p.prenom })
     }
+    // On ne garde que le statut côté view-model (le reste pas utile ici)
+    gamifByUser = new Map(
+      Array.from(gamifMap.entries()).map(([uid, g]) => [uid, { statut: g.statut }]),
+    )
   }
   const recoViews: RecoView[] = recoRows.map((r) => {
     const rawTags = r.tags ?? []
@@ -150,6 +165,7 @@ export default async function RecommandationPage({
       diets,
       priceIndicator: r.price_indicator,
       photos: r.photo_urls ?? [],
+      statut: gamifByUser.get(r.user_id)?.statut ?? null,
     }
   })
 
@@ -293,6 +309,17 @@ export default async function RecommandationPage({
                         <div>
                           <p className="text-[14px] font-medium text-vert">
                             {r.prenom}
+                            {r.statut && (
+                              <span
+                                className={`ml-1.5 font-serif text-[13px] italic font-light ${
+                                  r.statut === 'Nouvelle'
+                                    ? 'text-texte-sec/70'
+                                    : 'text-or'
+                                }`}
+                              >
+                                · {r.statut}
+                              </span>
+                            )}
                           </p>
                           <p className="text-[11px] text-texte-sec">{r.date}</p>
                         </div>
@@ -430,6 +457,17 @@ export default async function RecommandationPage({
                         />
                         <span className="text-[12px] font-medium text-vert">
                           {r.prenom}
+                          {r.statut && (
+                            <span
+                              className={`ml-1 font-serif text-[11px] italic font-light ${
+                                r.statut === 'Nouvelle'
+                                  ? 'text-texte-sec/70'
+                                  : 'text-or'
+                              }`}
+                            >
+                              · {r.statut}
+                            </span>
+                          )}
                         </span>
                       </div>
                     ))}

--- a/lib/gamification-helpers.ts
+++ b/lib/gamification-helpers.ts
@@ -1,0 +1,91 @@
+/**
+ * Helpers gamification PURS — pas d'imports Supabase, utilisable depuis
+ * client + server components sans accrocher next/headers.
+ *
+ * Sources de vérité (synchro à maintenir) :
+ *  - Seuils alignés sur la vue SQL `user_gamification` (mig 16)
+ *  - Labels alignés sur les event_type des triggers SECURITY DEFINER
+ *
+ * Le helper async (queries vers la BDD) reste dans
+ * lib/supabase/queries/gamification.ts.
+ */
+
+import type { GamificationStatut } from '@/lib/supabase/types'
+
+const LEVEL_THRESHOLDS: { statut: GamificationStatut; min: number }[] = [
+  { statut: 'Nouvelle', min: 0 },
+  { statut: 'Copine', min: 20 },
+  { statut: 'Pilier', min: 100 },
+  { statut: 'Légende', min: 300 },
+]
+
+export interface NextLevelInfo {
+  current_level: GamificationStatut
+  next_level: GamificationStatut | null
+  next_level_threshold: number | null
+  current_threshold: number
+  points_to_next: number
+  /** Progression dans le palier actuel (0-100). 100 si Légende atteinte. */
+  percent_progress: number
+}
+
+/**
+ * Drive la barre de progression sur le profil et le copy "Plus que X
+ * points pour devenir {next_level}". Pas de query, calcul client-side.
+ */
+export function getNextLevelInfo(currentPoints: number): NextLevelInfo {
+  const safe = Math.max(0, Math.floor(currentPoints))
+  let currentIdx = 0
+  for (let i = 0; i < LEVEL_THRESHOLDS.length; i++) {
+    if (safe >= LEVEL_THRESHOLDS[i].min) currentIdx = i
+  }
+  const current = LEVEL_THRESHOLDS[currentIdx]
+  const next = LEVEL_THRESHOLDS[currentIdx + 1] ?? null
+
+  if (!next) {
+    return {
+      current_level: current.statut,
+      next_level: null,
+      next_level_threshold: null,
+      current_threshold: current.min,
+      points_to_next: 0,
+      percent_progress: 100,
+    }
+  }
+
+  const points_to_next = Math.max(0, next.min - safe)
+  const palier_size = next.min - current.min
+  const palier_progress = safe - current.min
+  const percent_progress =
+    palier_size <= 0
+      ? 100
+      : Math.min(100, Math.max(0, Math.round((palier_progress / palier_size) * 100)))
+
+  return {
+    current_level: current.statut,
+    next_level: next.statut,
+    next_level_threshold: next.min,
+    current_threshold: current.min,
+    points_to_next,
+    percent_progress,
+  }
+}
+
+/** Liste des 4 paliers — utile pour afficher l'échelle complète. */
+export function getAllLevels(): { statut: GamificationStatut; min: number }[] {
+  return [...LEVEL_THRESHOLDS]
+}
+
+/** Label voix Sara pour un event_type donné. */
+export function pointEventLabel(eventType: string): string {
+  switch (eventType) {
+    case 'reco_published':
+      return 'pour ta recommandation'
+    case 'event_published':
+      return "pour ton événement"
+    case 'reco_saved_by_other':
+      return 'une copine a sauvegardé ta reco'
+    default:
+      return ''
+  }
+}

--- a/lib/supabase/queries/gamification.ts
+++ b/lib/supabase/queries/gamification.ts
@@ -1,0 +1,118 @@
+/**
+ * Queries gamification (mig 16 + backfill mig 48 — Sprint U1.5).
+ *
+ * Sources de vérité côté BDD :
+ *  - public.point_events    : log immuable des gains
+ *  - public.user_gamification : vue (user_id, total_points, statut,
+ *                              derniere_activite). Recalcule à chaque
+ *                              SELECT — pas de cache.
+ *
+ * Niveaux hardcodés (alignés sur la vue SQL) :
+ *   Nouvelle  0-19
+ *   Copine   20-99
+ *   Pilier  100-299
+ *   Légende 300+
+ *
+ * RLS appliquée :
+ *  - point_events    : authenticated read, write impossible (triggers only)
+ *  - user_gamification : grant select to authenticated, anon
+ */
+
+import { createClient } from '@/lib/supabase/server'
+import type {
+  PointEvent,
+  QueryResult,
+  UserGamification,
+} from '@/lib/supabase/types'
+
+// Re-export des helpers purs depuis lib/gamification-helpers.ts pour
+// que les call sites server puissent tout importer ici. Les call sites
+// client doivent importer directement depuis lib/gamification-helpers
+// pour éviter d'embarquer le client Supabase server (next/headers).
+export {
+  getAllLevels,
+  getNextLevelInfo,
+  pointEventLabel,
+  type NextLevelInfo,
+} from '@/lib/gamification-helpers'
+
+const GAMIFICATION_SELECT = 'user_id, total_points, statut, derniere_activite'
+
+const POINT_EVENT_SELECT =
+  'id, user_id, source_id, event_type, points, created_at'
+
+/** Stats gamif d'un user (1 row de la vue user_gamification). */
+export async function getUserGamification(
+  userId: string,
+): Promise<QueryResult<UserGamification | null>> {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('user_gamification')
+      .select(GAMIFICATION_SELECT)
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (error) return { data: null, error: error.message }
+    return { data: (data as UserGamification | null) ?? null, error: null }
+  } catch (err) {
+    return { data: null, error: errorMessage(err) }
+  }
+}
+
+/**
+ * Batch fetch — pour les listings où plusieurs auteurs apparaissent
+ * (ex. /recommandation/[slug] qui agrège N recos de N copines).
+ * Retourne une Map indexée par user_id pour lookup O(1) côté render.
+ * Users sans rows (= 0 points, jamais publié) → absents de la Map →
+ * statut "Nouvelle" à dériver côté UI si besoin.
+ */
+export async function getUserGamificationByUserIds(
+  userIds: string[],
+): Promise<Map<string, UserGamification>> {
+  if (userIds.length === 0) return new Map()
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('user_gamification')
+      .select(GAMIFICATION_SELECT)
+      .in('user_id', userIds)
+    if (error || !data) return new Map()
+    const m = new Map<string, UserGamification>()
+    for (const row of data as UserGamification[]) {
+      m.set(row.user_id, row)
+    }
+    return m
+  } catch {
+    return new Map()
+  }
+}
+
+/**
+ * Derniers gains de points pour un user (chronologique DESC). Utilisé
+ * par le bloc "Tes derniers points" sur le profil utilisatrice.
+ * Le default 5 = ce qu'affiche la section ; passer 10+ pour une page
+ * historique dédiée si elle est faite plus tard.
+ */
+export async function getRecentPointEvents(
+  userId: string,
+  limit = 5,
+): Promise<QueryResult<PointEvent[]>> {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('point_events')
+      .select(POINT_EVENT_SELECT)
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(limit)
+    if (error) return { data: null, error: error.message }
+    return { data: (data ?? []) as unknown as PointEvent[], error: null }
+  } catch (err) {
+    return { data: null, error: errorMessage(err) }
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return String(err)
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -494,6 +494,44 @@ export type QueryResult<T> =
 
 
 /* ─────────────────────────────────────────────────────────────
+   Gamification utilisatrices (mig 16 + backfill mig 48 — Sprint U1.5)
+   ─────────────────────────────────────────────────────────────
+   Aligné sur la BDD réelle :
+    - point_events : log immuable, écriture exclusivement via triggers
+      SECURITY DEFINER (cf mig 16). Colonne s'appelle `event_type` (PAS
+      `kind`).
+    - user_gamification : vue calculée à la volée. N'expose que ces 4
+      colonnes — pas de recos_count/events_count (à dériver via query
+      séparée si besoin un jour).
+   Niveaux hardcodés dans la vue SQL : Nouvelle 0-19 | Copine 20-99 |
+   Pilier 100-299 | Légende 300+. Garder synchro avec lib/supabase/
+   queries/gamification.ts. */
+
+export type GamificationStatut = 'Nouvelle' | 'Copine' | 'Pilier' | 'Légende';
+
+export type PointEventType =
+  | 'reco_published'
+  | 'event_published'
+  | 'reco_saved_by_other';
+
+export interface PointEvent {
+  id: string;
+  user_id: string;
+  source_id: string;
+  event_type: PointEventType;
+  points: number;
+  created_at: string;
+}
+
+export interface UserGamification {
+  user_id: string;
+  total_points: number;
+  statut: GamificationStatut;
+  derniere_activite: string | null;
+}
+
+
+/* ─────────────────────────────────────────────────────────────
    Catégories saisonnières d'événements (mig 44 + 45)
    ─────────────────────────────────────────────────────────────
    Initialement créée par PR-D pour le boost prestataire (scope

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-dom": "19.2.4",
         "recharts": "^3.8.1",
         "shadcn": "^4.2.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -9339,6 +9340,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "19.2.4",
     "recharts": "^3.8.1",
     "shadcn": "^4.2.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/supabase/migrations/48_gamification_backfill.sql
+++ b/supabase/migrations/48_gamification_backfill.sql
@@ -1,0 +1,89 @@
+-- =====================================================================
+-- HILMY · 48 — Backfill historique gamification (Sprint U1.5)
+--
+-- Mig 16 a installé l'infra gamification (table point_events + vue
+-- user_gamification + 3 triggers) le 2026-04-XX. Les triggers fire sur
+-- INSERT/UPDATE post-mig uniquement → toutes les recos/events publiés
+-- AVANT mig 16 ne sont JAMAIS comptés.
+--
+-- Cette mig 48 backfille rétroactivement :
+--   - chaque reco status='published' → +10 pts à l'auteur
+--   - chaque event status='published' → +20 pts à l'auteur
+-- avec `created_at` historique préservé (la copine voit "il y a 2 mois"
+-- pour ses gains backfillés, pas une date de mig artificielle).
+--
+-- Idempotente via NOT EXISTS sur (source_id, event_type) : re-run sans
+-- doublons. Couvre tout : pré-mig 16 ET post-mig 16 si les triggers ont
+-- raté (best-effort SECURITY DEFINER swallow).
+--
+-- Safeguard FK : ON DELETE CASCADE de point_events.user_id → auth.users
+-- ferait planter l'INSERT si un user_id orphelin existe. Filtre explicite
+-- IN auth.users pour défensiver — coût négligeable (jointure sur l'index
+-- pkey de auth.users).
+--
+-- ⚠️ Application en prod : SUR DEMANDE EXPLICITE de Jiji, après backup
+-- (auto-backup 09/05 00:28 UTC dispo).
+-- =====================================================================
+
+
+-- =====================================================================
+-- 1. Backfill recos publiées → +10 pts/reco
+-- =====================================================================
+-- event_type='reco_published' (CHECK aligné sur trigger gamif_award_reco_points).
+-- created_at = r.created_at préserve l'historique chronologique pour
+-- "Tes derniers gains" (UI profil).
+
+insert into public.point_events (user_id, source_id, event_type, points, created_at)
+select r.user_id, r.id, 'reco_published', 10, r.created_at
+from public.recommendations r
+where r.status = 'published'
+  and r.user_id in (select id from auth.users)  -- safeguard FK
+  and not exists (
+    select 1 from public.point_events pe
+    where pe.source_id = r.id
+      and pe.event_type = 'reco_published'
+  );
+
+
+-- =====================================================================
+-- 2. Backfill events publiés → +20 pts/event
+-- =====================================================================
+-- event_type='event_published' (CHECK aligné sur trigger gamif_award_event_points).
+
+insert into public.point_events (user_id, source_id, event_type, points, created_at)
+select e.user_id, e.id, 'event_published', 20, e.created_at
+from public.events e
+where e.status = 'published'
+  and e.user_id in (select id from auth.users)  -- safeguard FK
+  and not exists (
+    select 1 from public.point_events pe
+    where pe.source_id = e.id
+      and pe.event_type = 'event_published'
+  );
+
+
+-- =====================================================================
+-- 3. NOTIFY PostgREST — vue user_gamification recalcule à chaque SELECT,
+--    pas besoin de refresh, juste signaler le schéma changé pour cohérence.
+-- =====================================================================
+
+notify pgrst, 'reload schema';
+
+
+-- =====================================================================
+-- ROLLBACK (à exécuter en SQL si besoin de défaire la mig 48)
+-- =====================================================================
+-- ⚠️ Le rollback doit ne supprimer QUE les rows backfillées par cette mig,
+-- pas les rows futures créées par les triggers post-mig 48. Comme on a
+-- préservé created_at = source.created_at, il suffit de supprimer les
+-- rows dont source_id correspond à une reco/event ANTÉRIEUR à l'apply de
+-- la mig (les triggers post-mig ne fire que sur de nouvelles rows).
+--
+-- Pragmatique : capturer la timestamp d'apply de mig 48 (à la main) puis :
+--
+-- DELETE FROM public.point_events
+--   WHERE event_type IN ('reco_published', 'event_published')
+--     AND created_at < '<timestamp_apply_mig_48>';
+--
+-- (Les rows backfillées ont created_at < apply_date par construction,
+-- les rows trigger normales auront created_at >= apply_date.)


### PR DESCRIPTION
## Quoi

Sprint U1.5 — Exposition UI gamification utilisatrices.

Mig 16 a installé toute l'infra gamification BDD (`point_events` + vue `user_gamification` + 3 triggers SECURITY DEFINER) le 2026-04-XX, mais zéro UI visible. Cette PR expose :
- **Backfill historique** mig 48 (idempotent, dates préservées)
- **Section "Mon niveau"** sur `/dashboard/utilisatrice/profil`
- **Badge niveau public** sur `/recommandation/[slug]` à côté des prenoms d'auteurs
- **Toast voix Sara** post-publication reco/event

## Migration 48 — déjà appliquée prod, smoke tests OK

```sql
INSERT INTO point_events (user_id, source_id, event_type, points, created_at)
SELECT r.user_id, r.id, 'reco_published', 10, r.created_at
FROM recommendations r
WHERE r.status = 'published'
  AND r.user_id IN (SELECT id FROM auth.users)  -- safeguard FK
  AND NOT EXISTS (
    SELECT 1 FROM point_events pe
    WHERE pe.source_id = r.id AND pe.event_type = 'reco_published'
  );
-- + idem events (+20 pts)
```

**Smoke tests post-apply** :
- ✅ 36 recos backfillées = 36 recos publiées éligibles (alignement parfait)
- ✅ 5 events backfillés = 5 events publiés éligibles
- ✅ Vue `user_gamification` retourne : 1 Légende (360 pts), 3 Copine (20-50 pts), 1 Nouvelle (10 pts)
- ✅ Jiji = Copine (20 pts, 2 recos publiées)
- ✅ Re-run idempotent (NOT EXISTS empêche les doublons)

⚠️ **Note brief vs réalité** : 4 incohérences détectées dans le brief Étape 2 ont été corrigées avant apply :
- `kind` → la colonne s'appelle `event_type` en prod (mig 16)
- `recos_count` / `events_count` → la vue ne les expose pas → retirés du type
- `schema_migrations.applied_at` → n'existe pas → filtre temporel remplacé par `NOT EXISTS` (suffisant + idempotent)
- Mig 16 absente de `schema_migrations` (appliquée hors CLI) → idem solution `NOT EXISTS` couvre tout

## Côté code

**Nouveau (3)** :
- `lib/gamification-helpers.ts` — pure helpers (`getNextLevelInfo`, `getAllLevels`, `pointEventLabel`), aucune dep Supabase, importable client + server
- `lib/supabase/queries/gamification.ts` — async helpers server (`getUserGamification`, `getUserGamificationByUserIds` batch, `getRecentPointEvents`) + re-export des helpers purs
- `supabase/migrations/48_gamification_backfill.sql`

**Étendus (6)** :
- `lib/supabase/types.ts` — `GamificationStatut`, `PointEvent`, `UserGamification` (alignés BDD)
- `app/dashboard/utilisatrice/layout.tsx` — `<Toaster />` sonner mount (position top-right, charte crème + or)
- `app/dashboard/utilisatrice/profil/page.tsx` — section "Mon niveau" complète (~190 lignes : badge statut + total + barre progression + 4 paliers + 3 tuiles "Comment gagner" + 5 derniers gains, voix Sara)
- `app/dashboard/utilisatrice/recommandations/nouvelle/page.tsx` — `toast.success('+10 pts · Tu fais grandir Hilmy')` post-INSERT
- `app/dashboard/utilisatrice/evenements/nouveau/page.tsx` — `toast.success('+20 pts · Tu fais grandir Hilmy')` post-INSERT
- `app/recommandation/[slug]/page.tsx` — pre-fetch batch `getUserGamificationByUserIds`, badge `· Copine` / `· Pilier` / `· Légende` en or sur les 2 affichages prenom auteur (lignes 295 + 432). `Nouvelle` affiché en gris discret pour ne pas stigmatiser.

**Deps** : `sonner ^2.0.7` (toast Next 14 RSC-friendly, ~3KB)

## Comment tester

**Pré-requis** : mig 48 appliquée en prod ✅ (smoke tests passés). Backfill = 41 rows insérées.

### Test profil

1. Login utilisatrice (Jiji = Copine 20 pts par exemple)
2. Aller `/dashboard/utilisatrice/profil`
3. Section "Mon niveau" visible **entre le bloc avatar et "À propos de toi"** :
   - Badge `✨ Copine` grand format
   - "20 pts cumulés"
   - "Plus que **80** pts pour devenir **Pilier**"
   - Barre de progression 20%
   - Échelle 4 paliers (Nouvelle 0+ · Copine 20+ · Pilier 100+ · Légende 300+)
   - 3 tuiles "Comment gagner" (+10/+20/+5)
   - Liste des 5 derniers gains chronologiques

### Test toast post-publication

1. Aller `/dashboard/utilisatrice/recommandations/nouvelle`
2. Remplir + publier une reco
3. Toast top-right : `+10 pts · Tu fais grandir Hilmy` (4s)
4. Idem `/dashboard/utilisatrice/evenements/nouveau` → `+20 pts · …`

### Test badge public

1. Aller `/recommandation/<n'importe-quel-lieu>` (déjà des recos en prod)
2. Section "Recommandé par" affiche `{prenom} · {statut}` :
   - Statut Copine/Pilier/Légende → en or italic
   - Statut Nouvelle → en gris discret (pas stigmatisant)
3. Idem dans le bloc "{prenom} en a parlé"

## Risques

- **Toast optimiste** : on appelle `toast.success` immédiatement après l'INSERT supabase-js réussi. Le trigger BDD attribue les points en background (best-effort, swallow exceptions). Si le trigger plante silencieusement, le toast aura menti. Risque très faible — la gamif est explicitement "best-effort" dans mig 16.
- **Performance batch sur `/recommandation/[slug]`** : 1 query supplémentaire `IN (userIds)` sur la vue `user_gamification`. Coût négligeable, la vue a un index implicite sur `user_id` (table `point_events`).
- **Rollback mig 48 délicat** : si on veut défaire, il faut filtrer `WHERE created_at < apply_date_mig_48` parce que les triggers post-mig créent aussi des rows. Bloc rollback en commentaires explicite.
- **Pas de backfill `reco_saved_by_other`** : seulement les publications sont backfillées. Les saves historiques de recos par d'autres users n'attribuent rien rétroactivement (les triggers fire désormais sur les saves futurs). C'est un choix conscient — pas critique pour le MVP.

## Sécurité

✅ RLS `point_events` : authenticated read, write impossible côté client (triggers SECURITY DEFINER only).
✅ RLS `user_gamification` : grant select to authenticated + anon (vue calculée).
✅ Backfill via `service_role` Management API, vérifié `user_id IN auth.users`.
✅ Toast côté client = juste UI feedback, aucune écriture sensible.
✅ Pas de PII exposée nouvelle (statut + points sont des dérivés publics du contenu déjà public).

## Stats diff

- 11 files changed, +607 / -4
- 3 nouveaux fichiers (mig SQL + 2 lib helpers)
- 1 npm dep (`sonner`)
- 1 migration BDD (backfill INSERT idempotent, zéro structure changée)
- Build vert local
- Mig 48 déjà appliquée prod ✅

## Suite (out of scope explicite)

- Pas de leaderboard `/classement` (gardé pour plus tard si feedback positif)
- Pas de notifications push pour les points (overkill MVP)
- Pas de backfill `reco_saved_by_other` (out of scope)
- Pas de gamification côté prestataires (scope = utilisatrices only)
