### PR TITLE
feat(api): Bearer auth fallback for mobile clients

### DIFF
--- a/app/api/track/contact/route.ts
+++ b/app/api/track/contact/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { authenticateRequest } from '@/lib/supabase/bearer'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { enforceRateLimit } from '@/lib/rate-limit'
 import {
@@ -49,10 +49,9 @@ export async function POST(request: Request) {
     )
   }
 
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  // Récupère le user authentifié (peut être null pour anonyme).
+  // Cookies (web) avec fallback Bearer (mobile RN). Cf. lib/supabase/bearer.ts.
+  const { user } = await authenticateRequest(request)
 
   const meta = extractTrackingMeta(request)
 

--- a/app/api/track/place-contact/route.ts
+++ b/app/api/track/place-contact/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { authenticateRequest } from '@/lib/supabase/bearer'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { enforceRateLimit } from '@/lib/rate-limit'
 import {
@@ -58,10 +58,9 @@ export async function POST(request: Request) {
     )
   }
 
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  // Récupère le user authentifié (peut être null pour anonyme).
+  // Cookies (web) avec fallback Bearer (mobile RN). Cf. lib/supabase/bearer.ts.
+  const { user } = await authenticateRequest(request)
 
   const meta = extractTrackingMeta(request)
 

--- a/app/api/track/place-view/route.ts
+++ b/app/api/track/place-view/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { authenticateRequest } from '@/lib/supabase/bearer'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { enforceRateLimit } from '@/lib/rate-limit'
 import { extractTrackingMeta, isValidUuid } from '@/lib/tracking'
@@ -46,10 +46,9 @@ export async function POST(request: Request) {
     )
   }
 
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  // Récupère le user authentifié (peut être null pour anonyme).
+  // Cookies (web) avec fallback Bearer (mobile RN). Cf. lib/supabase/bearer.ts.
+  const { user } = await authenticateRequest(request)
 
   const meta = extractTrackingMeta(request)
 

--- a/app/api/track/view/route.ts
+++ b/app/api/track/view/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { authenticateRequest } from '@/lib/supabase/bearer'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { enforceRateLimit } from '@/lib/rate-limit'
 import { extractTrackingMeta, isValidUuid } from '@/lib/tracking'
@@ -41,11 +41,9 @@ export async function POST(request: Request) {
     )
   }
 
-  // Récupère le user authentifié (peut être null)
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  // Récupère le user authentifié (peut être null pour anonyme).
+  // Cookies (web) avec fallback Bearer (mobile RN). Cf. lib/supabase/bearer.ts.
+  const { user } = await authenticateRequest(request)
 
   const meta = extractTrackingMeta(request)
 

--- a/app/api/videos/upload/route.ts
+++ b/app/api/videos/upload/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { authenticateRequest } from '@/lib/supabase/bearer'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { enforceRateLimit } from '@/lib/rate-limit'
 import { isValidUuid } from '@/lib/tracking'
@@ -49,10 +49,8 @@ export async function POST(request: Request) {
   })
   if (limited) return limited
 
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  // Cookies (web) avec fallback Bearer (mobile RN). Cf. lib/supabase/bearer.ts.
+  const { supabase, user } = await authenticateRequest(request)
   if (!user) {
     return NextResponse.json({ error: 'Non authentifiée' }, { status: 401 })
   }

--- a/lib/supabase/bearer.ts
+++ b/lib/supabase/bearer.ts
@@ -1,0 +1,69 @@
+/**
+ * Authentification cookies + fallback Bearer (mobile RN/Expo).
+ *
+ * Les routes API Hilmy sont consommées par 2 clients :
+ *   - le web (browser, cookies Supabase posés par le middleware SSR)
+ *   - l'app mobile Expo (JWT Bearer en AsyncStorage, sans cookies)
+ *
+ * Priorité (zéro régression web) :
+ *   1. On tente d'abord l'auth via cookies (createClient server.ts).
+ *      Si un user est résolu → on l'utilise, on s'arrête là.
+ *   2. Sinon, si `Authorization: Bearer <jwt>` est présent → on crée un
+ *      client Supabase configuré avec ce header et on retourne le user
+ *      qu'il résout.
+ *   3. Sinon → user = null (la route renvoie 401 selon sa convention).
+ *
+ * Le client retourné est le client "qui a réussi l'auth" — toutes les
+ * queries `.from(...).select(...)` qui dépendent de RLS owner doivent
+ * passer par lui (pas par un autre instance). Les opérations en
+ * service-role (admin client) restent inchangées dans les routes.
+ *
+ * Note : avec le Bearer header on désactive volontairement
+ * `persistSession` + `autoRefreshToken`. L'app mobile gère son propre
+ * refresh côté client ; on ne veut pas que le serveur tente de
+ * rafraîchir un token qu'il n'a pas le droit de stocker.
+ */
+
+import { createClient as createSupabaseJsClient } from '@supabase/supabase-js'
+import type { SupabaseClient, User } from '@supabase/supabase-js'
+import { createClient as createCookieClient } from './server'
+
+export type AuthenticatedRequestContext = {
+  supabase: SupabaseClient
+  user: User | null
+}
+
+export async function authenticateRequest(
+  request: Request,
+): Promise<AuthenticatedRequestContext> {
+  // 1. Cookies first (web standard, zéro régression).
+  const cookieClient = await createCookieClient()
+  const {
+    data: { user: cookieUser },
+  } = await cookieClient.auth.getUser()
+  if (cookieUser) {
+    return { supabase: cookieClient, user: cookieUser }
+  }
+
+  // 2. Fallback Bearer (mobile RN/Expo, AsyncStorage).
+  const authHeader = request.headers.get('Authorization')
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const bearerClient = createSupabaseJsClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        global: { headers: { Authorization: authHeader } },
+        auth: { persistSession: false, autoRefreshToken: false },
+      },
+    )
+    const {
+      data: { user: bearerUser },
+    } = await bearerClient.auth.getUser()
+    if (bearerUser) {
+      return { supabase: bearerClient, user: bearerUser }
+    }
+  }
+
+  // 3. Anonyme.
+  return { supabase: cookieClient, user: null }
+}


### PR DESCRIPTION
## Summary

Étend 5 endpoints API pour accepter `Authorization: Bearer <jwt>` en alternative aux cookies Supabase. Cookies restent **prioritaires** : zéro régression côté web.

**Endpoints patchés** :
- `/api/videos/upload` — débloque l'upload vidéo mobile (A4)
- `/api/track/view`, `/track/contact`, `/track/place-view`, `/track/place-contact` — fixe `viewer_id NULL` documenté dans A2

**Helper neuf** : `lib/supabase/bearer.ts` → `authenticateRequest(request)` qui tente cookies puis fallback Bearer.

**Hors scope** : caps palier, validations, INSERT admin, logique métier — strictement inchangés.

## Test plan

- [x] Typecheck OK
- [x] Lint OK (1 warning pré-existant `createAdminClient unused` dans `videos/upload`, **non introduit** par cette PR)
- [x] curl `POST /track/view` body invalide → 400 ✓
- [x] curl `POST /videos/upload` sans auth → 401 ✓
- [x] curl `POST /videos/upload` Bearer invalide → 401 ✓ (prouve que le code path Bearer est emprunté)
- [x] curl `POST /track/view` Bearer invalide + UUID inconnu → 400 FK ✓ (anonyme accepté, INSERT admin tente l'insert)
- [ ] **À tester E2E manuel après merge** : connexion web normale (cookie path inchangé) + connexion mobile via Bearer (A4 mobile sera le proof point)

## Risque

Faible — le helper bascule UNIQUEMENT sur Bearer si cookies ne résolvent pas un user. Tous les paths existants (web cookies) sont préservés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)