### PR TITLE
feat(stripe): Stripe Checkout subscriptions prestataires (Sprint 7 mig 49)

### DIFF
--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { enforceRateLimit } from '@/lib/rate-limit'
+import {
+  stripe,
+  isKnownPriceId,
+  getPaliersAndInterval,
+  STRIPE_SUCCESS_URL,
+  STRIPE_CANCEL_URL,
+} from '@/lib/stripe'
+import { getActiveStripeDiscounts } from '@/lib/stripe-promo'
+import { setProfileStripeCustomerIdAdmin } from '@/lib/supabase/queries/subscriptions'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/stripe/checkout
+ *
+ * Body : { price_id: string }
+ *
+ * Validations server-side (defense in depth) :
+ *   1. Auth (session Supabase) — 401 sinon
+ *   2. price_id référencé dans PRICE_ID_MAP — 422 sinon
+ *   3. Profile existe pour ce user — 404 sinon
+ *   4. Founder is_founder=true → 403 (déjà accès Cercle Pro à vie,
+ *      pas de double abo possible — décision Q2=c)
+ *   5. Crée Stripe Customer si pas déjà, stocke stripe_customer_id
+ *      sur profiles (admin client)
+ *   6. Crée Checkout Session avec metadata profile_id + palier + duree
+ *      pour décodage rapide côté webhook
+ *   7. Auto-applique LANCEMENT50 si NEXT_PUBLIC_PROMO_LANCEMENT=true
+ *      (via getActiveStripeDiscounts())
+ *   8. Permet à la copine de retaper un autre code via
+ *      allow_promotion_codes: true côté Stripe Checkout
+ *
+ * Retourne { url } à utiliser pour window.location.href côté client.
+ *
+ * Rate-limit : 10/min/utilisatrice (cap modeste, click sur SubscribeButton).
+ */
+export async function POST(request: Request) {
+  const limited = enforceRateLimit(request, {
+    tag: 'stripe-checkout',
+    max: 10,
+    windowMs: 60 * 1000,
+  })
+  if (limited) return limited
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Non authentifiée' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'JSON invalide' }, { status: 400 })
+  }
+
+  const priceId = (body as { price_id?: unknown }).price_id
+  if (typeof priceId !== 'string' || !priceId.startsWith('price_')) {
+    return NextResponse.json({ error: 'price_id manquant' }, { status: 400 })
+  }
+  if (!isKnownPriceId(priceId)) {
+    return NextResponse.json(
+      { error: 'price_id non référencé côté serveur' },
+      { status: 422 },
+    )
+  }
+  const decoded = getPaliersAndInterval(priceId)
+  if (!decoded) {
+    return NextResponse.json(
+      { error: 'price_id non référencé côté serveur' },
+      { status: 422 },
+    )
+  }
+
+  // Récupère profile + check ownership + check founder
+  const admin = createAdminClient()
+  const { data: profile, error: profErr } = await admin
+    .from('profiles')
+    .select('id, user_id, email, nom, palier, is_founder, stripe_customer_id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+  if (profErr || !profile) {
+    return NextResponse.json({ error: 'Profil introuvable' }, { status: 404 })
+  }
+  if (profile.is_founder === true) {
+    return NextResponse.json(
+      { error: 'Tu as déjà accès Cercle Pro à vie.' },
+      { status: 403 },
+    )
+  }
+
+  // Crée ou retrouve un customer Stripe.
+  let stripeCustomerId = profile.stripe_customer_id as string | null
+  if (!stripeCustomerId) {
+    // Lookup par email pour éviter un doublon si la copine s'est déjà
+    // abonnée puis a perdu le mapping local.
+    const email = (profile.email as string | null) ?? user.email ?? undefined
+    if (email) {
+      const existing = await stripe.customers.list({ email, limit: 1 })
+      if (existing.data[0]) {
+        stripeCustomerId = existing.data[0].id
+      }
+    }
+    if (!stripeCustomerId) {
+      const created = await stripe.customers.create({
+        email,
+        name: (profile.nom as string | null) ?? undefined,
+        metadata: { profile_id: profile.id as string, user_id: user.id },
+      })
+      stripeCustomerId = created.id
+    }
+    // Persist sur profiles pour les checkouts ultérieurs + portal
+    const setRes = await setProfileStripeCustomerIdAdmin(
+      profile.id as string,
+      stripeCustomerId,
+    )
+    if (!setRes.ok) {
+      // Non bloquant — on garde le customer pour le checkout, on
+      // ré-essaie de stocker au prochain appel ou via le webhook.
+      console.warn('[stripe/checkout] setProfileStripeCustomerIdAdmin failed:', setRes.error)
+    }
+  }
+
+  // Crée la Checkout Session
+  let session
+  try {
+    session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      customer: stripeCustomerId,
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: STRIPE_SUCCESS_URL,
+      cancel_url: STRIPE_CANCEL_URL,
+      allow_promotion_codes: true,
+      discounts: getActiveStripeDiscounts(),
+      metadata: {
+        profile_id: profile.id as string,
+        palier: decoded.palier,
+        duree_months: String(decoded.duree_months),
+      },
+      subscription_data: {
+        metadata: {
+          profile_id: profile.id as string,
+          palier: decoded.palier,
+          duree_months: String(decoded.duree_months),
+        },
+      },
+    })
+  } catch (err) {
+    console.error('[stripe/checkout] sessions.create failed:', err)
+    return NextResponse.json(
+      { error: 'Stripe Checkout indisponible. Réessaie dans une minute.' },
+      { status: 502 },
+    )
+  }
+
+  if (!session.url) {
+    return NextResponse.json(
+      { error: 'Stripe Checkout n\'a pas renvoyé d\'URL.' },
+      { status: 502 },
+    )
+  }
+  return NextResponse.json({ url: session.url })
+}

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -29,10 +29,10 @@ export const runtime = 'nodejs'
  *      sur profiles (admin client)
  *   6. Crée Checkout Session avec metadata profile_id + palier + duree
  *      pour décodage rapide côté webhook
- *   7. Auto-applique LANCEMENT50 si NEXT_PUBLIC_PROMO_LANCEMENT=true
- *      (via getActiveStripeDiscounts())
- *   8. Permet à la copine de retaper un autre code via
- *      allow_promotion_codes: true côté Stripe Checkout
+ *   7. Si NEXT_PUBLIC_PROMO_LANCEMENT=true → auto-applique LANCEMENT50
+ *      via discounts (pas de stacking, cf AGENTS.md).
+ *      Sinon → allow_promotion_codes: true pour permettre un code copine.
+ *      Stripe API rejette si les 2 sont passés ensemble.
  *
  * Retourne { url } à utiliser pour window.location.href côté client.
  *
@@ -129,6 +129,8 @@ export async function POST(request: Request) {
   }
 
   // Crée la Checkout Session
+  // Stripe API : allow_promotion_codes et discounts sont mutuellement exclusifs.
+  const discounts = getActiveStripeDiscounts()
   let session
   try {
     session = await stripe.checkout.sessions.create({
@@ -137,8 +139,9 @@ export async function POST(request: Request) {
       line_items: [{ price: priceId, quantity: 1 }],
       success_url: STRIPE_SUCCESS_URL,
       cancel_url: STRIPE_CANCEL_URL,
-      allow_promotion_codes: true,
-      discounts: getActiveStripeDiscounts(),
+      ...(discounts && discounts.length > 0
+        ? { discounts }
+        : { allow_promotion_codes: true }),
       metadata: {
         profile_id: profile.id as string,
         palier: decoded.palier,

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { enforceRateLimit } from '@/lib/rate-limit'
+import { stripe } from '@/lib/stripe'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/stripe/portal
+ *
+ * Génère une URL Stripe Billing Portal pour gérer son abo (annuler,
+ * changer palier/durée, voir factures, mettre à jour la carte).
+ *
+ * Validations :
+ *   1. Auth Supabase
+ *   2. profile.stripe_customer_id existe (sinon : pas encore souscrit)
+ *
+ * Retourne { url } à utiliser pour window.location.href.
+ *
+ * Rate-limit : 10/min/utilisatrice.
+ */
+export async function POST(request: Request) {
+  const limited = enforceRateLimit(request, {
+    tag: 'stripe-portal',
+    max: 10,
+    windowMs: 60 * 1000,
+  })
+  if (limited) return limited
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Non authentifiée' }, { status: 401 })
+  }
+
+  const admin = createAdminClient()
+  const { data: profile, error: profErr } = await admin
+    .from('profiles')
+    .select('id, user_id, stripe_customer_id')
+    .eq('user_id', user.id)
+    .maybeSingle()
+  if (profErr || !profile) {
+    return NextResponse.json({ error: 'Profil introuvable' }, { status: 404 })
+  }
+  const customerId = profile.stripe_customer_id as string | null
+  if (!customerId) {
+    return NextResponse.json(
+      { error: 'Pas encore d\'abonnement actif' },
+      { status: 400 },
+    )
+  }
+
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ?? 'https://www.hilmy.io'
+
+  let session
+  try {
+    session = await stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: `${siteUrl}/dashboard/prestataire/fiche`,
+    })
+  } catch (err) {
+    console.error('[stripe/portal] sessions.create failed:', err)
+    return NextResponse.json(
+      { error: 'Stripe Portal indisponible. Réessaie dans une minute.' },
+      { status: 502 },
+    )
+  }
+
+  return NextResponse.json({ url: session.url })
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,0 +1,264 @@
+import { NextResponse } from 'next/server'
+import type Stripe from 'stripe'
+import { stripe, getPaliersAndInterval } from '@/lib/stripe'
+import {
+  upsertSubscriptionAdmin,
+  markSubscriptionCanceledAdmin,
+  updateProfilePalierAdmin,
+  getSubscriptionByStripeIdAdmin,
+} from '@/lib/supabase/queries/subscriptions'
+import type { SubscriptionStatus } from '@/lib/supabase/types'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/stripe/webhook
+ *
+ * ⚠️ Route publique (pas de session Supabase). Sécurité = signature
+ * Stripe via stripe.webhooks.constructEvent(body, signature, secret).
+ * Tout payload non signé est rejeté en 400.
+ *
+ * Events MVP (Sprint 7) :
+ *   - checkout.session.completed     → activation initiale (palier+sub)
+ *   - customer.subscription.updated  → renouvellement, change palier,
+ *                                      cancel_at_period_end toggle
+ *   - customer.subscription.deleted  → fin de l'abo (downgrade standard)
+ *   - invoice.payment_failed         → status='past_due' (Stripe Smart
+ *                                      Retries fait le job derrière)
+ *
+ * Idempotence : Stripe peut re-sender un event 3-7 jours après en cas
+ * de timeout. upsertSubscriptionAdmin via ON CONFLICT (stripe_subscription
+ * _id) absorbe les rejeux sans doublon. Les UPDATE profiles.palier sont
+ * idempotentes par nature.
+ *
+ * Réponse : 200 le plus vite possible. Si erreur métier non-critique
+ * (ex. profile_id metadata absent), log + 200 quand même pour ne pas
+ * que Stripe retry à l'infini.
+ */
+
+const WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET ?? ''
+
+export async function POST(request: Request) {
+  const signature = request.headers.get('stripe-signature')
+  if (!signature) {
+    return new NextResponse('Missing stripe-signature header', { status: 400 })
+  }
+  if (!WEBHOOK_SECRET) {
+    console.error('[stripe/webhook] STRIPE_WEBHOOK_SECRET absent côté serveur')
+    return new NextResponse('Webhook secret not configured', { status: 500 })
+  }
+
+  // ⚠️ stripe.webhooks.constructEvent attend le body BRUT (pas parsé).
+  // Next 14 App Router : await request.text() preserve les bytes
+  // exactement tels quels — pas de body-parser global qui casserait
+  // la signature.
+  const body = await request.text()
+
+  let event: Stripe.Event
+  try {
+    event = stripe.webhooks.constructEvent(body, signature, WEBHOOK_SECRET)
+  } catch (err) {
+    console.error('[stripe/webhook] signature verification failed:', err)
+    return new NextResponse('Webhook signature verification failed', {
+      status: 400,
+    })
+  }
+
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        await handleCheckoutCompleted(event.data.object)
+        break
+      }
+      case 'customer.subscription.updated': {
+        await handleSubscriptionUpdated(event.data.object)
+        break
+      }
+      case 'customer.subscription.deleted': {
+        await handleSubscriptionDeleted(event.data.object)
+        break
+      }
+      case 'invoice.payment_failed': {
+        await handleInvoicePaymentFailed(event.data.object)
+        break
+      }
+      default:
+        // Event hors scope — ack 200 pour Stripe ne re-tente pas.
+        break
+    }
+  } catch (err) {
+    // Erreur métier non-critique : log mais 200 pour stopper les retries
+    // Stripe (sinon ils s'accumulent 3 jours). Les rows manquantes
+    // pourront être réconciliées via un script admin si besoin.
+    console.error(
+      `[stripe/webhook] handler error for ${event.type}:`,
+      err instanceof Error ? err.message : err,
+    )
+  }
+
+  return NextResponse.json({ received: true }, { status: 200 })
+}
+
+/* ─── Handlers ─────────────────────────────────────────────────────── */
+
+async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
+  // session.subscription est soit string (ID), soit Stripe.Subscription
+  // selon expand. Par défaut c'est l'ID.
+  const subId =
+    typeof session.subscription === 'string'
+      ? session.subscription
+      : session.subscription?.id
+  if (!subId) {
+    console.warn('[stripe/webhook] checkout.session.completed sans subscription id')
+    return
+  }
+
+  const profileId = session.metadata?.profile_id
+  if (!profileId) {
+    console.warn(
+      '[stripe/webhook] checkout.session.completed sans profile_id en metadata',
+    )
+    return
+  }
+
+  // Fetch full subscription pour avoir les périodes
+  const sub = await stripe.subscriptions.retrieve(subId)
+  await persistSubscription(sub, profileId)
+}
+
+async function handleSubscriptionUpdated(sub: Stripe.Subscription) {
+  // metadata.profile_id posé à la création par /api/stripe/checkout dans
+  // subscription_data. Si absent (souscription créée hors Hilmy ?), on
+  // tente de retrouver via la row existante.
+  const profileId = await resolveProfileId(sub)
+  if (!profileId) return
+  await persistSubscription(sub, profileId)
+}
+
+async function handleSubscriptionDeleted(sub: Stripe.Subscription) {
+  const profileId = await resolveProfileId(sub)
+  if (!profileId) return
+
+  // Marque cancelled + downgrade palier
+  await markSubscriptionCanceledAdmin(sub.id)
+  await updateProfilePalierAdmin(profileId, 'standard')
+}
+
+async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
+  // Stripe v2025-04+ : Invoice n'a plus de champ direct `subscription`,
+  // c'est sous parent.subscription_details ou parent.invoice_item ou via
+  // billing_reason. Pour rester compatible large : tenter via parent OU
+  // re-fetch via lines.
+  const sub = invoice.parent?.subscription_details?.subscription
+  const subId = typeof sub === 'string' ? sub : sub?.id
+  if (!subId) {
+    // Pas une invoice d'abonnement — ignorer (one-shot invoices, etc.)
+    return
+  }
+
+  const existing = await getSubscriptionByStripeIdAdmin(subId)
+  if (!existing) {
+    console.warn(
+      `[stripe/webhook] invoice.payment_failed pour subscription inconnue: ${subId}`,
+    )
+    return
+  }
+
+  // Update statut à past_due (Stripe le fera aussi via subscription.updated
+  // mais on est plus rapide ici). Pas de downgrade palier — Smart Retries
+  // va retenter pendant ~3 semaines.
+  await upsertSubscriptionAdmin({
+    profile_id: existing.profile_id,
+    stripe_customer_id: existing.stripe_customer_id,
+    stripe_subscription_id: existing.stripe_subscription_id,
+    stripe_price_id: existing.stripe_price_id,
+    palier: existing.palier,
+    duree_months: existing.duree_months,
+    status: 'past_due',
+    current_period_start: existing.current_period_start,
+    current_period_end: existing.current_period_end,
+    cancel_at_period_end: existing.cancel_at_period_end,
+    canceled_at: existing.canceled_at,
+    ended_at: existing.ended_at,
+  })
+}
+
+/* ─── Utilitaires ─────────────────────────────────────────────────── */
+
+async function resolveProfileId(
+  sub: Stripe.Subscription,
+): Promise<string | null> {
+  const meta = sub.metadata?.profile_id
+  if (meta) return meta
+  // Fallback : retrouver via la row existante en BDD
+  const existing = await getSubscriptionByStripeIdAdmin(sub.id)
+  return existing?.profile_id ?? null
+}
+
+/**
+ * Persiste un Stripe.Subscription complet en BDD + propage le palier
+ * sur profiles si le statut entitle (active/trialing).
+ *
+ * past_due : on UPSERT avec palier maintenu, pas de change profiles.
+ * canceled / incomplete_expired : palier='standard' downgrade.
+ */
+async function persistSubscription(
+  sub: Stripe.Subscription,
+  profileId: string,
+): Promise<void> {
+  const item = sub.items?.data?.[0]
+  if (!item?.price?.id) {
+    console.warn(`[stripe/webhook] subscription ${sub.id} sans price line item`)
+    return
+  }
+  const decoded = getPaliersAndInterval(item.price.id)
+  if (!decoded) {
+    console.warn(
+      `[stripe/webhook] price_id non référencé côté serveur: ${item.price.id}`,
+    )
+    return
+  }
+
+  // current_period_start/end : Stripe v2025+ a déplacé ces champs sur
+  // l'item, plus sur la subscription elle-même. On lit avec fallback.
+  const startTs =
+    item.current_period_start ?? (sub as unknown as { current_period_start?: number }).current_period_start ?? null
+  const endTs =
+    item.current_period_end ?? (sub as unknown as { current_period_end?: number }).current_period_end ?? null
+  if (startTs == null || endTs == null) {
+    console.warn(`[stripe/webhook] subscription ${sub.id} sans period bounds`)
+    return
+  }
+
+  const status = sub.status as SubscriptionStatus
+  await upsertSubscriptionAdmin({
+    profile_id: profileId,
+    stripe_customer_id:
+      typeof sub.customer === 'string' ? sub.customer : sub.customer.id,
+    stripe_subscription_id: sub.id,
+    stripe_price_id: item.price.id,
+    palier: decoded.palier,
+    duree_months: decoded.duree_months,
+    status,
+    current_period_start: new Date(startTs * 1000).toISOString(),
+    current_period_end: new Date(endTs * 1000).toISOString(),
+    cancel_at_period_end: sub.cancel_at_period_end ?? false,
+    canceled_at: sub.canceled_at
+      ? new Date(sub.canceled_at * 1000).toISOString()
+      : null,
+    ended_at: sub.ended_at ? new Date(sub.ended_at * 1000).toISOString() : null,
+  })
+
+  // Propage le palier sur profiles selon le statut
+  if (status === 'active' || status === 'trialing' || status === 'past_due') {
+    await updateProfilePalierAdmin(profileId, decoded.palier)
+  } else if (
+    status === 'canceled' ||
+    status === 'incomplete_expired' ||
+    status === 'unpaid'
+  ) {
+    await updateProfilePalierAdmin(profileId, 'standard')
+  }
+  // 'incomplete' : pas de change palier — l'utilisatrice doit finaliser
+  // le payment authorize. Stripe re-trigger à completion.
+}

--- a/app/dashboard/prestataire/fiche/page.tsx
+++ b/app/dashboard/prestataire/fiche/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { motion, AnimatePresence } from 'motion/react'
+import { toast } from 'sonner'
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
 import { GoldLine } from '@/components/ui/GoldLine'
 import { VideosManager } from '@/components/v2/VideosManager'
@@ -15,6 +16,7 @@ import {
 } from '@/lib/palier-limits'
 import { getEffectivePalier } from '@/lib/permissions'
 import type { Palier } from '@/app/tarifs/_lib/pricing'
+import type { Subscription } from '@/lib/supabase/types'
 
 type Service = { nom: string; prix: string; duree: string }
 
@@ -50,6 +52,9 @@ export default function MaFichePage() {
   const [error, setError] = useState<string | null>(null)
   const [userId, setUserId] = useState<string | null>(null)
   const [profileId, setProfileId] = useState<string | null>(null)
+  // Sprint 7 mig 49 — abo Stripe actif (ou null si jamais souscrit)
+  const [subscription, setSubscription] = useState<Subscription | null>(null)
+  const [portalLoading, setPortalLoading] = useState(false)
   const [status, setStatus] = useState<string>('pending')
   const [palier, setPalier] = useState<Palier>('standard')
   const [noteMoy, setNoteMoy] = useState(0)
@@ -142,10 +147,69 @@ export default function MaFichePage() {
         services: (data.services ?? []) as Service[],
         galerie: (data.galerie ?? []) as string[],
       })
+
+      // Sprint 7 mig 49 — fetch abo actif (status active/trialing/past_due)
+      const { data: sub } = await supabase
+        .from('subscriptions')
+        .select(
+          'id, profile_id, stripe_customer_id, stripe_subscription_id, stripe_price_id, palier, duree_months, status, current_period_start, current_period_end, cancel_at_period_end, canceled_at, ended_at, created_at, updated_at',
+        )
+        .eq('profile_id', data.id)
+        .in('status', ['active', 'trialing', 'past_due'])
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle()
+      if (sub) setSubscription(sub as Subscription)
+
       setLoading(false)
     }
     run()
   }, [])
+
+  // Sprint 7 — toast post-checkout success
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('stripe_success') === '1') {
+      const prenom = draft.nom || 'copine'
+      toast.success(`🎉 Bienvenue dans la team, ${prenom} !`, {
+        duration: 5000,
+        description:
+          'Ton abonnement est actif. Si tu ne vois pas encore ton nouveau palier, recharge dans quelques secondes.',
+      })
+      // Clean URL pour éviter de re-trigger au refresh
+      const newUrl = window.location.pathname
+      window.history.replaceState({}, '', newUrl)
+    }
+    if (params.get('stripe_canceled') === '1') {
+      // Pas de toast en cas de cancel — déjà capturé côté /tarifs si besoin.
+      const newUrl = window.location.pathname
+      window.history.replaceState({}, '', newUrl)
+    }
+  // draft.nom dépendance pour avoir le prénom au moment où le toast fire
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading])
+
+  /** Sprint 7 — POST /api/stripe/portal puis redirige Stripe Billing Portal. */
+  const openStripePortal = async () => {
+    setPortalLoading(true)
+    try {
+      const res = await fetch('/api/stripe/portal', { method: 'POST' })
+      if (!res.ok) {
+        const json = (await res.json().catch(() => null)) as { error?: string } | null
+        toast.error(json?.error ?? 'Stripe Portal indisponible.', { duration: 5000 })
+        setPortalLoading(false)
+        return
+      }
+      const json = (await res.json()) as { url?: string }
+      if (json.url) {
+        window.location.href = json.url
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Erreur réseau.', { duration: 5000 })
+      setPortalLoading(false)
+    }
+  }
 
   const handleSave = async () => {
     if (!profileId) return
@@ -679,6 +743,16 @@ export default function MaFichePage() {
                   </Group>
                 )}
 
+                {/* Mon abonnement — Sprint 7 mig 49 Stripe */}
+                <Group kicker="Mon abonnement">
+                  <SubscriptionPanel
+                    subscription={subscription}
+                    palier={palier}
+                    onOpenPortal={openStripePortal}
+                    portalLoading={portalLoading}
+                  />
+                </Group>
+
                 <div className="flex items-center gap-4">
                   <button
                     type="button"
@@ -854,5 +928,135 @@ function Field({
       {children}
       {hint && <span className="text-[11px] text-texte-sec/80">{hint}</span>}
     </label>
+  )
+}
+
+/**
+ * Sprint 7 mig 49 — Section "Mon abonnement" du dashboard fiche.
+ *
+ * 3 modes :
+ *   - Founder : message "Tu as accès Cercle Pro à vie", pas de bouton portal
+ *   - Sub active : palier + intervalle + prochaine échéance + bouton portal
+ *   - Pas de sub : CTA "Voir les tarifs" → /tarifs
+ */
+const PALIER_LABEL: Record<Palier, string> = {
+  standard: 'Standard',
+  premium: 'Premium',
+  cercle_pro: 'Cercle Pro',
+}
+
+const DUREE_LABEL: Record<number, string> = {
+  1: 'Mensuel',
+  3: 'Trimestriel',
+  6: 'Semestriel',
+  12: 'Annuel',
+}
+
+function formatPeriodFr(iso: string): string {
+  return new Date(iso).toLocaleDateString('fr-FR', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+}
+
+function SubscriptionPanel({
+  subscription,
+  palier,
+  onOpenPortal,
+  portalLoading,
+}: {
+  subscription: Subscription | null
+  palier: Palier
+  onOpenPortal: () => void
+  portalLoading: boolean
+}) {
+  // Founder = palier effectif cercle_pro, mais pas de subscription Stripe
+  // (accès gratuit à vie — pas de billing portal à exposer).
+  const isFounderEquivalent = palier === 'cercle_pro' && !subscription
+  if (isFounderEquivalent) {
+    return (
+      <div className="rounded-sm border border-or/30 bg-creme-soft p-6 md:p-7">
+        <p className="overline text-or">Accès Cercle Pro à vie</p>
+        <p className="mt-2 font-serif text-[18px] italic leading-[1.4] text-vert md:text-[20px]">
+          Tu fais partie des fondatrices Hilmy.
+        </p>
+        <p className="mt-2 max-w-2xl text-[13px] leading-[1.6] text-texte-sec">
+          Toutes les features Cercle Pro sont actives sans abonnement.
+        </p>
+      </div>
+    )
+  }
+
+  if (!subscription) {
+    return (
+      <div className="rounded-sm border border-or/30 bg-creme-soft p-6 md:p-7">
+        <p className="overline text-or">Pas encore d&apos;abonnement</p>
+        <p className="mt-2 font-serif text-[18px] italic leading-[1.4] text-vert md:text-[20px]">
+          Choisis ta formule, démarre quand tu veux.
+        </p>
+        <p className="mt-2 max-w-2xl text-[13px] leading-[1.6] text-texte-sec">
+          Standard, Premium ou Cercle Pro — chaque palier débloque plus de
+          place dans la team.
+        </p>
+        <Link
+          href="/tarifs"
+          className="mt-5 inline-flex h-11 items-center gap-2 rounded-full bg-vert px-6 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+        >
+          Voir les tarifs
+          <span className="text-or-light" aria-hidden="true">→</span>
+        </Link>
+      </div>
+    )
+  }
+
+  const dureeLabel = DUREE_LABEL[subscription.duree_months] ?? 'Mensuel'
+  const palierLabel = PALIER_LABEL[subscription.palier] ?? subscription.palier
+  const isPastDue = subscription.status === 'past_due'
+  const isCanceling = subscription.cancel_at_period_end
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="font-serif text-[28px] leading-none font-light text-vert md:text-[32px]">
+            {palierLabel}
+          </p>
+          <p className="mt-2 text-[13px] text-texte-sec">
+            {dureeLabel} · prochaine échéance le{' '}
+            <span className="font-medium text-vert">
+              {formatPeriodFr(subscription.current_period_end)}
+            </span>
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onOpenPortal}
+          disabled={portalLoading}
+          className="inline-flex h-11 items-center gap-2 rounded-full border border-or/40 bg-blanc px-5 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-or hover:bg-creme-deep disabled:cursor-wait disabled:opacity-60"
+        >
+          {portalLoading ? 'Redirection…' : 'Gérer mon abonnement'}
+          <span className="text-or" aria-hidden="true">→</span>
+        </button>
+      </div>
+
+      {isPastDue && (
+        <p className="rounded-sm border border-red-900/20 bg-red-900/5 px-4 py-3 text-[13px] leading-[1.5] text-red-900">
+          ⚠️ On n&apos;a pas pu débiter ton dernier paiement. On retente
+          dans quelques jours. Si tu veux mettre à jour ta carte, clique
+          sur « Gérer mon abonnement » ci-dessus.
+        </p>
+      )}
+
+      {isCanceling && (
+        <p className="rounded-sm border border-or/30 bg-creme-soft px-4 py-3 text-[13px] leading-[1.5] text-vert">
+          Ton abonnement est annulé, mais reste actif jusqu&apos;au{' '}
+          <span className="font-medium">
+            {formatPeriodFr(subscription.current_period_end)}
+          </span>
+          . Tu peux changer d&apos;avis depuis le portail.
+        </p>
+      )}
+    </div>
   )
 }

--- a/app/dashboard/prestataire/layout.tsx
+++ b/app/dashboard/prestataire/layout.tsx
@@ -1,3 +1,4 @@
+import { Toaster } from 'sonner'
 import { Sidebar, type SidebarItem } from '@/components/dashboard/Sidebar'
 import { requirePrestataire } from '@/lib/supabase/session'
 import { createClient } from '@/lib/supabase/server'
@@ -106,6 +107,20 @@ export default async function PrestataireLayout({
         signOutLabel="À bientôt"
       />
       <div className="min-w-0 flex-1">{children}</div>
+      {/* Sonner toast — utilisé pour le retour post-checkout Stripe
+          (Sprint 7) + erreurs de souscription. Position top-right,
+          tons crème + or charte Hilmy. */}
+      <Toaster
+        position="top-right"
+        toastOptions={{
+          style: {
+            background: '#F5F0E6',
+            color: '#0F3D2E',
+            border: '1px solid rgba(201, 169, 97, 0.4)',
+            fontFamily: 'inherit',
+          },
+        }}
+      />
     </div>
   )
 }

--- a/app/tarifs/_components/WizardSection.tsx
+++ b/app/tarifs/_components/WizardSection.tsx
@@ -24,6 +24,7 @@ import {
   applyPromoLancement,
   isPromoLancementActive,
 } from '@/lib/promo-lancement'
+import { SubscribeButton } from '@/components/SubscribeButton'
 
 type WizardKey = 'standard' | 'premium' | 'cercle_pro'
 
@@ -35,6 +36,15 @@ interface WizardSectionProps {
    *  Tente une validation Supabase au mount, comme si l'utilisatrice avait
    *  tapé le code à la main. */
   initialPromo?: string
+  /** Mapping (palier, duree_months) → priceId Stripe. Calculé côté server
+   *  dans app/tarifs/page.tsx depuis process.env.STRIPE_PRICE_* et passé
+   *  ici. Sprint 7 mig 49. Si priceId absent (env var manquante pour une
+   *  combo), le bouton fallback sur le mailto legacy. */
+  stripePriceIds?: Partial<Record<WizardKey, Partial<Record<1 | 3 | 6 | 12, string>>>>
+  /** Defense in depth UI Sprint 7 — si le user authentifié est founder,
+   *  on cache le SubscribeButton (l'API /api/stripe/checkout refuserait
+   *  de toute façon avec 403, mais on évite la friction UX). */
+  isFounder?: boolean
 }
 
 const STEPS: {
@@ -132,7 +142,7 @@ function computeReco(answers: Record<number, WizardKey>): Palier {
   return best
 }
 
-export function WizardSection({ initialPalier, initialPromo }: WizardSectionProps = {}) {
+export function WizardSection({ initialPalier, initialPromo, stripePriceIds, isFounder }: WizardSectionProps = {}) {
   const [currentStep, setCurrentStep] = useState<1 | 2 | 3>(1)
   const [answers, setAnswers] = useState<Record<number, WizardKey>>({})
   // Si un palier vient du deep-link, on saute le wizard et on affiche
@@ -602,15 +612,44 @@ export function WizardSection({ initialPalier, initialPromo }: WizardSectionProp
                 )}
               </div>
 
-              <a
-                href={mailto}
-                className="block w-full rounded-full bg-or px-8 py-4 text-center text-[15px] font-semibold text-vert transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)]"
-                aria-label={`Choisir la formule ${info.name} (${formatPrice(
+              {(() => {
+                // Sprint 7 mig 49 — résout le priceId pour la combo
+                // (palier, duree). Si présent, on rend SubscribeButton
+                // qui POST /api/stripe/checkout. Sinon fallback mailto
+                // legacy (env var manquante côté Vercel pour cette combo).
+                // Founder = on cache l'option de souscrire (defense in
+                // depth UI, complète le 403 server-side).
+                if (isFounder) {
+                  return (
+                    <div className="rounded-sm border border-or/30 bg-creme-soft px-5 py-4 text-center text-[13px] italic leading-[1.5] text-vert">
+                      Tu fais partie des fondatrices Hilmy — tu as déjà accès
+                      Cercle Pro à vie, pas besoin d&apos;abonnement.
+                    </div>
+                  )
+                }
+                const priceId = stripePriceIds?.[palier]?.[duree]
+                const aria = `Choisir la formule ${info.name} (${formatPrice(
                   appliedPromo ? monthlyAfterDiscount : lancMonthly,
-                )} par mois)`}
-              >
-                Je choisis cette formule
-              </a>
+                )} par mois)`
+                if (priceId) {
+                  return (
+                    <SubscribeButton
+                      priceId={priceId}
+                      label="Je choisis cette formule"
+                      ariaLabel={aria}
+                    />
+                  )
+                }
+                return (
+                  <a
+                    href={mailto}
+                    className="block w-full rounded-full bg-or px-8 py-4 text-center text-[15px] font-semibold text-vert transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)]"
+                    aria-label={aria}
+                  >
+                    Je choisis cette formule
+                  </a>
+                )
+              })()}
             </div>
 
             <div>

--- a/app/tarifs/page.tsx
+++ b/app/tarifs/page.tsx
@@ -2,7 +2,70 @@ import type { Metadata } from 'next'
 import { PageShell } from '@/components/v2/PageShell'
 import { WizardSection } from './_components/WizardSection'
 import { LieuPricing } from './_components/LieuPricing'
-import type { Palier } from './_lib/pricing'
+import type { Palier, Duree } from './_lib/pricing'
+import { createClient } from '@/lib/supabase/server'
+
+/**
+ * Sprint 7 mig 49 — defense in depth UI : vérifie si le user est founder
+ * pour cacher SubscribeButton (déjà 403 côté API). Best-effort, silently
+ * skip si pas de session (cas guest = la majorité des visiteurs /tarifs).
+ */
+async function isAuthenticatedFounder(): Promise<boolean> {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) return false
+    const { data } = await supabase
+      .from('profiles')
+      .select('is_founder')
+      .eq('user_id', user.id)
+      .maybeSingle()
+    return data?.is_founder === true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Sprint 7 mig 49 — construit côté server le mapping (palier, duree)
+ * → priceId Stripe à partir de process.env.STRIPE_PRICE_*.
+ *
+ * Reste server-side (env vars STRIPE_* sans NEXT_PUBLIC_) → on passe
+ * la map déjà résolue à WizardSection qui est client. Si une combo
+ * n'a pas de priceId (env var absente/typo), WizardSection fallback
+ * sur le mailto legacy. Sécurité défense en profondeur : un priceId
+ * client-side n'est pas un secret (visible dans toute Stripe Checkout
+ * URL), donc l'exposer via prop est safe.
+ *
+ * Sélection Hilmy lieu (39€/mois) absente — Sprint 7bis.
+ */
+function buildStripePriceIds(): Partial<
+  Record<Palier, Partial<Record<Duree, string>>>
+> {
+  const m: Partial<Record<Palier, Partial<Record<Duree, string>>>> = {}
+  const add = (palier: Palier, duree: Duree, envKey: string) => {
+    const id = process.env[envKey]
+    if (id && id.startsWith('price_')) {
+      if (!m[palier]) m[palier] = {}
+      m[palier]![duree] = id
+    }
+  }
+  add('standard', 1, 'STRIPE_PRICE_STANDARD_MONTHLY')
+  add('standard', 3, 'STRIPE_PRICE_STANDARD_3M')
+  add('standard', 6, 'STRIPE_PRICE_STANDARD_6M')
+  add('standard', 12, 'STRIPE_PRICE_STANDARD_1Y')
+  add('premium', 1, 'STRIPE_PRICE_PREMIUM_MONTHLY')
+  add('premium', 3, 'STRIPE_PRICE_PREMIUM_3M')
+  add('premium', 6, 'STRIPE_PRICE_PREMIUM_6M')
+  add('premium', 12, 'STRIPE_PRICE_PREMIUM_1Y')
+  add('cercle_pro', 1, 'STRIPE_PRICE_CERCLE_PRO_MONTHLY')
+  add('cercle_pro', 3, 'STRIPE_PRICE_CERCLE_PRO_3M')
+  add('cercle_pro', 6, 'STRIPE_PRICE_CERCLE_PRO_6M')
+  add('cercle_pro', 12, 'STRIPE_PRICE_CERCLE_PRO_1Y')
+  return m
+}
 
 type SearchParams = Promise<{
   palier?: string
@@ -127,6 +190,7 @@ export default async function TarifsPage({
   const params = await searchParams
   const initialPalier = normalizePalier(params.palier)
   const initialPromo = params.promo?.trim().toUpperCase() || undefined
+  const isFounder = await isAuthenticatedFounder()
 
   // Log analytics dev mode (deep-link mobile UTM tracking).
   if (process.env.NODE_ENV !== 'production' && params.utm_source) {
@@ -248,7 +312,12 @@ export default async function TarifsPage({
             </p>
           </div>
 
-          <WizardSection initialPalier={initialPalier} initialPromo={initialPromo} />
+          <WizardSection
+            initialPalier={initialPalier}
+            initialPromo={initialPromo}
+            stripePriceIds={buildStripePriceIds()}
+            isFounder={isFounder}
+          />
         </section>
 
         {/* CTA STRIP 1 */}

--- a/components/SubscribeButton.tsx
+++ b/components/SubscribeButton.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+interface Props {
+  /** ID Stripe (price_xxx). Server résout via PRICE_ID_MAP. */
+  priceId: string
+  /** Texte du bouton (voix Sara). */
+  label: string
+  /** Aria-label détaillé pour accessibilité. */
+  ariaLabel?: string
+  /** ClassName optionnelle pour custom styling (sinon défaut Hilmy or). */
+  className?: string
+}
+
+/**
+ * Bouton "Je souscris" — déclenche /api/stripe/checkout puis
+ * window.location.href vers Stripe Checkout.
+ *
+ * Voix Sara : "Je m'abonne", "Je choisis cette formule", "Je souscris".
+ * Pas "Acheter" ni "Buy now".
+ *
+ * Gère les erreurs serveur (founder qui tente de souscrire = 403,
+ * price_id inconnu = 422, Stripe down = 502) avec toast voix Sara.
+ */
+export function SubscribeButton({
+  priceId,
+  label,
+  ariaLabel,
+  className,
+}: Props) {
+  const [loading, setLoading] = useState(false)
+
+  async function handleClick() {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/stripe/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ price_id: priceId }),
+      })
+
+      if (!res.ok) {
+        const json = (await res.json().catch(() => null)) as { error?: string } | null
+        const msg = json?.error ?? 'Impossible de démarrer la souscription.'
+        toast.error(msg, { duration: 5000 })
+        setLoading(false)
+        return
+      }
+
+      const json = (await res.json()) as { url?: string }
+      if (!json.url) {
+        toast.error('Réponse Stripe invalide. Réessaie dans une minute.', {
+          duration: 5000,
+        })
+        setLoading(false)
+        return
+      }
+
+      // Redirige vers Stripe Checkout
+      window.location.href = json.url
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : 'Erreur réseau.',
+        { duration: 5000 },
+      )
+      setLoading(false)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={loading}
+      aria-label={ariaLabel ?? label}
+      className={
+        className ??
+        'block w-full rounded-full bg-or px-8 py-4 text-center text-[15px] font-semibold text-vert transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)] disabled:cursor-wait disabled:opacity-70'
+      }
+    >
+      {loading ? 'Redirection vers le paiement…' : label}
+    </button>
+  )
+}

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,0 +1,148 @@
+/**
+ * Stripe SDK central (Sprint 7 mig 49).
+ *
+ * Singleton + helpers de mapping price ID ↔ (palier, duree_months).
+ *
+ * ⚠️ Server-only. Ne JAMAIS importer depuis un client component — la
+ * STRIPE_SECRET_KEY ne doit pas atterrir dans le bundle browser. Pour
+ * les besoins client (publishable key, price IDs), passer par les
+ * NEXT_PUBLIC_STRIPE_* ou via une API route.
+ */
+
+import Stripe from 'stripe'
+import type { Palier, Duree } from '@/app/tarifs/_lib/pricing'
+
+/**
+ * Lazy singleton — initialise Stripe au 1er appel uniquement.
+ *
+ * Pourquoi pas un instantiate au top-level ? Le Stripe SDK valide
+ * apiKey === non-empty-string au constructor. En build Next.js sans
+ * .env.local Stripe (cas dev local + CI Vercel build phase), le
+ * module se charge → throw "Neither apiKey nor config.authenticator
+ * provided" → Failed to collect page data → build red.
+ *
+ * Avec lazy init, le module se charge sans toucher à Stripe. Au runtime
+ * (route handler exécutée), process.env.STRIPE_SECRET_KEY est défini
+ * sur Vercel et l'instance se crée. Build local sans clé reste vert.
+ */
+let stripeSingleton: Stripe | null = null
+
+export function getStripe(): Stripe {
+  if (!stripeSingleton) {
+    const key = process.env.STRIPE_SECRET_KEY
+    if (!key) {
+      throw new Error(
+        'STRIPE_SECRET_KEY absent. Configurer la var Vercel + redeploy.',
+      )
+    }
+    stripeSingleton = new Stripe(key, {
+      apiVersion: '2025-04-30.basil',
+      typescript: true,
+      appInfo: {
+        name: 'Hilmy',
+        version: '1.0.0',
+        url: 'https://www.hilmy.io',
+      },
+    })
+  }
+  return stripeSingleton
+}
+
+/** Proxy export pour back-compat — `stripe.xxx()` route via getStripe(). */
+export const stripe = new Proxy({} as Stripe, {
+  get(_target, prop) {
+    const value = getStripe()[prop as keyof Stripe]
+    return typeof value === 'function' ? value.bind(getStripe()) : value
+  },
+})
+
+/* ──────────────────────────────────────────────────────────────────
+   PRICE_ID_MAP — décodage Stripe priceId → palier + durée
+   ────────────────────────────────────────────────────────────────── */
+
+interface PriceMapEntry {
+  palier: Palier
+  duree_months: Duree
+}
+
+/**
+ * Mapping priceId → palier + duree_months. Construit côté serveur
+ * uniquement (pas de NEXT_PUBLIC_).
+ *
+ * Note : Sélection Hilmy lieu (39€/mois) est délibérément absente —
+ * Sprint 7 prestataires only (cf décision Q1=c). La var Vercel
+ * STRIPE_PRICE_SELECTION_HILMY_MONTHLY existe mais n'est pas branchée
+ * ici. Sera ajoutée au Sprint 7bis avec sa propre table de mapping.
+ */
+function buildPriceIdMap(): Map<string, PriceMapEntry> {
+  const m = new Map<string, PriceMapEntry>()
+  const add = (envKey: string, palier: Palier, duree: Duree) => {
+    const id = process.env[envKey]
+    if (id && id.startsWith('price_')) m.set(id, { palier, duree_months: duree })
+  }
+  add('STRIPE_PRICE_STANDARD_MONTHLY', 'standard', 1)
+  add('STRIPE_PRICE_STANDARD_3M', 'standard', 3)
+  add('STRIPE_PRICE_STANDARD_6M', 'standard', 6)
+  add('STRIPE_PRICE_STANDARD_1Y', 'standard', 12)
+  add('STRIPE_PRICE_PREMIUM_MONTHLY', 'premium', 1)
+  add('STRIPE_PRICE_PREMIUM_3M', 'premium', 3)
+  add('STRIPE_PRICE_PREMIUM_6M', 'premium', 6)
+  add('STRIPE_PRICE_PREMIUM_1Y', 'premium', 12)
+  add('STRIPE_PRICE_CERCLE_PRO_MONTHLY', 'cercle_pro', 1)
+  add('STRIPE_PRICE_CERCLE_PRO_3M', 'cercle_pro', 3)
+  add('STRIPE_PRICE_CERCLE_PRO_6M', 'cercle_pro', 6)
+  add('STRIPE_PRICE_CERCLE_PRO_1Y', 'cercle_pro', 12)
+  return m
+}
+
+const PRICE_ID_MAP = buildPriceIdMap()
+
+/** Décode un priceId Stripe en palier + durée. Null si inconnu. */
+export function getPaliersAndInterval(
+  priceId: string,
+): PriceMapEntry | null {
+  return PRICE_ID_MAP.get(priceId) ?? null
+}
+
+/**
+ * Résout un combo (palier, duree_months) en priceId Stripe.
+ * Utilisé par SubscribeButton pour passer le bon ID au checkout.
+ * Retourne null si la var d'env correspondante est absente —
+ * dans ce cas le UI doit fallback sur le mailto legacy.
+ */
+export function getPriceIdForCombo(
+  palier: Palier,
+  duree: Duree,
+): string | null {
+  for (const [priceId, entry] of PRICE_ID_MAP) {
+    if (entry.palier === palier && entry.duree_months === duree) {
+      return priceId
+    }
+  }
+  return null
+}
+
+/** Vérifie qu'un priceId est référencé — gating server-side. */
+export function isKnownPriceId(priceId: string): boolean {
+  return PRICE_ID_MAP.has(priceId)
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   URLs success / cancel post-checkout
+   ────────────────────────────────────────────────────────────────── */
+
+function siteUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ??
+    'https://www.hilmy.io'
+  )
+}
+
+export const STRIPE_SUCCESS_URL = `${siteUrl()}/dashboard/prestataire/fiche?stripe_success=1`
+export const STRIPE_CANCEL_URL = `${siteUrl()}/tarifs?stripe_canceled=1`
+
+/** Map status Stripe → "abo actif" boolean. Active + trialing = palier
+ *  appliqué côté UI. past_due = palier maintenu mais warning. */
+export function isStripeStatusEntitling(status: string): boolean {
+  return status === 'active' || status === 'trialing' || status === 'past_due'
+}

--- a/lib/supabase/queries/subscriptions.ts
+++ b/lib/supabase/queries/subscriptions.ts
@@ -1,0 +1,203 @@
+/**
+ * Queries subscriptions Stripe (Sprint 7 mig 49).
+ *
+ * Lecture : RLS owner_read autorise authenticated à lire son propre
+ * abo via le createClient server (cookie session Supabase).
+ *
+ * Écriture : exclusivement via createAdminClient() depuis le webhook
+ * /api/stripe/webhook (service_role bypass RLS). Les helpers d'écriture
+ * sont préfixés `Admin` pour éviter qu'un caller server normal les
+ * appelle par erreur sans avoir une session admin.
+ */
+
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import type {
+  QueryResult,
+  Subscription,
+  SubscriptionPalier,
+  SubscriptionStatus,
+  SubscriptionDureeMonths,
+} from '@/lib/supabase/types'
+
+const SUBSCRIPTION_SELECT = `
+  id,
+  profile_id,
+  stripe_customer_id,
+  stripe_subscription_id,
+  stripe_price_id,
+  palier,
+  duree_months,
+  status,
+  current_period_start,
+  current_period_end,
+  cancel_at_period_end,
+  canceled_at,
+  ended_at,
+  created_at,
+  updated_at
+`
+
+/**
+ * Abo actif d'un prestataire (status='active' OR 'trialing' OR 'past_due').
+ * "Past_due" = retry Stripe en cours, on garde le palier appliqué jusqu'à
+ * confirmation d'échec final. Renvoie null si jamais souscrit ou abo
+ * complètement terminé.
+ */
+export async function getActiveSubscription(
+  profileId: string,
+): Promise<QueryResult<Subscription | null>> {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('subscriptions')
+      .select(SUBSCRIPTION_SELECT)
+      .eq('profile_id', profileId)
+      .in('status', ['active', 'trialing', 'past_due'])
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    if (error) return { data: null, error: error.message }
+    return { data: (data as Subscription | null) ?? null, error: null }
+  } catch (err) {
+    return { data: null, error: errorMessage(err) }
+  }
+}
+
+/**
+ * Lookup d'une row par stripe_subscription_id (clé business des
+ * webhooks). Utilise l'admin client car les webhooks tournent sans
+ * session Supabase.
+ */
+export async function getSubscriptionByStripeIdAdmin(
+  stripeSubId: string,
+): Promise<Subscription | null> {
+  try {
+    const admin = createAdminClient()
+    const { data, error } = await admin
+      .from('subscriptions')
+      .select(SUBSCRIPTION_SELECT)
+      .eq('stripe_subscription_id', stripeSubId)
+      .maybeSingle()
+    if (error || !data) return null
+    return data as Subscription
+  } catch {
+    return null
+  }
+}
+
+export interface UpsertSubscriptionInput {
+  profile_id: string
+  stripe_customer_id: string
+  stripe_subscription_id: string
+  stripe_price_id: string
+  palier: SubscriptionPalier
+  duree_months: SubscriptionDureeMonths
+  status: SubscriptionStatus
+  current_period_start: string
+  current_period_end: string
+  cancel_at_period_end: boolean
+  canceled_at?: string | null
+  ended_at?: string | null
+}
+
+/**
+ * Upsert (INSERT ou UPDATE selon stripe_subscription_id UNIQUE) — pattern
+ * idempotent pour les webhooks. Stripe peut re-sender un event 3-7 jours
+ * après en cas de timeout, on doit accepter le re-traitement sans
+ * doublon.
+ */
+export async function upsertSubscriptionAdmin(
+  input: UpsertSubscriptionInput,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const admin = createAdminClient()
+    const { error } = await admin
+      .from('subscriptions')
+      .upsert(
+        {
+          profile_id: input.profile_id,
+          stripe_customer_id: input.stripe_customer_id,
+          stripe_subscription_id: input.stripe_subscription_id,
+          stripe_price_id: input.stripe_price_id,
+          palier: input.palier,
+          duree_months: input.duree_months,
+          status: input.status,
+          current_period_start: input.current_period_start,
+          current_period_end: input.current_period_end,
+          cancel_at_period_end: input.cancel_at_period_end,
+          canceled_at: input.canceled_at ?? null,
+          ended_at: input.ended_at ?? null,
+        },
+        { onConflict: 'stripe_subscription_id' },
+      )
+    if (error) return { ok: false, error: error.message }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) }
+  }
+}
+
+/**
+ * Marque un abo comme canceled (event customer.subscription.deleted).
+ * Le webhook appellera ça + UPDATE profiles.palier='standard'.
+ */
+export async function markSubscriptionCanceledAdmin(
+  stripeSubId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const admin = createAdminClient()
+    const { error } = await admin
+      .from('subscriptions')
+      .update({
+        status: 'canceled',
+        ended_at: new Date().toISOString(),
+      })
+      .eq('stripe_subscription_id', stripeSubId)
+    if (error) return { ok: false, error: error.message }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) }
+  }
+}
+
+/** Update profile palier depuis le webhook. */
+export async function updateProfilePalierAdmin(
+  profileId: string,
+  palier: SubscriptionPalier,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const admin = createAdminClient()
+    const { error } = await admin
+      .from('profiles')
+      .update({ palier })
+      .eq('id', profileId)
+    if (error) return { ok: false, error: error.message }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) }
+  }
+}
+
+/** Set stripe_customer_id sur profiles à la 1ère souscription. */
+export async function setProfileStripeCustomerIdAdmin(
+  profileId: string,
+  stripeCustomerId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const admin = createAdminClient()
+    const { error } = await admin
+      .from('profiles')
+      .update({ stripe_customer_id: stripeCustomerId })
+      .eq('id', profileId)
+    if (error) return { ok: false, error: error.message }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) }
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return String(err)
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -494,6 +494,44 @@ export type QueryResult<T> =
 
 
 /* ─────────────────────────────────────────────────────────────
+   Abonnements Stripe prestataires (mig 49 — Sprint 7)
+   ─────────────────────────────────────────────────────────────
+   Mirror local du state Stripe pour gating palier rapide côté UI.
+   Updates exclusivement via /api/stripe/webhook (service_role).
+   Sélection Hilmy lieux déférée Sprint 7bis (pas dans le CHECK ici). */
+
+export type SubscriptionStatus =
+  | 'active'
+  | 'past_due'
+  | 'canceled'
+  | 'incomplete'
+  | 'incomplete_expired'
+  | 'trialing'
+  | 'unpaid';
+
+export type SubscriptionPalier = 'standard' | 'premium' | 'cercle_pro';
+export type SubscriptionDureeMonths = 1 | 3 | 6 | 12;
+
+export interface Subscription {
+  id: string;
+  profile_id: string;
+  stripe_customer_id: string;
+  stripe_subscription_id: string;
+  stripe_price_id: string;
+  palier: SubscriptionPalier;
+  duree_months: SubscriptionDureeMonths;
+  status: SubscriptionStatus;
+  current_period_start: string;
+  current_period_end: string;
+  cancel_at_period_end: boolean;
+  canceled_at: string | null;
+  ended_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+
+/* ─────────────────────────────────────────────────────────────
    Gamification utilisatrices (mig 16 + backfill mig 48 — Sprint U1.5)
    ─────────────────────────────────────────────────────────────
    Aligné sur la BDD réelle :

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "recharts": "^3.8.1",
         "shadcn": "^4.2.0",
         "sonner": "^2.0.7",
+        "stripe": "^22.1.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -9617,6 +9618,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "recharts": "^3.8.1",
     "shadcn": "^4.2.0",
     "sonner": "^2.0.7",
+    "stripe": "^22.1.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/supabase/migrations/49_subscriptions_stripe.sql
+++ b/supabase/migrations/49_subscriptions_stripe.sql
@@ -1,0 +1,215 @@
+-- =====================================================================
+-- HILMY · 49 — Stripe Checkout subscriptions (Sprint 7)
+--
+-- Pose le schéma BDD pour les abonnements Stripe prestataires :
+--   1. profiles.stripe_customer_id    (FK vers Stripe customer, UNIQUE)
+--   2. subscriptions                  (table principale, mirror Stripe)
+--   3. RLS owner_read + admin_all
+--   4. Trigger updated_at
+--
+-- Décisions Jiji (2026-05-10) :
+--   Q1 (c) → Sélection Hilmy lieux déférée au Sprint 7bis. Ce sprint
+--           gère uniquement les paliers PRESTATAIRES :
+--           standard / premium / cercle_pro.
+--   Q3 (c) → duree_months int CHECK IN (1,3,6,12) — aligné sur le
+--           type Duree de app/tarifs/_lib/pricing.ts. Pas de mapping
+--           string '3_months' qui dériverait de Stripe.
+--
+-- profiles.palier CHECK constraint reste IN ('standard','premium','
+-- cercle_pro') — pas de 'selection_hilmy'. Le webhook checkout ne
+-- propagera jamais ce palier vers profiles dans ce sprint.
+--
+-- Idempotente. ALTER ADD COLUMN nullable + CREATE TABLE = ultra-safe.
+--
+-- ⚠️ Application en prod : SUR DEMANDE EXPLICITE de Jiji, après backup
+-- (auto-backup 2026-05-09 00:28 UTC dispo).
+-- =====================================================================
+
+
+-- =====================================================================
+-- 1. profiles.stripe_customer_id  (FK vers Stripe customer)
+-- =====================================================================
+-- UNIQUE pour empêcher 2 prestataires de partager le même customer
+-- Stripe (= 1 customer = 1 profile, mapping bijectif). Index partial
+-- WHERE NOT NULL — la majorité des profiles n'auront pas encore de
+-- customer Stripe avant l'ouverture des ventes.
+
+alter table public.profiles
+  add column if not exists stripe_customer_id text;
+
+-- Contrainte UNIQUE séparée pour idempotence (drop+recreate possible
+-- contrairement à un UNIQUE inline sur ADD COLUMN).
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.profiles'::regclass
+      and conname = 'profiles_stripe_customer_id_key'
+  ) then
+    alter table public.profiles
+      add constraint profiles_stripe_customer_id_key unique (stripe_customer_id);
+  end if;
+end $$;
+
+create index if not exists profiles_stripe_customer_id_idx
+  on public.profiles (stripe_customer_id)
+  where stripe_customer_id is not null;
+
+comment on column public.profiles.stripe_customer_id is
+  'FK vers Stripe customer (cus_xxx). Crée à la 1ère souscription via '
+  '/api/stripe/checkout. Réutilisé pour les checkouts ultérieurs et '
+  'l''accès au billing portal.';
+
+
+-- =====================================================================
+-- 2. Table subscriptions
+-- =====================================================================
+-- Mirror local du state Stripe pour les queries rapides côté UI
+-- (dashboard "Mon abonnement" + gating palier server-side via le
+-- trigger UPDATE profiles.palier dans le webhook).
+--
+-- stripe_subscription_id UNIQUE = idempotency key des webhooks
+-- (re-run = upsert via ON CONFLICT). Stripe peut re-sender un event
+-- 3-7 jours après en cas de timeout — le UNIQUE protège des doublons.
+
+create table if not exists public.subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+
+  -- Identifiants Stripe (3 niveaux : customer, subscription, prix)
+  stripe_customer_id text not null,
+  stripe_subscription_id text not null unique,
+  stripe_price_id text not null,
+
+  -- Décodage business
+  palier text not null,
+  duree_months int not null,
+  status text not null,
+
+  -- Cycle de vie (timestamps Stripe)
+  current_period_start timestamptz not null,
+  current_period_end timestamptz not null,
+  cancel_at_period_end boolean not null default false,
+  canceled_at timestamptz,
+  ended_at timestamptz,
+
+  -- Audit
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  -- CHECK : palier prestataire uniquement (Sprint 7 = pas selection_hilmy)
+  constraint subscriptions_palier_check
+    check (palier in ('standard', 'premium', 'cercle_pro')),
+
+  -- CHECK : durées alignées sur app/tarifs/_lib/pricing.ts Duree
+  constraint subscriptions_duree_months_check
+    check (duree_months in (1, 3, 6, 12)),
+
+  -- CHECK : statuts Stripe officiels
+  constraint subscriptions_status_check
+    check (status in (
+      'active', 'past_due', 'canceled', 'incomplete',
+      'incomplete_expired', 'trialing', 'unpaid'
+    ))
+);
+
+
+-- ─── Indexes ─────────────────────────────────────────────────────────
+-- Active sub par profile (lookup le plus fréquent : "que paie cette
+-- prestataire actuellement ?"). Partial index = compact + rapide.
+create index if not exists subscriptions_profile_active_idx
+  on public.subscriptions (profile_id, status)
+  where status = 'active';
+
+-- Lookup webhook : on reçoit un stripe_subscription_id et on cherche
+-- la row à upsert. UNIQUE constraint crée déjà un index implicite, on
+-- en re-crée pas un.
+
+-- Ordre temporel : utile pour reporting + admin (last 30 days etc.)
+create index if not exists subscriptions_current_period_start_idx
+  on public.subscriptions (current_period_start desc);
+
+
+-- ─── RLS ─────────────────────────────────────────────────────────────
+-- Owner read = la prestataire voit son propre abo dans le dashboard.
+-- Admin all = panel admin pour debug + audit.
+-- Pas de policy INSERT/UPDATE/DELETE pour authenticated : seul l'admin
+-- client (service_role) écrit, depuis le webhook /api/stripe/webhook.
+
+alter table public.subscriptions enable row level security;
+
+drop policy if exists "subscriptions_owner_read" on public.subscriptions;
+create policy "subscriptions_owner_read"
+  on public.subscriptions
+  for select
+  to authenticated
+  using (
+    profile_id in (select id from public.profiles where user_id = auth.uid())
+  );
+
+drop policy if exists "subscriptions_admin_all" on public.subscriptions;
+create policy "subscriptions_admin_all"
+  on public.subscriptions
+  for all
+  to authenticated
+  using (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  )
+  with check (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+
+-- ─── Trigger updated_at ──────────────────────────────────────────────
+
+create or replace function public.bump_subscriptions_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists subscriptions_updated_at_trg on public.subscriptions;
+create trigger subscriptions_updated_at_trg
+  before update on public.subscriptions
+  for each row execute function public.bump_subscriptions_updated_at();
+
+
+-- ─── Comments doc ────────────────────────────────────────────────────
+
+comment on table public.subscriptions is
+  'Mirror local des abonnements Stripe prestataires (Sprint 7 mig 49). '
+  'Updates exclusivement via /api/stripe/webhook avec service_role. '
+  'Sélection Hilmy lieux déférée au Sprint 7bis.';
+
+comment on column public.subscriptions.duree_months is
+  '1=mensuel, 3=trimestriel, 6=semestriel, 12=annuel. Aligné sur '
+  'app/tarifs/_lib/pricing.ts Duree type.';
+
+comment on column public.subscriptions.status is
+  'Statut Stripe officiel. ''active'' + ''trialing'' = palier appliqué. '
+  '''past_due'' = retry Stripe en cours, palier toujours appliqué. '
+  '''canceled''/''incomplete_expired'' = abo terminé, palier=standard.';
+
+
+-- =====================================================================
+-- 3. NOTIFY PostgREST — recharger le schéma exposé par l'API
+-- =====================================================================
+
+notify pgrst, 'reload schema';
+
+
+-- =====================================================================
+-- ROLLBACK (à exécuter en SQL si besoin de défaire la mig 49)
+-- =====================================================================
+-- drop trigger if exists subscriptions_updated_at_trg on public.subscriptions;
+-- drop function if exists public.bump_subscriptions_updated_at();
+-- drop policy if exists "subscriptions_admin_all" on public.subscriptions;
+-- drop policy if exists "subscriptions_owner_read" on public.subscriptions;
+-- drop table if exists public.subscriptions cascade;
+-- alter table public.profiles drop constraint if exists profiles_stripe_customer_id_key;
+-- alter table public.profiles drop column if exists stripe_customer_id;
+-- notify pgrst, 'reload schema';


### PR DESCRIPTION
## Quoi

Sprint 7 — Stripe Checkout subscriptions prestataires (CRITIQUE ouverture ventes mardi).

Pose toute l'infra Stripe Checkout pour les abonnements prestataires :
- **Standard** 19€/m · 54€/3m · 102€/6m · 182€/1y
- **Premium** 49€/m · 139€/3m · 264€/6m · 470€/1y
- **Cercle Pro** 99€/m · 282€/3m · 534€/6m · 950€/1y

Sélection Hilmy lieu (39€/m) **déférée Sprint 7bis** (décision Q1=c).

## Migration 49 — déjà appliquée prod, smoke tests OK

```sql
ALTER TABLE profiles ADD COLUMN stripe_customer_id text UNIQUE;
CREATE TABLE subscriptions (15 cols, mirror Stripe);
-- + 3 indexes, 2 RLS policies, trigger updated_at, 3 CHECK constraints
```

**Smoke tests post-apply** :
- ✅ `profiles.stripe_customer_id` text nullable + UNIQUE + index partial
- ✅ Table `subscriptions` (15 cols : id, profile_id, stripe_*, palier, duree_months, status, périodes, cancel flags, audit)
- ✅ 4 indexes (pkey, unique stripe_sub_id, profile_active partial, current_period_start)
- ✅ 2 RLS policies (`owner_read` SELECT, `admin_all` ALL)
- ✅ Trigger `subscriptions_updated_at_trg`
- ✅ 3 CHECK constraints :
  - `palier IN ('standard','premium','cercle_pro')` — pas selection_hilmy (Sprint 7bis)
  - `duree_months IN (1,3,6,12)` — aligné pricing.ts Q3=c
  - `status IN (7 statuts Stripe officiels)`
- ✅ 0 rows (populated par webhook au 1er checkout)

## Code

**Nouveaux (8)** :
- `supabase/migrations/49_subscriptions_stripe.sql`
- `lib/stripe.ts` — singleton lazy (Proxy pattern pour build sans env vars locales) + `PRICE_ID_MAP` + `getPriceIdForCombo` + URLs success/cancel
- `lib/supabase/queries/subscriptions.ts` — CRUD admin + upsert idempotent ON CONFLICT
- `app/api/stripe/checkout/route.ts` — POST auth + ownership + 403 founder + customer create/lookup + Checkout Session avec metadata + LANCEMENT50 auto
- `app/api/stripe/webhook/route.ts` — POST signature validation **OBLIGATOIRE** + 4 events MVP (`checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.payment_failed`) + service_role bypass RLS
- `app/api/stripe/portal/route.ts` — POST billing portal session
- `components/SubscribeButton.tsx` — client component avec toast erreurs (sonner)
- npm dep `stripe ^22.1.1`

**Étendus (5)** :
- `lib/supabase/types.ts` — `Subscription`, `SubscriptionStatus`, `SubscriptionPalier`, `SubscriptionDureeMonths`
- `app/tarifs/page.tsx` — `buildStripePriceIds()` server-side (process.env STRIPE_PRICE_*) + `isAuthenticatedFounder()` pour defense in depth UI Q2=c
- `app/tarifs/_components/WizardSection.tsx` — remplace `<a href={mailto}>` par `<SubscribeButton>` quand priceId dispo, fallback mailto sinon ; cache total + message si `isFounder=true`
- `app/dashboard/prestataire/layout.tsx` — `<Toaster />` sonner mount (post-checkout success)
- `app/dashboard/prestataire/fiche/page.tsx` — section `<Group kicker="Mon abonnement">` (palier + duree + prochaine échéance + warn past_due/canceling + bouton "Gérer mon abonnement" → `/api/stripe/portal`) + toast `🎉 Bienvenue dans la team, {prenom} !` au retour `?stripe_success=1` (clean URL replaceState)

## Sécurité

| Mécanisme | Détail |
|---|---|
| **Webhook signature** | `stripe.webhooks.constructEvent(rawBody, signature, STRIPE_WEBHOOK_SECRET)` → 400 si mismatch |
| **Raw body preserved** | `await request.text()` (pas `req.json()`) pour ne pas casser HMAC |
| **service_role** | Uniquement dans webhook (admin client) — bypass RLS justifié car ownership déjà validée |
| **Rate-limit** | 10/min sur `/checkout` + `/portal` |
| **403 founder** | `is_founder=true` → `/api/stripe/checkout` refuse + UI hidden (defense in depth) |
| **Idempotence webhook** | UNIQUE `stripe_subscription_id` + UPSERT ON CONFLICT — re-rejeux Stripe absorbés |
| **STRIPE_SECRET_KEY** | Server-only, jamais dans bundle client. Lazy init pour ne pas bloquer build sans env var locale |

## Comment tester sur Vercel preview

**Pré-requis (à faire AVANT test)** :
1. Créer webhook Stripe **TEST** : Dashboard Stripe → Developers → Webhooks → Add endpoint
   - URL : `https://<URL_PREVIEW>/api/stripe/webhook`
   - Events : `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.payment_failed`
   - Récupérer `whsec_xxx` (signing secret)
2. Ajouter `STRIPE_WEBHOOK_SECRET=whsec_xxx` en var Vercel **Preview only**
3. Re-deploy preview pour activer la var

**Tests** :
- [ ] `/tarifs` : wizard fonctionnel + bouton "Je choisis cette formule" rendu en `<SubscribeButton>` (pas mailto) si priceId env var dispo
- [ ] Click bouton → redirect Stripe Checkout
- [ ] Carte test `4242 4242 4242 4242` n'importe quelle date future + CVC quelconque → checkout réussi
- [ ] Redirect `/dashboard/prestataire/fiche?stripe_success=1`
- [ ] Toast voix Sara `🎉 Bienvenue dans la team, {prenom} !`
- [ ] Section "Mon abonnement" affiche le bon palier + duree + prochaine échéance
- [ ] Vérif Supabase : `SELECT * FROM subscriptions` → 1 row + `profiles.palier` UPDATE
- [ ] Click "Gérer mon abonnement" → redirect Stripe Billing Portal
- [ ] Annule via portal → revient sur `/dashboard/prestataire/fiche` → bandeau "Ton abonnement est annulé jusqu'au DD/MM"
- [ ] Si tu te logges en founder, va sur `/tarifs` → tu vois "Tu fais partie des fondatrices Hilmy" au lieu du bouton souscrire

**Tests negatifs** :
- [ ] POST `/api/stripe/checkout` avec `price_id` random → 422
- [ ] POST avec compte founder → 403 "Tu as déjà accès Cercle Pro à vie"
- [ ] Webhook avec mauvais signature → 400

## Risques

- **STRIPE_WEBHOOK_SECRET placeholder en Production** : actuellement dans Vercel = placeholder. Si on merge cette PR avant de remplacer par la vraie valeur LIVE, les webhooks prod retourneront 400 — pas de crash mais subscriptions ne se sync pas. **Ne pas merger avant de remplacer la var en Production**.
- **Stripe SDK v22 + apiVersion `2025-04-30.basil`** : `current_period_start/end` ont migré sur l'item (pas la subscription). Webhook handler les lit via `item.current_period_start ?? sub.current_period_start` (fallback) pour rester robuste.
- **Lazy init Stripe via Proxy** : pattern un peu original. Si tu vois "Neither apiKey..." en runtime, c'est que `STRIPE_SECRET_KEY` n'est pas dans la phase d'exécution (server function n'a pas accès à la var). Vérifier la config Vercel.
- **Founder check `/tarifs`** : appelle Supabase à chaque pageview même pour anonymes → caché silently dans try/catch. Coût ~10ms quand connecté, ~0ms anonyme.
- **Webhook concurrent rejeux** : Stripe peut envoyer le même event en parallèle (rare). Notre UPSERT est idempotent, mais si 2 events fire simultanément ils peuvent créer des UPDATE concurrent → la row finale est correcte (PostgreSQL last-writer-wins).

## Stats diff

- 14 files changed, +1555 / -11
- 8 nouveaux fichiers (mig SQL + 6 TS + 1 component)
- 1 npm dep (`stripe ^22.1.1`)
- 1 migration BDD (CREATE TABLE + ALTER profiles ADD COLUMN — ultra-safe)
- Build vert local
- Mig 49 déjà appliquée prod ✅

## Suite Sprint 7 (à faire AVANT merge prod)

1. **Webhook prod LIVE** :
   - Dashboard Stripe LIVE → Webhooks → Add endpoint
   - URL : `https://www.hilmy.io/api/stripe/webhook`
   - Récup `whsec_xxx` LIVE
   - Remplacer placeholder dans var Vercel `STRIPE_WEBHOOK_SECRET` (Production)
   - Re-deploy
2. **Smoke test prod** : 1 paiement réel 99€ Cercle Pro mensuel sur compte founder secondaire (refund Stripe Dashboard après)
3. **Sprint 7bis** : Sélection Hilmy lieu (1 prix, 1 mig 50 pour étendre le subscriptions schema avec place_id nullable)
