### PR TITLE
Pass Copine — abonnement utilisatrices (6 phases)

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -8,6 +8,7 @@ import {
 import { createClient } from "@/lib/supabase/server";
 import { FollowButton } from "@/components/voix/FollowButton";
 import { RecosList } from "@/components/voix/RecosList";
+import { MemberName } from "@/components/badges/MemberName";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://hilmy.io";
 
@@ -88,10 +89,21 @@ export default async function VoixSlugPage({
   } = await supabase.auth.getUser();
   const isLoggedIn = Boolean(user);
 
-  const [{ data: isFollowing }, { data: recos }] = await Promise.all([
+  const [{ data: isFollowing }, { data: recos }, { data: copineRow }] = await Promise.all([
     isFollowingVoix(voix.user_id),
     getRecosByVoix(voix.user_id),
+    // Pass Copine (mig 50, Phase 6) : fetch séparé is_copine/copine_since
+    // — la vue voix_hilmy_public ne les expose pas (décision D1 Phase 6 :
+    // pas de migration pour étendre la vue SECURITY DEFINER).
+    supabase
+      .from("user_profiles")
+      .select("is_copine, copine_since")
+      .eq("user_id", voix.user_id)
+      .maybeSingle(),
   ]);
+  const isCopine = (copineRow as { is_copine?: boolean | null } | null)?.is_copine ?? null;
+  const copineSince =
+    (copineRow as { copine_since?: string | null } | null)?.copine_since ?? null;
 
   return (
     <main className="min-h-screen bg-creme">
@@ -99,7 +111,12 @@ export default async function VoixSlugPage({
         <header className="text-center">
           <PhotoPlaceholder prenom={voix.prenom} />
           <h1 className="mt-4 font-serif text-3xl font-semibold text-vert">
-            {voix.prenom}
+            <MemberName
+              prenom={voix.prenom}
+              isCopine={isCopine}
+              copineSince={copineSince}
+              badgeSize={18}
+            />
           </h1>
           <div className="mt-2 flex justify-center">
             <span className="inline-flex items-center gap-1 rounded-md bg-or px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-vert">

--- a/app/accueil/page.tsx
+++ b/app/accueil/page.tsx
@@ -246,7 +246,7 @@ export default async function AccueilPage() {
   // ── 6 events à venir ─────────────────────────────────────────────
   const { data: eventsRows } = await supabase
     .from('events')
-    .select('id, title, slug, description, start_date, city, address, event_type, flyer_url, places_max, inscrites_count')
+    .select('id, title, slug, description, start_date, city, address, event_type, flyer_url, places_max, inscrites_count, early_access_until')
     .eq('status', 'published')
     .gte('start_date', new Date().toISOString())
     .order('start_date', { ascending: true })
@@ -266,6 +266,7 @@ export default async function AccueilPage() {
     flyer: ev.flyer_url ?? null,
     places: ev.places_max ?? 20,
     inscrites: ev.inscrites_count ?? 0,
+    early_access_until: (ev as { early_access_until?: string | null }).early_access_until ?? null,
   }))
 
   // ── 3 favoris ────────────────────────────────────────────────────

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { requireUser } from '@/lib/supabase/session'
+import { countPendingPerksAdmin } from '@/lib/supabase/queries/pro-perks'
 import { AdminNavLink } from './admin-nav-link'
 import { AdminSignOut } from './admin-sign-out'
 
@@ -20,7 +21,7 @@ export default async function AdminLayout({
   //   'published' OR owner)
   // → service_role pour avoir les vrais chiffres. Safe parce que
   // l'accès à ce layout est déjà gaté par le notFound() ci-dessus.
-  const [prestaCount, eventCount, recoCount, reportCount, jeChercheSignalementsCount] = await Promise.all([
+  const [prestaCount, eventCount, recoCount, reportCount, jeChercheSignalementsCount, pendingPerksCount] = await Promise.all([
     admin
       .from('profiles')
       .select('id', { count: 'exact', head: true })
@@ -43,6 +44,8 @@ export default async function AdminLayout({
       .from('demande_signalements')
       .select('id', { count: 'exact', head: true })
       .gte('created_at', new Date(Date.now() - 30 * 86_400_000).toISOString()),
+    // Pro Perks (mig 50) : queue pending_review pour modération.
+    countPendingPerksAdmin(),
   ])
 
   const nav = [
@@ -76,6 +79,11 @@ export default async function AdminLayout({
       href: '/admin/event-seasonal-categories',
       label: 'Catégories saisonnières',
       badge: undefined,
+    },
+    {
+      href: '/admin/pro-perks',
+      label: 'Offres Cercle Pro',
+      badge: pendingPerksCount,
     },
   ]
 

--- a/app/admin/pro-perks/PerkModerationRow.tsx
+++ b/app/admin/pro-perks/PerkModerationRow.tsx
@@ -1,0 +1,193 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { AnimatePresence, motion } from 'motion/react'
+import type { ProPerk } from '@/lib/supabase/types'
+
+interface PerkModerationRowProps {
+  perk: ProPerk
+  presta: { nom: string; email: string | null; slug: string | null } | null
+}
+
+function discountLabel(perk: ProPerk): string {
+  return perk.discount_type === 'percentage'
+    ? `${perk.discount_value} %`
+    : `${perk.discount_value} €`
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return new Intl.DateTimeFormat('fr-FR', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  }).format(d)
+}
+
+export function PerkModerationRow({ perk, presta }: PerkModerationRowProps) {
+  const router = useRouter()
+  const [busy, setBusy] = useState<'approve' | 'reject' | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [showReject, setShowReject] = useState(false)
+  const [rejectReason, setRejectReason] = useState('')
+
+  const canModerate = perk.status === 'pending_review'
+
+  async function moderate(action: 'approve' | 'reject') {
+    if (busy) return
+    if (action === 'reject' && rejectReason.trim().length === 0) {
+      setError('Une raison de refus est obligatoire.')
+      return
+    }
+    setBusy(action)
+    setError(null)
+    try {
+      const res = await fetch(`/api/admin/pro-perks/${perk.id}/moderate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action,
+          reason: action === 'reject' ? rejectReason.trim() : undefined,
+        }),
+      })
+      const json = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string }
+        | null
+      if (!res.ok || !json?.ok) {
+        setError(json?.error ?? 'Erreur inconnue')
+        setBusy(null)
+        return
+      }
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur réseau.')
+      setBusy(null)
+    }
+  }
+
+  return (
+    <li className="overflow-hidden rounded-sm border border-or/20 bg-blanc">
+      <div className="flex flex-col gap-4 p-5 md:flex-row md:items-start md:p-6">
+        <div className="flex-1">
+          <div className="flex flex-wrap items-baseline gap-2">
+            <p className="font-serif text-xl font-light text-vert">
+              {perk.title}
+            </p>
+            <span className="rounded-full bg-or/15 px-2.5 py-0.5 text-[10px] tracking-[0.22em] text-or-deep uppercase">
+              {discountLabel(perk)}
+            </span>
+            <span className="text-[11px] tracking-[0.18em] text-texte-sec uppercase">
+              {presta?.nom ?? '—'}
+              {presta?.email && ` · ${presta.email}`}
+            </span>
+          </div>
+          {perk.description && (
+            <p className="mt-2 text-[13px] leading-[1.6] text-texte-sec">
+              {perk.description}
+            </p>
+          )}
+          {perk.conditions && (
+            <p className="mt-2 text-[12px] italic leading-[1.6] text-texte-sec">
+              Conditions : {perk.conditions}
+            </p>
+          )}
+          <div className="mt-3 flex flex-wrap gap-4 text-[11px] tracking-[0.18em] text-texte-sec uppercase">
+            <span>
+              Utilisations max : {perk.max_uses ?? 'illimité'}
+            </span>
+            <span>Début : {formatDate(perk.starts_at)}</span>
+            <span>Fin : {formatDate(perk.ends_at)}</span>
+            <span>Reçue : {formatDate(perk.created_at)}</span>
+          </div>
+          {perk.status === 'rejected' && perk.rejection_reason && (
+            <p className="mt-3 rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[12px] text-red-900">
+              Refus : {perk.rejection_reason}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-col gap-2 md:w-44 md:shrink-0">
+          {presta?.slug && (
+            <a
+              href={`/prestataires/${presta.slug}`}
+              target="_blank"
+              rel="noopener"
+              className="inline-flex h-9 items-center justify-center rounded-full border border-or/30 px-4 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-colors hover:border-or hover:bg-creme-deep"
+            >
+              Voir la fiche
+            </a>
+          )}
+          {canModerate && (
+            <>
+              <button
+                type="button"
+                onClick={() => moderate('approve')}
+                disabled={busy !== null}
+                className="inline-flex h-9 items-center justify-center rounded-full bg-vert px-4 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-colors hover:bg-vert-dark disabled:opacity-60"
+              >
+                {busy === 'approve' ? '…' : 'Approuver'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowReject((v) => !v)}
+                disabled={busy !== null}
+                className="inline-flex h-9 items-center justify-center rounded-full border border-or/30 px-4 text-[11px] font-medium tracking-[0.22em] text-texte-sec uppercase transition-colors hover:border-red-900 hover:text-red-900 disabled:opacity-60"
+              >
+                Refuser
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {showReject && canModerate && (
+          <motion.div
+            initial={{ height: 0 }}
+            animate={{ height: 'auto' }}
+            exit={{ height: 0 }}
+            className="overflow-hidden border-t border-or/10 bg-creme-soft p-5"
+          >
+            <label htmlFor={`reject-${perk.id}`} className="overline text-or">
+              Raison du refus (envoyée au prestataire)
+            </label>
+            <textarea
+              id={`reject-${perk.id}`}
+              value={rejectReason}
+              onChange={(e) => setRejectReason(e.target.value)}
+              maxLength={500}
+              rows={3}
+              className="mt-2 block w-full rounded-sm border border-or/30 bg-white px-3 py-2 text-[13px] text-vert focus:border-or focus:outline-none focus:ring-1 focus:ring-or"
+              placeholder="Ex. la valeur de la réduction n'est pas claire — précise."
+            />
+            <div className="mt-3 flex gap-3">
+              <button
+                type="button"
+                onClick={() => moderate('reject')}
+                disabled={busy !== null || rejectReason.trim().length === 0}
+                className="inline-flex h-9 items-center justify-center rounded-full bg-red-900 px-4 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-colors hover:bg-red-950 disabled:opacity-60"
+              >
+                {busy === 'reject' ? '…' : 'Envoyer le refus'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowReject(false)}
+                className="inline-flex h-9 items-center justify-center px-4 text-[11px] font-medium tracking-[0.22em] text-texte-sec uppercase transition-colors hover:text-vert"
+              >
+                Annuler
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {error && (
+        <p className="border-t border-red-900/10 bg-red-900/5 px-5 py-2 text-[12px] text-red-900">
+          {error}
+        </p>
+      )}
+    </li>
+  )
+}

--- a/app/admin/pro-perks/page.tsx
+++ b/app/admin/pro-perks/page.tsx
@@ -1,0 +1,119 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+import { listPerksByStatusAdmin } from '@/lib/supabase/queries/pro-perks'
+import type { ProPerk, ProPerkStatus } from '@/lib/supabase/types'
+import { PerkModerationRow } from './PerkModerationRow'
+
+type ListableStatus = Extract<
+  ProPerkStatus,
+  'pending_review' | 'active' | 'rejected' | 'paused'
+>
+
+const TABS: { key: ListableStatus; label: string; heading: string }[] = [
+  { key: 'pending_review', label: 'En attente', heading: 'À modérer.' },
+  { key: 'active', label: 'Actives', heading: 'En ligne.' },
+  { key: 'rejected', label: 'Refusées', heading: 'Refusées.' },
+  { key: 'paused', label: 'En pause', heading: 'En pause.' },
+]
+
+function isListable(status: string | undefined): status is ListableStatus {
+  return (
+    status === 'pending_review' ||
+    status === 'active' ||
+    status === 'rejected' ||
+    status === 'paused'
+  )
+}
+
+/**
+ * Queue de modération admin des Pro Perks (mig 50).
+ *
+ * Auth gating : assuré par app/admin/layout.tsx (requireUser +
+ * user_metadata.is_admin). service_role pour bypass RLS et voir tous
+ * les statuts (pending_review n'est PAS dans la policy
+ * public_active_select).
+ *
+ * Pattern copié sur app/admin/evenements-a-valider (tabs filter
+ * par ?status=...).
+ */
+export default async function AdminProPerksPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string }>
+}) {
+  const { status: rawStatus } = await searchParams
+  const status: ListableStatus = isListable(rawStatus) ? rawStatus : 'pending_review'
+
+  const perks = await listPerksByStatusAdmin(status)
+
+  // Lookup prestataires pour afficher le nom/email côté admin
+  // (l'info reste utile même pour les tabs autres que pending).
+  const prestaIds = Array.from(new Set(perks.map((p) => p.prestataire_profile_id)))
+  let prestaByid = new Map<
+    string,
+    { nom: string; email: string | null; slug: string | null }
+  >()
+  if (prestaIds.length > 0) {
+    const admin = createAdminClient()
+    const { data: prestas } = await admin
+      .from('profiles')
+      .select('id, nom, email, slug')
+      .in('id', prestaIds)
+    prestaByid = new Map(
+      ((prestas as Array<{ id: string; nom: string; email: string | null; slug: string | null }> | null) ?? []).map(
+        (p) => [p.id, { nom: p.nom, email: p.email, slug: p.slug }],
+      ),
+    )
+  }
+
+  const heading = TABS.find((t) => t.key === status)?.heading ?? 'Offres Cercle Pro.'
+
+  return (
+    <section className="px-6 py-10 md:px-12 md:py-14">
+      <header className="border-b border-or/15 pb-6">
+        <p className="overline text-or">Modération · offres Cercle Pro</p>
+        <h1 className="mt-3 font-serif text-3xl font-light text-vert md:text-4xl">
+          {heading}
+        </h1>
+      </header>
+
+      <nav className="mt-6 flex flex-wrap gap-2">
+        {TABS.map((t) => {
+          const active = status === t.key
+          return (
+            <a
+              key={t.key}
+              href={`?status=${t.key}`}
+              className={`inline-flex items-center rounded-full px-4 py-2 text-[11px] font-medium tracking-[0.22em] uppercase transition-colors ${
+                active
+                  ? 'bg-vert text-creme'
+                  : 'bg-blanc text-texte-sec hover:bg-creme-deep hover:text-vert'
+              }`}
+            >
+              {t.label}
+            </a>
+          )
+        })}
+      </nav>
+
+      <div className="mt-8">
+        {perks.length === 0 ? (
+          <div className="rounded-sm border border-or/15 bg-blanc p-10 text-center">
+            <p className="font-serif text-xl italic text-vert">
+              Aucune offre dans cette file.
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-4">
+            {perks.map((perk: ProPerk) => (
+              <PerkModerationRow
+                key={perk.id}
+                perk={perk}
+                presta={prestaByid.get(perk.prestataire_profile_id) ?? null}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/app/api/admin/pro-perks/[id]/moderate/route.ts
+++ b/app/api/admin/pro-perks/[id]/moderate/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { enforceRateLimit } from '@/lib/rate-limit'
+import {
+  getPerkByIdAdmin,
+  setPerkStatusAdmin,
+} from '@/lib/supabase/queries/pro-perks'
+import {
+  sendPerkApproved,
+  sendPerkRejected,
+} from '@/lib/email/transactional'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/admin/pro-perks/[id]/moderate
+ *
+ * Modération admin d'un perk en pending_review.
+ * Body :
+ *   { action: 'approve' }              → status='active'
+ *   { action: 'reject', reason: text } → status='rejected', stores reason
+ *
+ * Gating defense-in-depth :
+ *   1. Auth — 401 sinon
+ *   2. user_metadata.is_admin = true — 403 sinon
+ *      (RLS admin_all gate aussi côté DB — defense-in-depth)
+ *   3. Action ∈ {approve, reject} — 400 sinon
+ *   4. reject : reason non vide (l'email au presta l'inclut)
+ *
+ * Email best-effort post-décision (approved ou rejected).
+ *
+ * Rate-limit : 30/min/IP (modération en série côté admin).
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const limited = enforceRateLimit(request, {
+    tag: 'admin-pro-perks-moderate',
+    max: 30,
+    windowMs: 60 * 1000,
+  })
+  if (limited) return limited
+
+  const { id: perkId } = await params
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Non authentifiée' }, { status: 401 })
+  }
+  if (!user.user_metadata?.is_admin) {
+    return NextResponse.json({ error: 'Réservé admin' }, { status: 403 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'JSON invalide' }, { status: 400 })
+  }
+  const action = (body as { action?: unknown }).action
+  const reason = (body as { reason?: unknown }).reason
+
+  if (action !== 'approve' && action !== 'reject') {
+    return NextResponse.json(
+      { error: "action doit être 'approve' ou 'reject'" },
+      { status: 400 },
+    )
+  }
+  if (action === 'reject') {
+    if (typeof reason !== 'string' || reason.trim().length === 0) {
+      return NextResponse.json(
+        { error: 'Une raison de refus est obligatoire.' },
+        { status: 422 },
+      )
+    }
+    if (reason.length > 500) {
+      return NextResponse.json(
+        { error: 'Raison trop longue (max 500 caractères).' },
+        { status: 422 },
+      )
+    }
+  }
+
+  // Fetch perk + presta pour l'email post-décision.
+  const perk = await getPerkByIdAdmin(perkId)
+  if (!perk) {
+    return NextResponse.json({ error: 'Offre introuvable' }, { status: 404 })
+  }
+  if (perk.status !== 'pending_review') {
+    return NextResponse.json(
+      { error: 'Cette offre a déjà été modérée.' },
+      { status: 409 },
+    )
+  }
+
+  const admin = createAdminClient()
+  const { data: presta } = await admin
+    .from('profiles')
+    .select('id, nom, email')
+    .eq('id', perk.prestataire_profile_id)
+    .maybeSingle()
+
+  // Update status. RLS admin_all autorise. setPerkStatusAdmin gère
+  // aussi rejection_reason (null si approve).
+  const nextStatus = action === 'approve' ? 'active' : 'rejected'
+  const updateRes = await setPerkStatusAdmin(
+    perkId,
+    nextStatus,
+    action === 'reject' ? (reason as string).trim() : null,
+  )
+  if (!updateRes.ok) {
+    return NextResponse.json({ error: updateRes.error }, { status: 500 })
+  }
+
+  // Email post-décision — best-effort.
+  const origin =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ??
+    new URL(request.url).origin
+  const dashboardUrl = `${origin}/dashboard/prestataire/avantages`
+
+  try {
+    const prestaEmail = (presta as { email?: string | null } | null)?.email
+    const prestaNom = (presta as { nom?: string | null } | null)?.nom ?? ''
+    if (prestaEmail) {
+      if (action === 'approve') {
+        await sendPerkApproved({
+          to: prestaEmail,
+          prestaPrenom: prestaNom || 'la team',
+          perkTitle: perk.title,
+          dashboardUrl,
+        })
+      } else {
+        await sendPerkRejected({
+          to: prestaEmail,
+          prestaPrenom: prestaNom || 'la team',
+          perkTitle: perk.title,
+          rejectionReason: (reason as string).trim(),
+          dashboardUrl,
+        })
+      }
+    }
+  } catch (err) {
+    console.warn('[admin/pro-perks/moderate] email failed:', err)
+  }
+
+  return NextResponse.json({ ok: true, status: nextStatus })
+}

--- a/app/api/events/[id]/inscription/route.ts
+++ b/app/api/events/[id]/inscription/route.ts
@@ -38,7 +38,7 @@ export async function POST(
   const { data: event, error: evErr } = await supabase
     .from("events")
     .select(
-      "id, title, slug, start_date, city, address, status, visibility, places_max, inscrites_count, prestataire_id, user_id",
+      "id, title, slug, start_date, city, address, status, visibility, places_max, inscrites_count, prestataire_id, user_id, early_access_until",
     )
     .eq("id", eventId)
     .maybeSingle();
@@ -62,6 +62,28 @@ export async function POST(
       { error: "L'événement est complet." },
       { status: 400 },
     );
+  }
+
+  // Defense-in-depth Pass Copine (mig 50) : si l'event est en fenêtre
+  // d'accès anticipé Copines (early_access_until > now()) et que la
+  // user n'est pas Copine, on bloque l'inscription côté serveur même
+  // si le client gate a été contourné. Le client reconnaît le code
+  // EARLY_ACCESS_COPINE_ONLY et ouvre le paywall.
+  if (event.early_access_until) {
+    const earlyAccessTs = new Date(event.early_access_until).getTime();
+    if (!Number.isNaN(earlyAccessTs) && earlyAccessTs > Date.now()) {
+      const { data: copineRow } = await supabase
+        .from("user_profiles")
+        .select("is_copine")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!copineRow?.is_copine) {
+        return NextResponse.json(
+          { error: "EARLY_ACCESS_COPINE_ONLY" },
+          { status: 403 },
+        );
+      }
+    }
   }
 
   // Upsert inscription (unique sur user+event)

--- a/app/api/pro-perks/[id]/claim/route.ts
+++ b/app/api/pro-perks/[id]/claim/route.ts
@@ -1,0 +1,195 @@
+import { NextResponse } from 'next/server'
+import { randomBytes } from 'node:crypto'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { enforceRateLimit } from '@/lib/rate-limit'
+import {
+  incrementPerkUsedCountAdmin,
+  getPerkByIdAdmin,
+} from '@/lib/supabase/queries/pro-perks'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/pro-perks/[id]/claim
+ *
+ * Une Copine claim une offre Pro Perk. Retourne le code unique
+ * HILMY-XXXX-YYYY à afficher.
+ *
+ * Gating defense-in-depth (Phase 5 D5) :
+ *   1. Auth — 401 sinon
+ *   2. user_profiles.is_copine = true — 403 sinon
+ *      (DB-side : RLS INSERT gated by is_user_copine() — double rideau)
+ *   3. Perk existe, status='active', fenêtre OK — 404/410 sinon
+ *   4. Race-safe max_uses check via UPDATE conditionné
+ *      (incrementPerkUsedCountAdmin) — si dépassement, rollback claim
+ *
+ * Idempotence : la contrainte UNIQUE(perk_id, user_id) garantit qu'un
+ * 2e claim sur le même perk retourne le code DÉJÀ généré (on lit
+ * d'abord pro_perk_claims avant d'insérer).
+ *
+ * Rate-limit : 10/min/IP.
+ */
+
+function generateClaimCode(): string {
+  // 2 segments de 4 hex chars majuscules (regex DB ^HILMY-[A-F0-9]{4}-[A-F0-9]{4}$).
+  const segment = () => randomBytes(2).toString('hex').toUpperCase()
+  return `HILMY-${segment()}-${segment()}`
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const limited = enforceRateLimit(request, {
+    tag: 'pro-perks-claim',
+    max: 10,
+    windowMs: 60 * 1000,
+  })
+  if (limited) return limited
+
+  const { id: perkId } = await params
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Non authentifiée' }, { status: 401 })
+  }
+
+  // Gate is_copine (defense-in-depth — RLS DB-side gate aussi via
+  // is_user_copine()).
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('is_copine')
+    .eq('user_id', user.id)
+    .maybeSingle()
+  if (!profile?.is_copine) {
+    return NextResponse.json(
+      { error: 'COPINE_REQUIRED', message: 'Réservé aux Copines.' },
+      { status: 403 },
+    )
+  }
+
+  // Fetch perk pour vérifier qu'il est claimable (active + fenêtre OK).
+  const perk = await getPerkByIdAdmin(perkId)
+  if (!perk) {
+    return NextResponse.json({ error: 'Offre introuvable' }, { status: 404 })
+  }
+  if (perk.status !== 'active') {
+    return NextResponse.json(
+      { error: "Cette offre n'est plus active." },
+      { status: 410 },
+    )
+  }
+  const now = Date.now()
+  if (new Date(perk.starts_at).getTime() > now) {
+    return NextResponse.json(
+      { error: "Cette offre n'est pas encore ouverte." },
+      { status: 410 },
+    )
+  }
+  if (perk.ends_at && new Date(perk.ends_at).getTime() <= now) {
+    return NextResponse.json(
+      { error: 'Cette offre est terminée.' },
+      { status: 410 },
+    )
+  }
+
+  // Idempotence : si la Copine a déjà claim ce perk, on lui renvoie son code.
+  const admin = createAdminClient()
+  const { data: existing } = await admin
+    .from('pro_perk_claims')
+    .select('id, code_displayed, marked_used_at, created_at')
+    .eq('perk_id', perkId)
+    .eq('user_id', user.id)
+    .maybeSingle()
+  if (existing) {
+    return NextResponse.json({
+      ok: true,
+      already_claimed: true,
+      code: (existing as { code_displayed: string }).code_displayed,
+      claim_id: (existing as { id: string }).id,
+    })
+  }
+
+  // Génère le code et insère le claim (RLS pro_perk_claims_copine_insert
+  // re-vérifie is_user_copine — defense-in-depth DB).
+  const code = generateClaimCode()
+  const { data: claim, error: claimErr } = await supabase
+    .from('pro_perk_claims')
+    .insert({
+      perk_id: perkId,
+      user_id: user.id,
+      code_displayed: code,
+    })
+    .select('id, code_displayed')
+    .single()
+
+  if (claimErr || !claim) {
+    return NextResponse.json(
+      { error: claimErr?.message ?? 'Impossible de générer ton code.' },
+      { status: 500 },
+    )
+  }
+
+  // Incrément atomique used_count avec garde max_uses (race-safe).
+  // Si la garde DB filtre (perk au max entre fetch et insert), on
+  // rollback le claim pour éviter d'avoir un code orphelin.
+  const incr = await incrementPerkUsedCountAdmin(perkId)
+  if (!incr.ok) {
+    await admin.from('pro_perk_claims').delete().eq('id', claim.id)
+    return NextResponse.json(
+      { error: 'Cette offre n\'a plus de places disponibles.' },
+      { status: 409 },
+    )
+  }
+
+  return NextResponse.json({
+    ok: true,
+    already_claimed: false,
+    code: claim.code_displayed,
+    claim_id: claim.id,
+  })
+}
+
+/**
+ * PATCH /api/pro-perks/[id]/claim — marque le claim comme utilisé.
+ *
+ * RLS pro_perk_claims_self_update autorise la Copine à patcher son
+ * propre claim (user_id = auth.uid()). Pas de gating supplémentaire
+ * côté API au-delà de l'auth.
+ */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const limited = enforceRateLimit(request, {
+    tag: 'pro-perks-mark-used',
+    max: 10,
+    windowMs: 60 * 1000,
+  })
+  if (limited) return limited
+
+  const { id: perkId } = await params
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Non authentifiée' }, { status: 401 })
+  }
+
+  const { error } = await supabase
+    .from('pro_perk_claims')
+    .update({ marked_used_at: new Date().toISOString() })
+    .eq('perk_id', perkId)
+    .eq('user_id', user.id)
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/pro-perks/[id]/pause/route.ts
+++ b/app/api/pro-perks/[id]/pause/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { enforceRateLimit } from '@/lib/rate-limit'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/pro-perks/[id]/pause
+ *
+ * Toggle pause↔active sur un perk dont le caller est owner.
+ * Body : { action: 'pause' | 'resume' }
+ *
+ * Gating :
+ *   - Auth — 401 sinon
+ *   - RLS owner_all filtre déjà : un caller non-owner ne peut pas
+ *     update les rows d'un autre prestataire. On garde le check
+ *     explicite côté client (.eq(prestataire_profile_id)) pour clarté.
+ *
+ * Règle : on n'autorise pause↔active. Un perk en pending_review ou
+ * rejected ne peut pas être paused/resumed — seul l'admin déplace
+ * depuis ces statuts.
+ *
+ * Rate-limit : 10/min/IP.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const limited = enforceRateLimit(request, {
+    tag: 'pro-perks-toggle',
+    max: 10,
+    windowMs: 60 * 1000,
+  })
+  if (limited) return limited
+
+  const { id: perkId } = await params
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Non authentifiée' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'JSON invalide' }, { status: 400 })
+  }
+  const action = (body as { action?: unknown }).action
+  if (action !== 'pause' && action !== 'resume') {
+    return NextResponse.json(
+      { error: "action doit être 'pause' ou 'resume'" },
+      { status: 400 },
+    )
+  }
+
+  // Fetch courant pour vérifier la transition autorisée.
+  const { data: perk, error: fetchErr } = await supabase
+    .from('pro_perks')
+    .select('id, status, prestataire_profile_id')
+    .eq('id', perkId)
+    .maybeSingle()
+  if (fetchErr || !perk) {
+    return NextResponse.json(
+      { error: fetchErr?.message ?? 'Offre introuvable' },
+      { status: 404 },
+    )
+  }
+
+  const current = (perk as { status: string }).status
+  if (action === 'pause' && current !== 'active') {
+    return NextResponse.json(
+      { error: "Seules les offres actives peuvent être mises en pause." },
+      { status: 409 },
+    )
+  }
+  if (action === 'resume' && current !== 'paused') {
+    return NextResponse.json(
+      { error: "Seules les offres en pause peuvent être réactivées." },
+      { status: 409 },
+    )
+  }
+
+  const nextStatus = action === 'pause' ? 'paused' : 'active'
+  const { error: updateErr } = await supabase
+    .from('pro_perks')
+    .update({ status: nextStatus })
+    .eq('id', perkId)
+
+  if (updateErr) {
+    return NextResponse.json({ error: updateErr.message }, { status: 500 })
+  }
+  return NextResponse.json({ ok: true, status: nextStatus })
+}

--- a/app/api/pro-perks/route.ts
+++ b/app/api/pro-perks/route.ts
@@ -1,0 +1,165 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { enforceRateLimit } from '@/lib/rate-limit'
+import { hasCerclePro } from '@/lib/permissions'
+import { sendPerkPendingReview } from '@/lib/email/transactional'
+import type { Palier } from '@/app/tarifs/_lib/pricing'
+
+export const runtime = 'nodejs'
+
+/**
+ * POST /api/pro-perks
+ *
+ * Création d'une offre Pro Perk par un prestataire Cercle Pro.
+ *
+ * Gating defense-in-depth (Phase 5 D5) :
+ *   1. Auth (cookie session) — 401 sinon
+ *   2. Profile présent — 404 sinon
+ *   3. hasCerclePro(profile) (palier='cercle_pro' OR is_founder=true)
+ *      AND status='approved' — 403 sinon
+ *   4. Validation Zod du payload (titre 1-80, description ≤300, etc.)
+ *
+ * Insert avec status='pending_review' obligatoire — l'admin doit
+ * modérer avant que le perk soit visible aux Copines.
+ *
+ * Email notification founders/admins via sendPerkPendingReview
+ * (best-effort, ne bloque pas la réponse 200).
+ *
+ * Rate-limit : 5/min/IP (création modeste, anti-spam).
+ */
+
+const PerkInputSchema = z.object({
+  title: z.string().trim().min(1).max(80),
+  description: z.string().trim().max(300).optional().nullable(),
+  discount_type: z.enum(['percentage', 'fixed']),
+  discount_value: z.number().positive(),
+  conditions: z.string().trim().max(500).optional().nullable(),
+  max_uses: z.number().int().positive().optional().nullable(),
+  starts_at: z.string().datetime().optional().nullable(),
+  ends_at: z.string().datetime().optional().nullable(),
+})
+
+function buildAdminUrl(request: Request): string {
+  const origin =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ??
+    new URL(request.url).origin
+  return `${origin}/admin/pro-perks`
+}
+
+export async function POST(request: Request) {
+  const limited = enforceRateLimit(request, {
+    tag: 'pro-perks-create',
+    max: 5,
+    windowMs: 60 * 1000,
+  })
+  if (limited) return limited
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Non authentifiée' }, { status: 401 })
+  }
+
+  // Gating prestataire Cercle Pro + status approved (admin lookup
+  // pour défensif — RLS pourrait filtrer)
+  const admin = createAdminClient()
+  const { data: profile, error: profErr } = await admin
+    .from('profiles')
+    .select('id, user_id, nom, palier, is_founder, status')
+    .eq('user_id', user.id)
+    .maybeSingle()
+  if (profErr || !profile) {
+    return NextResponse.json({ error: 'Profil prestataire introuvable' }, { status: 404 })
+  }
+  if (profile.status !== 'approved') {
+    return NextResponse.json(
+      { error: 'Ta fiche doit être validée avant de créer une offre.' },
+      { status: 403 },
+    )
+  }
+  if (
+    !hasCerclePro({
+      palier: profile.palier as Palier | null,
+      is_founder: profile.is_founder as boolean | null,
+    })
+  ) {
+    return NextResponse.json(
+      { error: 'Les offres Copines sont réservées au Cercle Pro.' },
+      { status: 403 },
+    )
+  }
+
+  // Parse + validate payload
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'JSON invalide' }, { status: 400 })
+  }
+  const parsed = PerkInputSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Données invalides', issues: parsed.error.issues },
+      { status: 422 },
+    )
+  }
+  const input = parsed.data
+
+  // Coherence check fenêtre temporelle (la DB CHECK le fait aussi)
+  if (input.starts_at && input.ends_at) {
+    if (new Date(input.ends_at) <= new Date(input.starts_at)) {
+      return NextResponse.json(
+        { error: "ends_at doit être postérieur à starts_at." },
+        { status: 422 },
+      )
+    }
+  }
+
+  // Insert — RLS owner_all autorise puisque prestataire_profile_id
+  // pointe sur profile.id de l'auth.uid().
+  const { data: inserted, error: insertErr } = await supabase
+    .from('pro_perks')
+    .insert({
+      prestataire_profile_id: profile.id,
+      title: input.title,
+      description: input.description ?? null,
+      discount_type: input.discount_type,
+      discount_value: input.discount_value,
+      conditions: input.conditions ?? null,
+      max_uses: input.max_uses ?? null,
+      starts_at: input.starts_at ?? new Date().toISOString(),
+      ends_at: input.ends_at ?? null,
+      status: 'pending_review',
+    })
+    .select('id, title, discount_type, discount_value')
+    .single()
+
+  if (insertErr || !inserted) {
+    return NextResponse.json(
+      { error: insertErr?.message ?? 'Impossible de créer le perk' },
+      { status: 500 },
+    )
+  }
+
+  // Notification founders/admins — best-effort, log mais ne bloque pas.
+  try {
+    const discountLabel =
+      inserted.discount_type === 'percentage'
+        ? `${inserted.discount_value} % de réduction`
+        : `${inserted.discount_value} € de réduction`
+    await sendPerkPendingReview({
+      perkTitle: inserted.title,
+      prestaNom: (profile.nom as string) ?? 'Une prestataire',
+      discountLabel,
+      adminUrl: buildAdminUrl(request),
+    })
+  } catch (err) {
+    console.warn('[pro-perks] sendPerkPendingReview failed:', err)
+  }
+
+  return NextResponse.json({ ok: true, id: inserted.id })
+}

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -5,38 +5,60 @@ import { enforceRateLimit } from '@/lib/rate-limit'
 import {
   stripe,
   isKnownPriceId,
+  isCopinePriceId,
   getPaliersAndInterval,
+  getCopinePlan,
+  getCopinePriceIdForPlan,
   buildStripeSuccessUrl,
   buildStripeCancelUrl,
+  buildCopineSuccessUrl,
+  buildCopineCancelUrl,
 } from '@/lib/stripe'
 import { getActiveStripeDiscounts } from '@/lib/stripe-promo'
 import { setProfileStripeCustomerIdAdmin } from '@/lib/supabase/queries/subscriptions'
+import {
+  getUserProfileCopineByUserIdAdmin,
+  setUserProfileCopineStripeCustomerIdAdmin,
+} from '@/lib/supabase/queries/copine-subscriptions'
+import type { CopinePlan } from '@/lib/supabase/types'
+import type { User } from '@supabase/supabase-js'
 
 export const runtime = 'nodejs'
 
 /**
  * POST /api/stripe/checkout
  *
- * Body : { price_id: string }
+ * Body accepte 2 shapes :
+ *   1. { price_id: string } — flow legacy prestataire ou Copine direct
+ *   2. { plan: 'monthly' | 'annual' } — flow Pass Copine (le price_id
+ *      est résolu server-side via STRIPE_PRICE_COPINE_*, ces env vars
+ *      sont volontairement server-only — décision A5)
+ *
+ * Dispatch interne : si le price_id résolu est Copine
+ * (isCopinePriceId), le flow saute le check founder, lookup
+ * user_profiles au lieu de profiles, et stocke le customer sur
+ * copine_stripe_customer_id (décision A6).
  *
  * Validations server-side (defense in depth) :
  *   1. Auth (session Supabase) — 401 sinon
- *   2. price_id référencé dans PRICE_ID_MAP — 422 sinon
- *   3. Profile existe pour ce user — 404 sinon
- *   4. Founder is_founder=true → 403 (déjà accès Cercle Pro à vie,
- *      pas de double abo possible — décision Q2=c)
- *   5. Crée Stripe Customer si pas déjà, stocke stripe_customer_id
- *      sur profiles (admin client)
- *   6. Crée Checkout Session avec metadata profile_id + palier + duree
- *      pour décodage rapide côté webhook
- *   7. Si NEXT_PUBLIC_PROMO_LANCEMENT=true → auto-applique LANCEMENT50
- *      via discounts (pas de stacking, cf AGENTS.md).
- *      Sinon → allow_promotion_codes: true pour permettre un code copine.
- *      Stripe API rejette si les 2 sont passés ensemble.
+ *   2. Flow prestataire : price_id référencé dans PRICE_ID_MAP — 422 sinon
+ *      Flow Copine : plan ∈ {monthly, annual} ET price Stripe configuré
+ *   3. Flow prestataire : Profile existe — 404 sinon
+ *      Flow Copine : user_profile existe — 404 sinon
+ *   4. Flow prestataire : Founder is_founder=true → 403 (Cercle Pro à vie)
+ *      Flow Copine : founders PEUVENT être Copines (deux abos distincts)
+ *   5. Crée/réutilise Stripe Customer (lookup par email), stocke l'ID
+ *      sur la bonne table (profiles ou user_profiles selon flow)
+ *   6. Crée Checkout Session avec metadata distinctes selon flow :
+ *      - Prestataire : { profile_id, palier, duree_months }
+ *      - Copine     : { user_id, plan, is_copine_sub: 'true' }
+ *   7. Promo LANCEMENT50 : appliquée UNIQUEMENT au flow prestataire
+ *      (décision Jiji 2026-05-13 : Pass Copine hors périmètre promo).
  *
  * Retourne { url } à utiliser pour window.location.href côté client.
  *
- * Rate-limit : 10/min/utilisatrice (cap modeste, click sur SubscribeButton).
+ * Rate-limit : 10/min/IP (cap partagé entre les deux flows — cap
+ * modeste, click sur SubscribeButton).
  */
 export async function POST(request: Request) {
   const limited = enforceRateLimit(request, {
@@ -61,16 +83,59 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'JSON invalide' }, { status: 400 })
   }
 
-  const priceId = (body as { price_id?: unknown }).price_id
-  if (typeof priceId !== 'string' || !priceId.startsWith('price_')) {
-    return NextResponse.json({ error: 'price_id manquant' }, { status: 400 })
-  }
-  if (!isKnownPriceId(priceId)) {
+  // ─── Résolution du priceId + détection du flow ────────────────────
+  // Body shape 1 : { plan: 'monthly' | 'annual' } → résolution Copine
+  // Body shape 2 : { price_id } → flow Copine si isCopinePriceId, sinon
+  //                prestataire si isKnownPriceId, sinon 422.
+  const bodyObj = body as { price_id?: unknown; plan?: unknown }
+  let priceId: string
+  let isCopineFlow = false
+
+  if (typeof bodyObj.plan === 'string') {
+    if (bodyObj.plan !== 'monthly' && bodyObj.plan !== 'annual') {
+      return NextResponse.json(
+        { error: 'plan doit être "monthly" ou "annual"' },
+        { status: 400 },
+      )
+    }
+    const resolved = getCopinePriceIdForPlan(bodyObj.plan as CopinePlan)
+    if (!resolved) {
+      console.error(
+        '[stripe/checkout] STRIPE_PRICE_COPINE_* absent côté serveur',
+      )
+      return NextResponse.json(
+        { error: 'Pass Copine indisponible côté serveur' },
+        { status: 503 },
+      )
+    }
+    priceId = resolved
+    isCopineFlow = true
+  } else if (
+    typeof bodyObj.price_id === 'string' &&
+    bodyObj.price_id.startsWith('price_')
+  ) {
+    priceId = bodyObj.price_id
+    if (isCopinePriceId(priceId)) {
+      isCopineFlow = true
+    } else if (!isKnownPriceId(priceId)) {
+      return NextResponse.json(
+        { error: 'price_id non référencé côté serveur' },
+        { status: 422 },
+      )
+    }
+  } else {
     return NextResponse.json(
-      { error: 'price_id non référencé côté serveur' },
-      { status: 422 },
+      { error: 'price_id ou plan requis' },
+      { status: 400 },
     )
   }
+
+  // ─── Dispatch flow Copine ─────────────────────────────────────────
+  if (isCopineFlow) {
+    return createCopineCheckoutSession(request, user, priceId)
+  }
+
+  // ─── Flow prestataire (existant, inchangé en comportement) ────────
   const decoded = getPaliersAndInterval(priceId)
   if (!decoded) {
     return NextResponse.json(
@@ -167,6 +232,138 @@ export async function POST(request: Request) {
   if (!session.url) {
     return NextResponse.json(
       { error: 'Stripe Checkout n\'a pas renvoyé d\'URL.' },
+      { status: 502 },
+    )
+  }
+  return NextResponse.json({ url: session.url })
+}
+
+
+/* ────────────────────────────────────────────────────────────────────
+   Flow Pass Copine (mig 50) — créé en dispatch depuis POST ci-dessus.
+
+   Différences clés avec le flow prestataire :
+     • Lookup user_profiles au lieu de profiles
+     • Pas de check is_founder (les founders peuvent être Copines —
+       deux abos distincts pour deux rôles distincts)
+     • Customer Stripe stocké sur user_profiles.copine_stripe_customer_id
+       (peut être identique à profiles.stripe_customer_id si l'email
+       Stripe est le même — Stripe dédoublonne par email)
+     • Defense in depth : si user_profile.is_copine = true → 409 (déjà
+       Copine, pas de double abo). Le UI redirect aussi vers la page
+       gestion avant d'arriver ici.
+     • Metadata Stripe : is_copine_sub = 'true' pour dispatch webhook
+     • PROMO_LANCEMENT50 N'EST PAS appliquée — Pass Copine hors périmètre
+   ──────────────────────────────────────────────────────────────────── */
+
+async function createCopineCheckoutSession(
+  request: Request,
+  user: User,
+  priceId: string,
+): Promise<NextResponse> {
+  const plan = getCopinePlan(priceId)
+  if (!plan) {
+    // Ne devrait jamais arriver — isCopinePriceId a déjà filtré.
+    return NextResponse.json(
+      { error: 'price_id Copine non décodable' },
+      { status: 500 },
+    )
+  }
+
+  // Lookup user_profile (admin client : besoin de lire copine_* qui
+  // pourraient ne pas être exposées via RLS UPDATE — défense en
+  // profondeur). Le user_profile est créé à l'onboarding ; absence =
+  // onboarding incomplet → 404 explicite.
+  const userProfile = await getUserProfileCopineByUserIdAdmin(user.id)
+  if (!userProfile) {
+    return NextResponse.json(
+      { error: 'Profil utilisatrice introuvable — onboarding requis' },
+      { status: 404 },
+    )
+  }
+
+  if (userProfile.is_copine) {
+    return NextResponse.json(
+      {
+        error: 'Tu es déjà Copine. File sur ton espace pour gérer ton abo.',
+        redirect: '/dashboard/utilisatrice/copine',
+      },
+      { status: 409 },
+    )
+  }
+
+  // Crée ou retrouve un Stripe customer. Si la personne est aussi
+  // prestataire avec le même email, Stripe nous retournera le même
+  // customer.id que profiles.stripe_customer_id — c'est attendu et OK
+  // (1 customer = 1 email côté Stripe, 2 subscriptions distinctes côté
+  // Hilmy).
+  let stripeCustomerId = userProfile.copine_stripe_customer_id
+  if (!stripeCustomerId) {
+    const email = user.email ?? undefined
+    if (email) {
+      const existing = await stripe.customers.list({ email, limit: 1 })
+      if (existing.data[0]) {
+        stripeCustomerId = existing.data[0].id
+      }
+    }
+    if (!stripeCustomerId) {
+      const created = await stripe.customers.create({
+        email,
+        name: userProfile.prenom ?? undefined,
+        metadata: { user_id: user.id, source: 'pass_copine' },
+      })
+      stripeCustomerId = created.id
+    }
+    // Persist sur user_profiles pour les checkouts/portal ultérieurs.
+    const setRes = await setUserProfileCopineStripeCustomerIdAdmin(
+      user.id,
+      stripeCustomerId,
+    )
+    if (!setRes.ok) {
+      // Non bloquant — le webhook ré-essaiera de stocker si l'event
+      // checkout.session.completed arrive avant cette fin de fonction.
+      console.warn(
+        '[stripe/checkout] setUserProfileCopineStripeCustomerIdAdmin failed:',
+        setRes.error,
+      )
+    }
+  }
+
+  const origin = new URL(request.url).origin
+  let session
+  try {
+    session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      customer: stripeCustomerId,
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: buildCopineSuccessUrl(origin),
+      cancel_url: buildCopineCancelUrl(origin),
+      // PROMO_LANCEMENT50 volontairement absente du flow Copine.
+      allow_promotion_codes: false,
+      metadata: {
+        user_id: user.id,
+        plan,
+        is_copine_sub: 'true',
+      },
+      subscription_data: {
+        metadata: {
+          user_id: user.id,
+          plan,
+          is_copine_sub: 'true',
+        },
+      },
+    })
+  } catch (err) {
+    console.error('[stripe/checkout] copine sessions.create failed:', err)
+    return NextResponse.json(
+      { error: 'Stripe Checkout indisponible. Réessaie dans une minute.' },
+      { status: 502 },
+    )
+  }
+
+  if (!session.url) {
+    return NextResponse.json(
+      { error: "Stripe Checkout n'a pas renvoyé d'URL." },
       { status: 502 },
     )
   }

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -3,22 +3,30 @@ import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { enforceRateLimit } from '@/lib/rate-limit'
 import { stripe } from '@/lib/stripe'
+import { getUserProfileCopineByUserIdAdmin } from '@/lib/supabase/queries/copine-subscriptions'
 
 export const runtime = 'nodejs'
 
 /**
- * POST /api/stripe/portal
+ * POST /api/stripe/portal[?type=copine]
  *
- * Génère une URL Stripe Billing Portal pour gérer son abo (annuler,
- * changer palier/durée, voir factures, mettre à jour la carte).
+ * Génère une URL Stripe Billing Portal pour gérer un abo (annuler,
+ * changer plan, voir factures, mettre à jour la carte).
+ *
+ * Dispatch par query param :
+ *   • default (sans ?type) → flow prestataire (Cercle Pro / Premium /
+ *     Standard) : lookup profiles.stripe_customer_id, return_url vers
+ *     /dashboard/prestataire/fiche
+ *   • ?type=copine → flow Pass Copine : lookup
+ *     user_profiles.copine_stripe_customer_id, return_url vers
+ *     /dashboard/utilisatrice/copine
  *
  * Validations :
- *   1. Auth Supabase
- *   2. profile.stripe_customer_id existe (sinon : pas encore souscrit)
+ *   1. Auth Supabase — 401 sinon
+ *   2. Customer Stripe existe sur la bonne table — 400 sinon (= pas
+ *      encore souscrit)
  *
- * Retourne { url } à utiliser pour window.location.href.
- *
- * Rate-limit : 10/min/utilisatrice.
+ * Rate-limit : 10/min/IP.
  */
 export async function POST(request: Request) {
   const limited = enforceRateLimit(request, {
@@ -36,31 +44,52 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Non authentifiée' }, { status: 401 })
   }
 
-  const admin = createAdminClient()
-  const { data: profile, error: profErr } = await admin
-    .from('profiles')
-    .select('id, user_id, stripe_customer_id')
-    .eq('user_id', user.id)
-    .maybeSingle()
-  if (profErr || !profile) {
-    return NextResponse.json({ error: 'Profil introuvable' }, { status: 404 })
+  const url = new URL(request.url)
+  const flowType = url.searchParams.get('type')
+  const isCopineFlow = flowType === 'copine'
+
+  // Lookup customer_id selon le flow
+  let customerId: string | null
+  if (isCopineFlow) {
+    const userProfile = await getUserProfileCopineByUserIdAdmin(user.id)
+    if (!userProfile) {
+      return NextResponse.json(
+        { error: 'Profil utilisatrice introuvable' },
+        { status: 404 },
+      )
+    }
+    customerId = userProfile.copine_stripe_customer_id
+  } else {
+    const admin = createAdminClient()
+    const { data: profile, error: profErr } = await admin
+      .from('profiles')
+      .select('id, user_id, stripe_customer_id')
+      .eq('user_id', user.id)
+      .maybeSingle()
+    if (profErr || !profile) {
+      return NextResponse.json({ error: 'Profil introuvable' }, { status: 404 })
+    }
+    customerId = profile.stripe_customer_id as string | null
   }
-  const customerId = profile.stripe_customer_id as string | null
+
   if (!customerId) {
     return NextResponse.json(
-      { error: 'Pas encore d\'abonnement actif' },
+      { error: "Pas encore d'abonnement actif" },
       { status: 400 },
     )
   }
 
   const siteUrl =
     process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ?? 'https://www.hilmy.io'
+  const returnUrl = isCopineFlow
+    ? `${siteUrl}/dashboard/utilisatrice/copine`
+    : `${siteUrl}/dashboard/prestataire/fiche`
 
   let session
   try {
     session = await stripe.billingPortal.sessions.create({
       customer: customerId,
-      return_url: `${siteUrl}/dashboard/prestataire/fiche`,
+      return_url: returnUrl,
     })
   } catch (err) {
     console.error('[stripe/portal] sessions.create failed:', err)

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -20,6 +20,8 @@ import {
   setUserProfileCopineStripeCustomerIdAdmin,
   getCopineSubscriptionByStripeIdAdmin,
 } from '@/lib/supabase/queries/copine-subscriptions'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { sendCopineWelcome } from '@/lib/email/transactional'
 import type { SubscriptionStatus } from '@/lib/supabase/types'
 
 export const runtime = 'nodejs'
@@ -502,7 +504,15 @@ async function persistCopineSubscription(
 
   // Propage le flag is_copine sur user_profiles selon le statut.
   if (status === 'active' || status === 'trialing' || status === 'past_due') {
+    // Détection "premier abo" pour le welcome email (Phase 6) : on lit
+    // copine_since AVANT l'update. Si null → c'est la première
+    // activation → on enverra le welcome après setUserProfileCopineActiveAdmin.
+    // (cf décision D2 Phase 6 : check simple, pas de table dédiée).
+    const isFirstActivation = await wasNeverActivatedBefore(userId)
     await setUserProfileCopineActiveAdmin(userId)
+    if (isFirstActivation) {
+      await maybeSendCopineWelcome(userId)
+    }
   } else if (
     status === 'canceled' ||
     status === 'incomplete_expired' ||
@@ -512,4 +522,65 @@ async function persistCopineSubscription(
   }
   // 'incomplete' : pas de change — paiement à finaliser. Stripe
   // re-trigger à completion.
+}
+
+/**
+ * Helper Phase 6 : true si l'utilisatrice n'a JAMAIS été Copine
+ * (copine_since est NULL avant l'UPDATE qui va le set). Sert à gater
+ * l'envoi du welcome email au PREMIER abo uniquement.
+ *
+ * Race condition résiduelle : si Stripe re-trigger l'event en
+ * parallèle, 2 lectures peuvent toutes deux voir NULL et déclencher
+ * 2 emails. À l'échelle actuelle (72 utilisatrices) c'est acceptable
+ * (cf décision D2 Phase 6).
+ */
+async function wasNeverActivatedBefore(userId: string): Promise<boolean> {
+  try {
+    const admin = createAdminClient()
+    const { data, error } = await admin
+      .from('user_profiles')
+      .select('copine_since')
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (error || !data) return false
+    return (data as { copine_since: string | null }).copine_since === null
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Envoie le welcome Copine. Best-effort : log + swallow en cas
+ * d'erreur réseau pour ne pas faire échouer le webhook (Stripe
+ * re-trigger 3-7 jours, ce qui re-déclencherait l'email — pas
+ * souhaitable).
+ *
+ * Récupère email + prénom via admin client (auth.users + user_profiles).
+ */
+async function maybeSendCopineWelcome(userId: string): Promise<void> {
+  try {
+    const admin = createAdminClient()
+    const { data: profile } = await admin
+      .from('user_profiles')
+      .select('prenom')
+      .eq('user_id', userId)
+      .maybeSingle()
+    const { data: authUser } = await admin.auth.admin.getUserById(userId)
+    const email = authUser?.user?.email ?? null
+    if (!email) {
+      console.warn('[stripe/webhook] welcome Copine : pas d\'email pour', userId)
+      return
+    }
+
+    const siteUrl =
+      process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ??
+      'https://www.hilmy.io'
+    await sendCopineWelcome({
+      to: email,
+      prenom: (profile as { prenom: string | null } | null)?.prenom ?? null,
+      dashboardUrl: `${siteUrl}/dashboard/utilisatrice/avantages`,
+    })
+  } catch (err) {
+    console.warn('[stripe/webhook] sendCopineWelcome failed:', err)
+  }
 }

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,12 +1,25 @@
 import { NextResponse } from 'next/server'
 import type Stripe from 'stripe'
-import { stripe, getPaliersAndInterval } from '@/lib/stripe'
+import {
+  stripe,
+  getPaliersAndInterval,
+  isCopinePriceId,
+  getCopinePlan,
+} from '@/lib/stripe'
 import {
   upsertSubscriptionAdmin,
   markSubscriptionCanceledAdmin,
   updateProfilePalierAdmin,
   getSubscriptionByStripeIdAdmin,
 } from '@/lib/supabase/queries/subscriptions'
+import {
+  upsertCopineSubscriptionAdmin,
+  markCopineSubscriptionCanceledAdmin,
+  setUserProfileCopineActiveAdmin,
+  setUserProfileCopineInactiveAdmin,
+  setUserProfileCopineStripeCustomerIdAdmin,
+  getCopineSubscriptionByStripeIdAdmin,
+} from '@/lib/supabase/queries/copine-subscriptions'
 import type { SubscriptionStatus } from '@/lib/supabase/types'
 
 export const runtime = 'nodejs'
@@ -25,6 +38,13 @@ export const runtime = 'nodejs'
  *   - customer.subscription.deleted  → fin de l'abo (downgrade standard)
  *   - invoice.payment_failed         → status='past_due' (Stripe Smart
  *                                      Retries fait le job derrière)
+ *
+ * Dispatch interne Pass Copine (mig 50) :
+ *   Chaque handler vérifie d'abord si l'event concerne un abo Copine
+ *   (metadata.is_copine_sub === 'true' OU price_id ∈ COPINE_PRICE_ID_MAP).
+ *   Si oui → branche Copine (user_profiles + copine_subscriptions).
+ *   Sinon → branche prestataire historique (profiles + subscriptions).
+ *   Le même endpoint webhook gère les deux flows — décision A6 Jiji.
  *
  * Idempotence : Stripe peut re-sender un event 3-7 jours après en cas
  * de timeout. upsertSubscriptionAdmin via ON CONFLICT (stripe_subscription
@@ -99,11 +119,36 @@ export async function POST(request: Request) {
   return NextResponse.json({ received: true }, { status: 200 })
 }
 
+/* ─── Dispatch helpers (Copine vs Prestataire) ─────────────────────── */
+
+/** Vrai si la Checkout Session correspond à un abo Pass Copine. */
+function isCopineSession(session: Stripe.Checkout.Session): boolean {
+  return session.metadata?.is_copine_sub === 'true'
+}
+
+/**
+ * Vrai si la Subscription correspond à un abo Pass Copine. Dispatch
+ * primaire par metadata.is_copine_sub (posée à la création) ; fallback
+ * par price_id si la metadata a été perdue côté Stripe.
+ */
+function isCopineSubscription(sub: Stripe.Subscription): boolean {
+  if (sub.metadata?.is_copine_sub === 'true') return true
+  const priceId = sub.items?.data?.[0]?.price?.id
+  if (priceId && isCopinePriceId(priceId)) return true
+  return false
+}
+
+
 /* ─── Handlers ─────────────────────────────────────────────────────── */
 
 async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
-  // session.subscription est soit string (ID), soit Stripe.Subscription
-  // selon expand. Par défaut c'est l'ID.
+  // Dispatch Copine
+  if (isCopineSession(session)) {
+    await handleCopineCheckoutCompleted(session)
+    return
+  }
+
+  // ─── Flow prestataire (inchangé) ────────────────────────────────
   const subId =
     typeof session.subscription === 'string'
       ? session.subscription
@@ -127,6 +172,13 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
 }
 
 async function handleSubscriptionUpdated(sub: Stripe.Subscription) {
+  // Dispatch Copine
+  if (isCopineSubscription(sub)) {
+    await handleCopineSubscriptionUpdated(sub)
+    return
+  }
+
+  // ─── Flow prestataire (inchangé) ────────────────────────────────
   // metadata.profile_id posé à la création par /api/stripe/checkout dans
   // subscription_data. Si absent (souscription créée hors Hilmy ?), on
   // tente de retrouver via la row existante.
@@ -136,6 +188,13 @@ async function handleSubscriptionUpdated(sub: Stripe.Subscription) {
 }
 
 async function handleSubscriptionDeleted(sub: Stripe.Subscription) {
+  // Dispatch Copine
+  if (isCopineSubscription(sub)) {
+    await handleCopineSubscriptionDeleted(sub)
+    return
+  }
+
+  // ─── Flow prestataire (inchangé) ────────────────────────────────
   const profileId = await resolveProfileId(sub)
   if (!profileId) return
 
@@ -156,6 +215,29 @@ async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
   const subId = typeof sub === 'string' ? sub : sub?.id
   if (!subId) {
     // Pas une invoice d'abonnement — ignorer (one-shot invoices, etc.)
+    return
+  }
+
+  // Dispatch : on tente d'abord côté Copine, puis côté prestataire.
+  // Pas de risque de collision (stripe_subscription_id UNIQUE dans
+  // chaque table, et une sub appartient à une seule des deux).
+  const copineExisting = await getCopineSubscriptionByStripeIdAdmin(subId)
+  if (copineExisting) {
+    await upsertCopineSubscriptionAdmin({
+      user_id: copineExisting.user_id,
+      stripe_customer_id: copineExisting.stripe_customer_id,
+      stripe_subscription_id: copineExisting.stripe_subscription_id,
+      stripe_price_id: copineExisting.stripe_price_id,
+      plan: copineExisting.plan,
+      status: 'past_due',
+      current_period_start: copineExisting.current_period_start,
+      current_period_end: copineExisting.current_period_end,
+      cancel_at_period_end: copineExisting.cancel_at_period_end,
+      canceled_at: copineExisting.canceled_at,
+      ended_at: copineExisting.ended_at,
+    })
+    // past_due : is_copine reste true (Smart Retries en cours). Pas de
+    // setUserProfileCopineInactiveAdmin ici.
     return
   }
 
@@ -264,4 +346,170 @@ async function persistSubscription(
   }
   // 'incomplete' : pas de change palier — l'utilisatrice doit finaliser
   // le payment authorize. Stripe re-trigger à completion.
+}
+
+
+/* ────────────────────────────────────────────────────────────────────
+   Handlers Pass Copine (mig 50)
+
+   Mirror du flow prestataire, mais :
+     • Persiste dans copine_subscriptions (pas subscriptions)
+     • Met à jour user_profiles.is_copine + copine_since (pas
+       profiles.palier)
+     • metadata clé = user_id (pas profile_id)
+   ──────────────────────────────────────────────────────────────────── */
+
+async function handleCopineCheckoutCompleted(
+  session: Stripe.Checkout.Session,
+): Promise<void> {
+  const subId =
+    typeof session.subscription === 'string'
+      ? session.subscription
+      : session.subscription?.id
+  if (!subId) {
+    console.warn(
+      '[stripe/webhook] copine checkout.session.completed sans subscription id',
+    )
+    return
+  }
+
+  const userId = session.metadata?.user_id
+  if (!userId) {
+    console.warn(
+      '[stripe/webhook] copine checkout.session.completed sans user_id en metadata',
+    )
+    return
+  }
+
+  // Persiste copine_stripe_customer_id si le checkout a créé un
+  // nouveau customer côté Stripe et que /api/stripe/checkout n'a pas
+  // réussi à le stocker en BDD (race condition rare). Le call est
+  // idempotent.
+  const customerId =
+    typeof session.customer === 'string' ? session.customer : session.customer?.id
+  if (customerId) {
+    const setRes = await setUserProfileCopineStripeCustomerIdAdmin(
+      userId,
+      customerId,
+    )
+    if (!setRes.ok) {
+      console.warn(
+        '[stripe/webhook] copine setUserProfileCopineStripeCustomerIdAdmin failed:',
+        setRes.error,
+      )
+    }
+  }
+
+  const sub = await stripe.subscriptions.retrieve(subId)
+  await persistCopineSubscription(sub, userId)
+}
+
+async function handleCopineSubscriptionUpdated(
+  sub: Stripe.Subscription,
+): Promise<void> {
+  const userId = await resolveCopineUserId(sub)
+  if (!userId) return
+  await persistCopineSubscription(sub, userId)
+}
+
+async function handleCopineSubscriptionDeleted(
+  sub: Stripe.Subscription,
+): Promise<void> {
+  const userId = await resolveCopineUserId(sub)
+  if (!userId) return
+
+  const canceledAt = sub.canceled_at
+    ? new Date(sub.canceled_at * 1000).toISOString()
+    : null
+  await markCopineSubscriptionCanceledAdmin(sub.id, canceledAt)
+  // Désactive is_copine. copine_since reste préservé (analytics).
+  await setUserProfileCopineInactiveAdmin(userId)
+}
+
+
+/* ─── Utilitaires Copine ────────────────────────────────────────────── */
+
+async function resolveCopineUserId(
+  sub: Stripe.Subscription,
+): Promise<string | null> {
+  const meta = sub.metadata?.user_id
+  if (meta) return meta
+  // Fallback : retrouver via la row existante en BDD
+  const existing = await getCopineSubscriptionByStripeIdAdmin(sub.id)
+  return existing?.user_id ?? null
+}
+
+/**
+ * Persiste une Stripe.Subscription Copine en BDD + propage le flag
+ * is_copine sur user_profiles selon le statut.
+ *
+ * active / trialing / past_due → is_copine = true
+ * canceled / incomplete_expired / unpaid → is_copine = false
+ * incomplete → pas de change (paiement à finaliser)
+ */
+async function persistCopineSubscription(
+  sub: Stripe.Subscription,
+  userId: string,
+): Promise<void> {
+  const item = sub.items?.data?.[0]
+  if (!item?.price?.id) {
+    console.warn(
+      `[stripe/webhook] copine subscription ${sub.id} sans price line item`,
+    )
+    return
+  }
+  const plan = getCopinePlan(item.price.id)
+  if (!plan) {
+    console.warn(
+      `[stripe/webhook] copine price_id non référencé côté serveur: ${item.price.id}`,
+    )
+    return
+  }
+
+  // Stripe v2025+ : current_period_* sur l'item, fallback sub level.
+  const startTs =
+    item.current_period_start ??
+    (sub as unknown as { current_period_start?: number }).current_period_start ??
+    null
+  const endTs =
+    item.current_period_end ??
+    (sub as unknown as { current_period_end?: number }).current_period_end ??
+    null
+  if (startTs == null || endTs == null) {
+    console.warn(
+      `[stripe/webhook] copine subscription ${sub.id} sans period bounds`,
+    )
+    return
+  }
+
+  const status = sub.status as SubscriptionStatus
+  await upsertCopineSubscriptionAdmin({
+    user_id: userId,
+    stripe_customer_id:
+      typeof sub.customer === 'string' ? sub.customer : sub.customer.id,
+    stripe_subscription_id: sub.id,
+    stripe_price_id: item.price.id,
+    plan,
+    status,
+    current_period_start: new Date(startTs * 1000).toISOString(),
+    current_period_end: new Date(endTs * 1000).toISOString(),
+    cancel_at_period_end: sub.cancel_at_period_end ?? false,
+    canceled_at: sub.canceled_at
+      ? new Date(sub.canceled_at * 1000).toISOString()
+      : null,
+    ended_at: sub.ended_at ? new Date(sub.ended_at * 1000).toISOString() : null,
+  })
+
+  // Propage le flag is_copine sur user_profiles selon le statut.
+  if (status === 'active' || status === 'trialing' || status === 'past_due') {
+    await setUserProfileCopineActiveAdmin(userId)
+  } else if (
+    status === 'canceled' ||
+    status === 'incomplete_expired' ||
+    status === 'unpaid'
+  ) {
+    await setUserProfileCopineInactiveAdmin(userId)
+  }
+  // 'incomplete' : pas de change — paiement à finaliser. Stripe
+  // re-trigger à completion.
 }

--- a/app/dashboard/prestataire/avantages/_components/PerkForm.tsx
+++ b/app/dashboard/prestataire/avantages/_components/PerkForm.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { toast } from 'sonner'
+
+type DiscountType = 'percentage' | 'fixed'
+
+/**
+ * Form de création d'une offre Pro Perk.
+ *
+ * POST /api/pro-perks → la route gate côté serveur (Cercle Pro + Zod).
+ * Succès → toast + redirect vers la liste pour voir le perk en
+ * pending_review.
+ *
+ * Validation client minimaliste (title non vide, discount > 0). La
+ * validation autoritaire est côté API route via Zod — on évite de
+ * dupliquer les règles ici, on ne fait que de l'UX guidance.
+ */
+export function PerkForm() {
+  const router = useRouter()
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [discountType, setDiscountType] = useState<DiscountType>('percentage')
+  const [discountValue, setDiscountValue] = useState('')
+  const [conditions, setConditions] = useState('')
+  const [maxUses, setMaxUses] = useState('')
+  const [endsAt, setEndsAt] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (submitting) return
+
+    const parsedValue = Number(discountValue)
+    if (!title.trim()) {
+      toast.error('Donne un titre à ton offre.')
+      return
+    }
+    if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+      toast.error('La valeur de la réduction doit être positive.')
+      return
+    }
+
+    const parsedMaxUses = maxUses.trim() ? Number(maxUses) : null
+    if (parsedMaxUses !== null && (!Number.isInteger(parsedMaxUses) || parsedMaxUses <= 0)) {
+      toast.error('Nombre d\'utilisations max invalide.')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const payload = {
+        title: title.trim(),
+        description: description.trim() || null,
+        discount_type: discountType,
+        discount_value: parsedValue,
+        conditions: conditions.trim() || null,
+        max_uses: parsedMaxUses,
+        ends_at: endsAt ? new Date(endsAt).toISOString() : null,
+      }
+      const res = await fetch('/api/pro-perks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const json = (await res.json().catch(() => null)) as
+        | { ok?: boolean; id?: string; error?: string }
+        | null
+      if (!res.ok || !json?.ok) {
+        toast.error(json?.error ?? 'Impossible de créer ton offre.')
+        setSubmitting(false)
+        return
+      }
+      toast.success('Ton offre est envoyée pour modération.')
+      router.push('/dashboard/prestataire/avantages')
+      router.refresh()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Erreur réseau.')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-md border border-or/20 bg-white p-6 md:p-10"
+    >
+      <div className="space-y-6">
+        <div>
+          <label htmlFor="perk-title" className="overline text-or">
+            Titre de l&apos;offre
+          </label>
+          <input
+            id="perk-title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={80}
+            placeholder="Ex. 15 % sur ton premier soin"
+            required
+            className="mt-2 block w-full rounded-sm border border-or/30 bg-creme/40 px-4 py-3 text-[14px] text-vert placeholder:text-texte-sec/60 focus:border-or focus:outline-none focus:ring-1 focus:ring-or"
+          />
+          <p className="mt-1 text-[11px] text-texte-sec">{title.length}/80</p>
+        </div>
+
+        <div>
+          <label htmlFor="perk-description" className="overline text-or">
+            Description (optionnelle)
+          </label>
+          <textarea
+            id="perk-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            maxLength={300}
+            rows={3}
+            placeholder="Ce que la Copine reçoit en pratique."
+            className="mt-2 block w-full rounded-sm border border-or/30 bg-creme/40 px-4 py-3 text-[14px] text-vert placeholder:text-texte-sec/60 focus:border-or focus:outline-none focus:ring-1 focus:ring-or"
+          />
+          <p className="mt-1 text-[11px] text-texte-sec">{description.length}/300</p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="perk-discount-type" className="overline text-or">
+              Type de réduction
+            </label>
+            <select
+              id="perk-discount-type"
+              value={discountType}
+              onChange={(e) => setDiscountType(e.target.value as DiscountType)}
+              className="mt-2 block w-full rounded-sm border border-or/30 bg-creme/40 px-4 py-3 text-[14px] text-vert focus:border-or focus:outline-none focus:ring-1 focus:ring-or"
+            >
+              <option value="percentage">Pourcentage (%)</option>
+              <option value="fixed">Montant fixe (€)</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="perk-discount-value" className="overline text-or">
+              Valeur {discountType === 'percentage' ? '(%)' : '(€)'}
+            </label>
+            <input
+              id="perk-discount-value"
+              type="number"
+              min="0.01"
+              step="0.01"
+              value={discountValue}
+              onChange={(e) => setDiscountValue(e.target.value)}
+              placeholder={discountType === 'percentage' ? '15' : '20'}
+              required
+              className="mt-2 block w-full rounded-sm border border-or/30 bg-creme/40 px-4 py-3 text-[14px] text-vert focus:border-or focus:outline-none focus:ring-1 focus:ring-or"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="perk-conditions" className="overline text-or">
+            Conditions (optionnel)
+          </label>
+          <textarea
+            id="perk-conditions"
+            value={conditions}
+            onChange={(e) => setConditions(e.target.value)}
+            maxLength={500}
+            rows={2}
+            placeholder="Ex. valable sur les soins de plus de 60 minutes, hors promo."
+            className="mt-2 block w-full rounded-sm border border-or/30 bg-creme/40 px-4 py-3 text-[14px] text-vert placeholder:text-texte-sec/60 focus:border-or focus:outline-none focus:ring-1 focus:ring-or"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="perk-max-uses" className="overline text-or">
+              Nombre d&apos;utilisations max (optionnel)
+            </label>
+            <input
+              id="perk-max-uses"
+              type="number"
+              min="1"
+              step="1"
+              value={maxUses}
+              onChange={(e) => setMaxUses(e.target.value)}
+              placeholder="Illimité si vide"
+              className="mt-2 block w-full rounded-sm border border-or/30 bg-creme/40 px-4 py-3 text-[14px] text-vert focus:border-or focus:outline-none focus:ring-1 focus:ring-or"
+            />
+          </div>
+          <div>
+            <label htmlFor="perk-ends-at" className="overline text-or">
+              Date de fin (optionnelle)
+            </label>
+            <input
+              id="perk-ends-at"
+              type="date"
+              value={endsAt}
+              onChange={(e) => setEndsAt(e.target.value)}
+              className="mt-2 block w-full rounded-sm border border-or/30 bg-creme/40 px-4 py-3 text-[14px] text-vert focus:border-or focus:outline-none focus:ring-1 focus:ring-or"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-10 flex flex-col-reverse items-stretch gap-3 md:flex-row md:items-center md:justify-between">
+        <Link
+          href="/dashboard/prestataire/avantages"
+          className="text-center text-[13px] font-medium text-texte-sec transition-colors hover:text-vert"
+        >
+          ← Annuler
+        </Link>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex items-center justify-center rounded-full bg-or px-8 py-4 text-[13px] font-semibold tracking-[0.18em] text-vert uppercase transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)] disabled:cursor-wait disabled:opacity-70"
+        >
+          {submitting ? 'Envoi…' : 'Envoyer pour modération'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/app/dashboard/prestataire/avantages/_components/PerkOwnerRow.tsx
+++ b/app/dashboard/prestataire/avantages/_components/PerkOwnerRow.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+import type { ProPerk } from '@/lib/supabase/types'
+
+interface PerkOwnerRowProps {
+  perk: ProPerk
+  statusLabel: string
+  statusTone: string
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return new Intl.DateTimeFormat('fr-FR', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  }).format(d)
+}
+
+function discountLabel(perk: ProPerk): string {
+  return perk.discount_type === 'percentage'
+    ? `${perk.discount_value} %`
+    : `${perk.discount_value} €`
+}
+
+export function PerkOwnerRow({ perk, statusLabel, statusTone }: PerkOwnerRowProps) {
+  const router = useRouter()
+  const [busy, setBusy] = useState(false)
+
+  const canPause = perk.status === 'active'
+  const canResume = perk.status === 'paused'
+
+  async function toggleStatus(action: 'pause' | 'resume') {
+    if (busy) return
+    setBusy(true)
+    try {
+      const res = await fetch(`/api/pro-perks/${perk.id}/pause`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action }),
+      })
+      const json = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string }
+        | null
+      if (!res.ok || !json?.ok) {
+        toast.error(json?.error ?? 'Impossible de changer le statut.')
+        setBusy(false)
+        return
+      }
+      toast.success(action === 'pause' ? 'Offre mise en pause.' : 'Offre réactivée.')
+      router.refresh()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Erreur réseau.')
+      setBusy(false)
+    }
+  }
+
+  return (
+    <li className="overflow-hidden rounded-md border border-or/20 bg-white">
+      <div className="flex flex-col gap-4 p-5 md:flex-row md:items-start md:p-6">
+        <div className="flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="font-serif text-[20px] font-light text-vert">
+              {perk.title}
+            </p>
+            <span
+              className={`rounded-full px-2.5 py-0.5 text-[10px] tracking-[0.22em] uppercase ${statusTone}`}
+            >
+              {statusLabel}
+            </span>
+            <span className="rounded-full bg-or/15 px-2.5 py-0.5 text-[10px] tracking-[0.22em] text-or-deep uppercase">
+              {discountLabel(perk)}
+            </span>
+          </div>
+          {perk.description && (
+            <p className="mt-2 text-[13px] leading-[1.6] text-texte-sec">
+              {perk.description}
+            </p>
+          )}
+          <div className="mt-3 flex flex-wrap gap-4 text-[11px] tracking-[0.18em] text-texte-sec uppercase">
+            <span>
+              Utilisations : <span className="text-vert">{perk.used_count}</span>
+              {perk.max_uses ? ` / ${perk.max_uses}` : ' (illimité)'}
+            </span>
+            <span>Début : {formatDate(perk.starts_at)}</span>
+            <span>Fin : {formatDate(perk.ends_at)}</span>
+          </div>
+          {perk.status === 'rejected' && perk.rejection_reason && (
+            <p className="mt-3 rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[12px] text-red-900">
+              Raison du refus : {perk.rejection_reason}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-col gap-2 md:w-40 md:shrink-0">
+          {canPause && (
+            <button
+              type="button"
+              onClick={() => toggleStatus('pause')}
+              disabled={busy}
+              className="inline-flex h-9 items-center justify-center rounded-full border border-or/30 px-4 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-colors hover:border-or hover:bg-creme-deep disabled:opacity-60"
+            >
+              {busy ? '…' : 'Mettre en pause'}
+            </button>
+          )}
+          {canResume && (
+            <button
+              type="button"
+              onClick={() => toggleStatus('resume')}
+              disabled={busy}
+              className="inline-flex h-9 items-center justify-center rounded-full bg-vert px-4 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-colors hover:bg-vert-dark disabled:opacity-60"
+            >
+              {busy ? '…' : 'Réactiver'}
+            </button>
+          )}
+        </div>
+      </div>
+    </li>
+  )
+}

--- a/app/dashboard/prestataire/avantages/nouveau/page.tsx
+++ b/app/dashboard/prestataire/avantages/nouveau/page.tsx
@@ -1,0 +1,46 @@
+import { redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
+import { requirePrestataire } from '@/lib/supabase/session'
+import { hasCerclePro } from '@/lib/permissions'
+import { PerkForm } from '../_components/PerkForm'
+
+export const metadata: Metadata = {
+  title: 'Nouvelle offre Copines',
+}
+
+/**
+ * Page création d'une offre Pro Perk.
+ *
+ * Auth gating : requirePrestataire() redirige déjà vers /onboarding
+ * si pas de fiche. On ajoute un gate hasCerclePro qui redirige vers
+ * la page liste (qui affiche le teasing upgrade).
+ *
+ * Le form est un Client Component (validation + appel API), wrappé
+ * dans un Server Component pour le gating SSR + métadonnées.
+ */
+export default async function NouvelleOffrePage() {
+  const { prestataire } = await requirePrestataire()
+  if (!hasCerclePro(prestataire)) {
+    redirect('/dashboard/prestataire/avantages')
+  }
+
+  return (
+    <div className="min-h-screen bg-creme">
+      <DashboardHeader
+        kicker="Pro Perks"
+        titre={
+          <>
+            Nouvelle <span className="italic text-or">offre Copines</span>
+          </>
+        }
+        lead="Ton offre passera par une modération rapide avant d'apparaître aux Copines."
+      />
+      <section className="px-6 py-10 md:px-12 md:py-14">
+        <div className="mx-auto max-w-2xl">
+          <PerkForm />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/dashboard/prestataire/avantages/page.tsx
+++ b/app/dashboard/prestataire/avantages/page.tsx
@@ -1,0 +1,130 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
+import { GoldLine } from '@/components/ui/GoldLine'
+import { requirePrestataire } from '@/lib/supabase/session'
+import { hasCerclePro } from '@/lib/permissions'
+import { listPerksForPrestataire } from '@/lib/supabase/queries/pro-perks'
+import type { ProPerk, ProPerkStatus } from '@/lib/supabase/types'
+import { PerkOwnerRow } from './_components/PerkOwnerRow'
+
+export const metadata: Metadata = {
+  title: 'Tes offres Copines',
+}
+
+const STATUS_LABEL: Record<ProPerkStatus, string> = {
+  pending_review: 'En attente',
+  active: 'En ligne',
+  paused: 'En pause',
+  expired: 'Expirée',
+  rejected: 'Refusée',
+}
+
+const STATUS_TONE: Record<ProPerkStatus, string> = {
+  pending_review: 'bg-creme text-or-deep',
+  active: 'bg-vert/10 text-vert',
+  paused: 'bg-or/15 text-or-deep',
+  expired: 'bg-texte/10 text-texte-sec',
+  rejected: 'bg-red-900/10 text-red-900',
+}
+
+export default async function PrestataireAvantagesPage() {
+  const { prestataire } = await requirePrestataire()
+  const isCerclePro = hasCerclePro(prestataire)
+
+  if (!isCerclePro) {
+    return (
+      <div className="min-h-screen bg-creme">
+        <DashboardHeader
+          kicker="Pro Perks"
+          titre={
+            <>
+              Tes <span className="italic text-or">offres Copines</span>
+            </>
+          }
+          lead="Crée une réduction pour les Copines. Elles te repèrent, elles viennent."
+        />
+        <section className="px-6 py-10 md:px-12 md:py-14">
+          <div className="mx-auto max-w-2xl rounded-md border border-or/20 bg-white p-10 text-center md:p-14">
+            <GoldLine className="mx-auto" width={48} />
+            <h2 className="mt-6 font-serif text-[28px] font-light leading-tight text-vert md:text-[32px]">
+              Réservé au Cercle Pro.
+            </h2>
+            <p className="mt-5 text-[15px] leading-[1.7] text-texte-sec">
+              Les offres Copines sont réservées au Cercle Pro. C&apos;est le palier
+              qui te met en avant auprès des Copines les plus engagées.
+            </p>
+            <div className="mt-8 flex flex-col items-center gap-3">
+              <Link
+                href="/dashboard/prestataire/abonnement"
+                className="inline-flex items-center justify-center rounded-full bg-or px-8 py-4 text-[14px] font-semibold tracking-[0.18em] text-vert uppercase transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)]"
+              >
+                Passer au Cercle Pro
+              </Link>
+              <Link
+                href="/tarifs"
+                className="text-[12px] font-medium tracking-[0.22em] text-texte-sec uppercase hover:text-vert"
+              >
+                Voir les tarifs
+              </Link>
+            </div>
+          </div>
+        </section>
+      </div>
+    )
+  }
+
+  const { data: perks } = await listPerksForPrestataire(prestataire.id)
+  const list = (perks ?? []) as ProPerk[]
+
+  return (
+    <div className="min-h-screen bg-creme">
+      <DashboardHeader
+        kicker="Pro Perks"
+        titre={
+          <>
+            Tes <span className="italic text-or">offres Copines</span>
+          </>
+        }
+        lead="Crée une réduction pour les Copines. Elles te repèrent, elles viennent."
+        actions={
+          <Link
+            href="/dashboard/prestataire/avantages/nouveau"
+            className="inline-flex items-center justify-center rounded-full bg-vert px-6 py-3 text-[12px] font-semibold tracking-[0.18em] text-creme uppercase transition-colors hover:bg-vert-dark"
+          >
+            Créer une offre
+          </Link>
+        }
+      />
+      <section className="px-6 py-10 md:px-12 md:py-14">
+        {list.length === 0 ? (
+          <div className="mx-auto max-w-2xl rounded-md border border-or/20 bg-white p-10 text-center">
+            <p className="font-serif text-[22px] font-light italic text-vert">
+              Aucune offre pour le moment.
+            </p>
+            <p className="mt-3 text-[14px] text-texte-sec">
+              Lance ta première offre Copines pour te faire repérer.
+            </p>
+            <Link
+              href="/dashboard/prestataire/avantages/nouveau"
+              className="mt-6 inline-flex items-center justify-center rounded-full bg-or px-6 py-3 text-[12px] font-semibold tracking-[0.18em] text-vert uppercase hover:bg-or-light"
+            >
+              Créer une offre
+            </Link>
+          </div>
+        ) : (
+          <ul className="space-y-4">
+            {list.map((perk) => (
+              <PerkOwnerRow
+                key={perk.id}
+                perk={perk}
+                statusLabel={STATUS_LABEL[perk.status]}
+                statusTone={STATUS_TONE[perk.status]}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/app/dashboard/prestataire/layout.tsx
+++ b/app/dashboard/prestataire/layout.tsx
@@ -67,6 +67,14 @@ export default async function PrestataireLayout({
           },
         ] as SidebarItem[])
       : []),
+    // Pro Perks (mig 50). Item toujours visible (cf décision D8
+    // Phase 5) : levier de conversion vers Cercle Pro pour les
+    // Standard/Premium qui découvrent la feature.
+    {
+      href: '/dashboard/prestataire/avantages',
+      label: 'Mes offres Copines',
+      icon: '★',
+    },
     {
       href: '/dashboard/prestataire/abonnement',
       label: 'Mon abonnement',

--- a/app/dashboard/utilisatrice/avantages/_components/PerkClaimButton.tsx
+++ b/app/dashboard/utilisatrice/avantages/_components/PerkClaimButton.tsx
@@ -15,7 +15,7 @@ interface PerkClaimButtonProps {
  * Bouton de claim d'un Pro Perk pour une Copine.
  *
  * 3 états :
- *   - Non-Copine → bouton désactivé + CTA "Devenir Copine"
+ *   - Non-Copine → bouton désactivé + CTA "Je prends mon Pass"
  *   - Copine + pas encore claim → bouton "Récupérer mon code"
  *   - Copine + déjà claim → affiche le code HILMY-XXXX-YYYY + bouton
  *     "Marquer comme utilisé" si pas encore marqué
@@ -38,7 +38,7 @@ export function PerkClaimButton({
         href="/pass-copine"
         className="block w-full rounded-full bg-vert px-6 py-3 text-center text-[12px] font-semibold tracking-[0.18em] text-creme uppercase transition-colors hover:bg-vert-dark"
       >
-        Devenir Copine
+        Je prends mon Pass
       </Link>
     )
   }

--- a/app/dashboard/utilisatrice/avantages/_components/PerkClaimButton.tsx
+++ b/app/dashboard/utilisatrice/avantages/_components/PerkClaimButton.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { toast } from 'sonner'
+import type { ProPerkClaim } from '@/lib/supabase/types'
+
+interface PerkClaimButtonProps {
+  perkId: string
+  isCopine: boolean
+  initialClaim: ProPerkClaim | null
+}
+
+/**
+ * Bouton de claim d'un Pro Perk pour une Copine.
+ *
+ * 3 états :
+ *   - Non-Copine → bouton désactivé + CTA "Devenir Copine"
+ *   - Copine + pas encore claim → bouton "Récupérer mon code"
+ *   - Copine + déjà claim → affiche le code HILMY-XXXX-YYYY + bouton
+ *     "Marquer comme utilisé" si pas encore marqué
+ *
+ * Les codes sont générés server-side (crypto.randomBytes) et insérés
+ * via /api/pro-perks/[id]/claim. L'idempotence est gérée côté serveur
+ * (UNIQUE perk_id × user_id) : un 2e POST retourne le code existant.
+ */
+export function PerkClaimButton({
+  perkId,
+  isCopine,
+  initialClaim,
+}: PerkClaimButtonProps) {
+  const [claim, setClaim] = useState<ProPerkClaim | null>(initialClaim)
+  const [busy, setBusy] = useState(false)
+
+  if (!isCopine) {
+    return (
+      <Link
+        href="/pass-copine"
+        className="block w-full rounded-full bg-vert px-6 py-3 text-center text-[12px] font-semibold tracking-[0.18em] text-creme uppercase transition-colors hover:bg-vert-dark"
+      >
+        Devenir Copine
+      </Link>
+    )
+  }
+
+  async function handleClaim() {
+    if (busy || claim) return
+    setBusy(true)
+    try {
+      const res = await fetch(`/api/pro-perks/${perkId}/claim`, {
+        method: 'POST',
+      })
+      const json = (await res.json().catch(() => null)) as
+        | {
+            ok?: boolean
+            code?: string
+            claim_id?: string
+            already_claimed?: boolean
+            error?: string
+          }
+        | null
+      if (!res.ok || !json?.ok || !json.code) {
+        toast.error(json?.error ?? 'Impossible de récupérer ton code.')
+        setBusy(false)
+        return
+      }
+      setClaim({
+        id: json.claim_id ?? '',
+        perk_id: perkId,
+        user_id: '',
+        code_displayed: json.code,
+        marked_used_at: null,
+        created_at: new Date().toISOString(),
+      })
+      toast.success(
+        json.already_claimed ? 'Voici ton code.' : 'Ton code est prêt.',
+      )
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Erreur réseau.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleMarkUsed() {
+    if (busy || !claim || claim.marked_used_at) return
+    setBusy(true)
+    try {
+      const res = await fetch(`/api/pro-perks/${perkId}/claim`, {
+        method: 'PATCH',
+      })
+      const json = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string }
+        | null
+      if (!res.ok || !json?.ok) {
+        toast.error(json?.error ?? 'Impossible de marquer comme utilisé.')
+        setBusy(false)
+        return
+      }
+      setClaim({ ...claim, marked_used_at: new Date().toISOString() })
+      toast.success('Marqué comme utilisé.')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Erreur réseau.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (claim) {
+    return (
+      <div className="space-y-3">
+        <div className="rounded-md border border-or/40 bg-creme p-4 text-center">
+          <p className="text-[10px] font-medium tracking-[0.22em] text-or-deep uppercase">
+            Ton code
+          </p>
+          <p
+            className="mt-2 font-mono text-[18px] font-semibold tracking-[0.18em] text-vert"
+            aria-label={`Code de réduction ${claim.code_displayed}`}
+          >
+            {claim.code_displayed}
+          </p>
+          {claim.marked_used_at && (
+            <p className="mt-2 text-[11px] italic text-texte-sec">
+              Marqué utilisé.
+            </p>
+          )}
+        </div>
+        {!claim.marked_used_at && (
+          <button
+            type="button"
+            onClick={handleMarkUsed}
+            disabled={busy}
+            className="block w-full rounded-full border border-or/30 px-6 py-3 text-[12px] font-medium tracking-[0.22em] text-vert uppercase transition-colors hover:border-or hover:bg-creme-deep disabled:opacity-60"
+          >
+            {busy ? '…' : 'Marquer comme utilisé'}
+          </button>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClaim}
+      disabled={busy}
+      className="block w-full rounded-full bg-or px-6 py-3 text-[12px] font-semibold tracking-[0.18em] text-vert uppercase transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)] disabled:cursor-wait disabled:opacity-70"
+    >
+      {busy ? '…' : 'Récupérer mon code'}
+    </button>
+  )
+}

--- a/app/dashboard/utilisatrice/avantages/page.tsx
+++ b/app/dashboard/utilisatrice/avantages/page.tsx
@@ -1,0 +1,166 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
+import { GoldLine } from '@/components/ui/GoldLine'
+import { requireUserProfile } from '@/lib/supabase/session'
+import { createClient } from '@/lib/supabase/server'
+import {
+  listActivePerks,
+  listMyClaims,
+  type ActivePerkWithPrestataire,
+} from '@/lib/supabase/queries/pro-perks'
+import type { ProPerkClaim } from '@/lib/supabase/types'
+import { PerkClaimButton } from './_components/PerkClaimButton'
+
+export const metadata: Metadata = {
+  title: 'Tes avantages Copine',
+}
+
+function discountLabel(perk: ActivePerkWithPrestataire): string {
+  return perk.discount_type === 'percentage'
+    ? `${perk.discount_value} % de réduction`
+    : `${perk.discount_value} € de réduction`
+}
+
+function formatEndsAt(iso: string | null): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return `Valable jusqu'au ${new Intl.DateTimeFormat('fr-FR', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  }).format(d)}`
+}
+
+export default async function UtilisatriceAvantagesPage() {
+  // requireUserProfile gère déjà l'auth + redirect onboarding ;
+  // on ne fetch is_copine que pour adapter UX (claim vs teasing).
+  const { user } = await requireUserProfile()
+  const supabase = await createClient()
+  const { data: profileRow } = await supabase
+    .from('user_profiles')
+    .select('is_copine')
+    .eq('user_id', user.id)
+    .maybeSingle()
+  const isCopine = profileRow?.is_copine ?? false
+
+  const { data: perks } = await listActivePerks()
+  const list = (perks ?? []) as ActivePerkWithPrestataire[]
+
+  // Claims existants — pour afficher "Déjà claim → code XXXX" sans
+  // refaire un POST. Skip pour les non-Copines (RLS retournera [] de
+  // toute façon, mais on évite le round-trip).
+  let claimsByPerkId = new Map<string, ProPerkClaim>()
+  if (isCopine) {
+    const { data: claims } = await listMyClaims()
+    claimsByPerkId = new Map(
+      ((claims ?? []) as ProPerkClaim[]).map((c) => [c.perk_id, c]),
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-creme">
+      <DashboardHeader
+        kicker={isCopine ? 'Tes avantages Copine' : 'Les avantages Copine'}
+        titre={
+          isCopine ? (
+            <>
+              Tes <span className="italic text-or">avantages Copine</span>
+            </>
+          ) : (
+            <>
+              Les <span className="italic text-or">avantages Copine</span>
+            </>
+          )
+        }
+        lead={
+          isCopine
+            ? "Les pros qu'on adore te font des prix. Profites-en."
+            : 'Les Copines ont des réductions chez les pros. Rejoins-les pour en profiter.'
+        }
+        actions={
+          isCopine ? undefined : (
+            <Link
+              href="/pass-copine"
+              className="inline-flex items-center justify-center rounded-full bg-or px-6 py-3 text-[12px] font-semibold tracking-[0.18em] text-vert uppercase transition-colors hover:bg-or-light"
+            >
+              Devenir Copine
+            </Link>
+          )
+        }
+      />
+      <section className="px-6 py-10 md:px-12 md:py-14">
+        {list.length === 0 ? (
+          <div className="mx-auto max-w-2xl rounded-md border border-or/20 bg-white p-10 text-center">
+            <GoldLine className="mx-auto" width={48} />
+            <p className="mt-6 font-serif text-[22px] font-light italic text-vert">
+              Bientôt des offres ici.
+            </p>
+            <p className="mt-3 text-[14px] text-texte-sec">
+              Les prestataires Cercle Pro lancent leurs premières offres
+              — repasse vite.
+            </p>
+          </div>
+        ) : (
+          <ul className="grid grid-cols-1 gap-5 md:grid-cols-2">
+            {list.map((perk) => {
+              const existingClaim = claimsByPerkId.get(perk.id)
+              const endsLabel = formatEndsAt(perk.ends_at)
+              return (
+                <li
+                  key={perk.id}
+                  className="flex h-full flex-col rounded-md border border-or/20 bg-white p-6 md:p-8"
+                >
+                  <div className="flex flex-wrap items-baseline gap-2">
+                    <span className="rounded-full bg-or/15 px-2.5 py-0.5 text-[10px] font-semibold tracking-[0.22em] text-or-deep uppercase">
+                      {discountLabel(perk)}
+                    </span>
+                    {perk.prestataire?.categorie && (
+                      <span className="text-[11px] tracking-[0.18em] text-texte-sec uppercase">
+                        {perk.prestataire.categorie}
+                      </span>
+                    )}
+                  </div>
+                  <h3 className="mt-4 font-serif text-[22px] font-light leading-tight text-vert">
+                    {perk.title}
+                  </h3>
+                  {perk.prestataire && (
+                    <p className="mt-1 text-[12px] tracking-[0.18em] text-or-deep uppercase">
+                      {perk.prestataire.nom}
+                      {perk.prestataire.ville
+                        ? ` · ${perk.prestataire.ville}`
+                        : ''}
+                    </p>
+                  )}
+                  {perk.description && (
+                    <p className="mt-3 text-[14px] leading-[1.65] text-texte-sec">
+                      {perk.description}
+                    </p>
+                  )}
+                  {perk.conditions && (
+                    <p className="mt-3 text-[12px] italic leading-[1.6] text-texte-sec">
+                      Conditions : {perk.conditions}
+                    </p>
+                  )}
+                  {endsLabel && (
+                    <p className="mt-2 text-[11px] tracking-[0.18em] text-texte-sec uppercase">
+                      {endsLabel}
+                    </p>
+                  )}
+                  <div className="mt-auto pt-6">
+                    <PerkClaimButton
+                      perkId={perk.id}
+                      isCopine={isCopine}
+                      initialClaim={existingClaim ?? null}
+                    />
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/app/dashboard/utilisatrice/avantages/page.tsx
+++ b/app/dashboard/utilisatrice/avantages/page.tsx
@@ -85,7 +85,7 @@ export default async function UtilisatriceAvantagesPage() {
               href="/pass-copine"
               className="inline-flex items-center justify-center rounded-full bg-or px-6 py-3 text-[12px] font-semibold tracking-[0.18em] text-vert uppercase transition-colors hover:bg-or-light"
             >
-              Devenir Copine
+              Je prends mon Pass
             </Link>
           )
         }

--- a/app/dashboard/utilisatrice/copine/page.tsx
+++ b/app/dashboard/utilisatrice/copine/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
+import { CopineSubscriptionStatus } from '@/components/pass-copine/CopineSubscriptionStatus'
+import { getActiveCopineSubscription } from '@/lib/supabase/queries/copine-subscriptions'
+
+export const metadata: Metadata = {
+  title: 'Ton Pass Copine',
+}
+
+/**
+ * Page gestion du Pass Copine.
+ *
+ * Auth gating : le layout parent (utilisatrice/layout.tsx) appelle déjà
+ * requireUserProfile() qui redirige vers /auth/login si non connectée
+ * et vers /onboarding si profil incomplet. Donc ici on a forcément un
+ * user + user_profile.
+ *
+ * Si is_copine=false → redirect vers la landing /pass-copine. La source
+ * de vérité est user_profiles.is_copine (mirror dénormalisé maintenu
+ * par le webhook).
+ *
+ * Détails du plan (4,99€/mois ou 49€/an, date de renouvellement,
+ * cancel_at_period_end) lus depuis copine_subscriptions via le helper
+ * RLS-safe getActiveCopineSubscription().
+ */
+export default async function PassCopineGestionPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  // Belt-and-braces : le layout parent l'a déjà fait, on garde une
+  // garde explicite ici pour clarté et pour gérer le cas (rare) où le
+  // user_profile n'aurait pas encore la colonne is_copine peuplée.
+  if (!user) redirect('/auth/login')
+
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('is_copine, copine_since')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (!profile?.is_copine) {
+    redirect('/pass-copine')
+  }
+
+  const { data: sub } = await getActiveCopineSubscription()
+
+  return (
+    <div className="min-h-screen bg-creme">
+      <DashboardHeader
+        kicker="Pass Copine"
+        titre={
+          <>
+            Ton <span className="italic text-or">Pass Copine</span>
+          </>
+        }
+        lead="Gère ton abonnement, change de plan ou annule quand tu veux. Tu restes maîtresse de la suite."
+      />
+      <CopineSubscriptionStatus
+        copineSince={profile.copine_since}
+        plan={sub?.plan ?? null}
+        currentPeriodEnd={sub?.current_period_end ?? null}
+        cancelAtPeriodEnd={sub?.cancel_at_period_end ?? false}
+      />
+    </div>
+  )
+}

--- a/app/dashboard/utilisatrice/layout.tsx
+++ b/app/dashboard/utilisatrice/layout.tsx
@@ -50,6 +50,13 @@ export default async function UtilisatriceLayout({
       label: isCopine ? 'Mon Pass Copine' : 'Devenir Copine',
       icon: '★',
     },
+    // Pro Perks (mig 50). Visible pour toutes — la page elle-même
+    // adapte l'UX (Copine = claim, non-Copine = teasing).
+    {
+      href: '/dashboard/utilisatrice/avantages',
+      label: isCopine ? 'Mes avantages' : 'Avantages Copines',
+      icon: '◉',
+    },
     { href: '/dashboard/utilisatrice/profil', label: 'Mon profil', icon: '❋' },
     {
       href: '/dashboard/utilisatrice/parametres',

--- a/app/dashboard/utilisatrice/layout.tsx
+++ b/app/dashboard/utilisatrice/layout.tsx
@@ -1,6 +1,7 @@
 import { Toaster } from 'sonner'
 import { Sidebar, type SidebarItem } from '@/components/dashboard/Sidebar'
 import { requireUserProfile } from '@/lib/supabase/session'
+import { createClient } from '@/lib/supabase/server'
 
 export default async function UtilisatriceLayout({
   children,
@@ -9,6 +10,17 @@ export default async function UtilisatriceLayout({
 }) {
   const { user, profile } = await requireUserProfile()
   const isAdmin = Boolean(user.user_metadata?.is_admin)
+
+  // Pass Copine fast-path : lookup is_copine pour personnaliser le label
+  // sidebar (Devenir Copine vs Mon Pass Copine) et afficher le badge sur
+  // le UserBlock.
+  const supabase = await createClient()
+  const { data: copineRow } = await supabase
+    .from('user_profiles')
+    .select('is_copine')
+    .eq('user_id', user.id)
+    .maybeSingle()
+  const isCopine = copineRow?.is_copine ?? false
 
   const items: SidebarItem[] = [
     { href: '/dashboard/utilisatrice', label: 'Accueil', icon: '·' },
@@ -32,6 +44,11 @@ export default async function UtilisatriceLayout({
       href: '/dashboard/utilisatrice/evenements',
       label: 'Mes événements',
       icon: '◇',
+    },
+    {
+      href: isCopine ? '/dashboard/utilisatrice/copine' : '/pass-copine',
+      label: isCopine ? 'Mon Pass Copine' : 'Devenir Copine',
+      icon: '★',
     },
     { href: '/dashboard/utilisatrice/profil', label: 'Mon profil', icon: '❋' },
     {
@@ -66,6 +83,7 @@ export default async function UtilisatriceLayout({
           prenom: profile.prenom,
           avatar: profile.avatar_url ?? '#D4C5B0',
           meta: `Membre depuis ${memberSince}`,
+          badge: isCopine ? 'Copine' : undefined,
         }}
         signOutLabel="À bientôt"
       />

--- a/app/dashboard/utilisatrice/layout.tsx
+++ b/app/dashboard/utilisatrice/layout.tsx
@@ -12,7 +12,7 @@ export default async function UtilisatriceLayout({
   const isAdmin = Boolean(user.user_metadata?.is_admin)
 
   // Pass Copine fast-path : lookup is_copine pour personnaliser le label
-  // sidebar (Devenir Copine vs Mon Pass Copine) et afficher le badge sur
+  // sidebar (Mon Pass vs Mon Pass Copine) et afficher le badge sur
   // le UserBlock.
   const supabase = await createClient()
   const { data: copineRow } = await supabase
@@ -47,7 +47,7 @@ export default async function UtilisatriceLayout({
     },
     {
       href: isCopine ? '/dashboard/utilisatrice/copine' : '/pass-copine',
-      label: isCopine ? 'Mon Pass Copine' : 'Devenir Copine',
+      label: isCopine ? 'Mon Pass Copine' : 'Mon Pass',
       icon: '★',
     },
     // Pro Perks (mig 50). Visible pour toutes — la page elle-même

--- a/app/evenement-v2/[slug]/page.tsx
+++ b/app/evenement-v2/[slug]/page.tsx
@@ -57,6 +57,7 @@ function adaptDbEventForCard(ev: HilmyEvent): MockEvenement {
     flyer: ev.flyer_url ?? null,
     places: ev.places_max ?? 20,
     inscrites: ev.inscrites_count ?? 0,
+    early_access_until: ev.early_access_until,
   }
 }
 
@@ -82,6 +83,7 @@ export default async function EvenementV2Page({
 
   // Inscription status (si user connectée)
   let isInscrite = false
+  let isCopine = false
   if (user) {
     const { data: ins } = await supabase
       .from('event_inscriptions')
@@ -90,6 +92,15 @@ export default async function EvenementV2Page({
       .eq('user_id', user.id)
       .maybeSingle()
     isInscrite = ins?.status === 'inscrite'
+    // Pass Copine (mig 50) — drive le client gate du paywall events
+    // accès anticipé. Le check defense-in-depth tourne aussi côté
+    // /api/events/[id]/inscription.
+    const { data: copineRow } = await supabase
+      .from('user_profiles')
+      .select('is_copine')
+      .eq('user_id', user.id)
+      .maybeSingle()
+    isCopine = copineRow?.is_copine ?? false
   }
 
   const isOwner = !!user && user.id === ev.user_id
@@ -214,6 +225,8 @@ export default async function EvenementV2Page({
                   variant="solid"
                   registrationMode={ev.registration_mode ?? 'internal'}
                   externalUrl={ev.external_signup_url}
+                  earlyAccessUntil={ev.early_access_until}
+                  isCopine={isCopine}
                 />
                 <FavoriteButton
                   itemType="evenement"
@@ -374,6 +387,8 @@ export default async function EvenementV2Page({
                     variant="outline"
                     registrationMode={ev.registration_mode ?? 'internal'}
                     externalUrl={ev.external_signup_url}
+                    earlyAccessUntil={ev.early_access_until}
+                    isCopine={isCopine}
                   />
                 </div>
               </div>

--- a/app/evenements-v2/page.tsx
+++ b/app/evenements-v2/page.tsx
@@ -85,6 +85,7 @@ function adaptEvenementFromDb(e: DbEventWithCategory): MockEvenement {
     seasonal_category: seasonal
       ? { slug: seasonal.slug, label: seasonal.label, emoji: seasonal.emoji }
       : null,
+    early_access_until: e.early_access_until,
   }
 }
 
@@ -141,7 +142,7 @@ function EvenementsV2PageInner() {
               // mig 46 PR-F : event_seasonal_category_id + LEFT JOIN
               // event_seasonal_categories (relation auto-détectée par PostgREST
               // via la FK). Le LEFT JOIN renvoie null si pas de catégorie.
-              'id, user_id, prestataire_id, title, slug, description, event_type, format, visibility, start_date, end_date, country, region, city, address, online_link, flyer_url, external_signup_url, price_type, price_amount, price_currency, places_max, inscrites_count, status, created_at, updated_at, event_seasonal_category_id, event_seasonal_category:event_seasonal_categories(id, slug, label, emoji)',
+              'id, user_id, prestataire_id, title, slug, description, event_type, format, visibility, start_date, end_date, country, region, city, address, online_link, flyer_url, external_signup_url, price_type, price_amount, price_currency, places_max, inscrites_count, status, early_access_until, created_at, updated_at, event_seasonal_category_id, event_seasonal_category:event_seasonal_categories(id, slug, label, emoji)',
             )
             .eq('status', 'published')
             .gte('start_date', now)

--- a/app/je-cherche/[id]/_components/ResponseRow.tsx
+++ b/app/je-cherche/[id]/_components/ResponseRow.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { formatRelativeTime } from '@/lib/format-relative-time'
 import { toggleThanksAction } from '@/app/je-cherche/_actions'
 import { SignalementModal } from '@/components/je-cherche/SignalementModal'
+import { MemberName } from '@/components/badges/MemberName'
 import type { DemandeResponseWithProfile } from '@/lib/types/je-cherche'
 
 interface Props {
@@ -63,7 +64,11 @@ export function ResponseRow({ response, demandeId, thanked, isOwn }: Props) {
           </div>
           <div className="min-w-0 flex-1">
             <p className="text-[13px] font-medium text-vert">
-              {response.author_prenom ?? 'Une copine'}
+              <MemberName
+                prenom={response.author_prenom}
+                isCopine={response.author_is_copine}
+                copineSince={response.author_copine_since}
+              />
             </p>
             <p className="text-[11px] text-texte-sec">
               {formatRelativeTime(response.created_at)}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { Navigation } from '@/components/landing/Navigation'
+import { NavigationServer } from '@/components/landing/NavigationServer'
 import { HeroV2 } from '@/components/landing/HeroV2'
 import { StartingPoint } from '@/components/landing/StartingPoint'
 import { ThreePromises } from '@/components/landing/ThreePromises'
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
 export default function HomePage() {
   return (
     <div className="min-h-screen overflow-x-hidden bg-creme text-texte">
-      <Navigation />
+      <NavigationServer />
       <main>
         <HeroV2 />
         <StartingPoint />

--- a/app/pass-copine/page.tsx
+++ b/app/pass-copine/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { NavigationServer } from '@/components/landing/NavigationServer'
+import { FooterV2 } from '@/components/landing/FooterV2'
+import { PassCopineHero } from '@/components/pass-copine/PassCopineHero'
+import { FeaturesList } from '@/components/pass-copine/FeaturesList'
+import { PricingCards } from '@/components/pass-copine/PricingCards'
+
+export const metadata: Metadata = {
+  title: 'Pass Copine',
+  description:
+    "Le Pass Copine Hilmy — favoris illimités, accès anticipé aux Rendez-vous, coupons Cercle Pro, badge Copine et newsletter premium de Sara. 4,99 €/mois ou 49 €/an.",
+  alternates: { canonical: '/pass-copine' },
+  openGraph: {
+    title: 'Le Pass Copine — Hilmy',
+    description:
+      "Tu fais déjà partie de la team. Le Pass, c'est juste pour aller plus loin.",
+    url: '/pass-copine',
+    type: 'website',
+  },
+}
+
+/**
+ * Landing publique du Pass Copine.
+ *
+ * Si la user est déjà Copine (is_copine=true), on redirige vers la page
+ * gestion — pas besoin de lui montrer une page d'incitation. Phase 2 a
+ * câblé toutes les URLs Stripe vers /dashboard/utilisatrice/copine, on
+ * reste cohérent.
+ */
+export default async function PassCopinePage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (user) {
+    const { data } = await supabase
+      .from('user_profiles')
+      .select('is_copine')
+      .eq('user_id', user.id)
+      .maybeSingle()
+    if (data?.is_copine) {
+      redirect('/dashboard/utilisatrice/copine')
+    }
+  }
+
+  return (
+    <>
+      <NavigationServer variant="solid" />
+      <main className="min-h-screen bg-creme text-texte">
+        <PassCopineHero />
+        <FeaturesList />
+        <PricingCards />
+      </main>
+      <FooterV2 />
+    </>
+  )
+}

--- a/app/prestataires/[slug]/page.tsx
+++ b/app/prestataires/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import Image from 'next/image'
-import { Navigation } from '@/components/landing/Navigation'
+import { NavigationServer } from '@/components/landing/NavigationServer'
 import { FooterV2 } from '@/components/landing/FooterV2'
 import { GoldLine } from '@/components/ui/GoldLine'
 import { CardOverlayGated } from '@/components/v2/CardOverlayGated'
@@ -128,7 +128,7 @@ export default async function PrestatairePage({
 
   return (
     <div className="min-h-screen bg-creme text-texte">
-      <Navigation variant="solid" />
+      <NavigationServer variant="solid" />
 
       {/* Hero */}
       <header className="pt-28 pb-8 md:pt-36 md:pb-12">

--- a/app/recommandation/[slug]/page.tsx
+++ b/app/recommandation/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { PageShell } from '@/components/v2/PageShell'
 import { FavoriteButton } from '@/components/v2/FavoriteButton'
 import { TrackPlaceView } from '@/components/v2/TrackPlaceView'
 import { PlaceContactLink } from '@/components/v2/PlaceContactLink'
+import { MemberName } from '@/components/badges/MemberName'
 import { GoldLine } from '@/components/ui/GoldLine'
 import { FadeInSection } from '@/components/ui/FadeInSection'
 import { LieuCard } from '@/components/v2/LieuCard'
@@ -39,6 +40,9 @@ type RecoView = {
   /** Statut gamif (mig 16 + backfill mig 48). NULL si user n'a aucun
    *  point cumulé (= jamais publié de reco/event au moment du fetch). */
   statut: GamificationStatut | null
+  /** Pass Copine (mig 50, Phase 6) — drive le badge `<MemberName>`. */
+  isCopine: boolean | null
+  copineSince: string | null
 }
 
 const AVATAR_PALETTE = ['#B8C7B0', '#D9C9A8', '#C4B8D4', '#E8C5B5', '#A8C4C9', '#D4B8A8']
@@ -130,20 +134,37 @@ export default async function RecommandationPage({
   const { data: recos } = await getRecommendationsByPlace(row.id)
   const recoRows = (recos ?? []) as Recommendation[]
   const userIds = Array.from(new Set(recoRows.map((r) => r.user_id)))
-  const profilesById = new Map<string, { prenom: string }>()
+  const profilesById = new Map<
+    string,
+    {
+      prenom: string
+      is_copine: boolean | null
+      copine_since: string | null
+    }
+  >()
   // Pré-fetch gamif batch (Sprint U1.5) — 1 RPC sur la vue user_gamification
   // pour tous les auteurs en parallèle des prenoms. RLS authenticated read OK.
+  // Phase 6 : on ajoute is_copine + copine_since pour le badge MemberName.
   let gamifByUser = new Map<string, { statut: GamificationStatut }>()
   if (userIds.length > 0) {
     const [{ data: profs }, gamifMap] = await Promise.all([
       supabase
         .from('user_profiles')
-        .select('user_id, prenom')
+        .select('user_id, prenom, is_copine, copine_since')
         .in('user_id', userIds),
       getUserGamificationByUserIds(userIds),
     ])
-    for (const p of (profs ?? []) as { user_id: string; prenom: string }[]) {
-      profilesById.set(p.user_id, { prenom: p.prenom })
+    for (const p of (profs ?? []) as Array<{
+      user_id: string
+      prenom: string
+      is_copine: boolean | null
+      copine_since: string | null
+    }>) {
+      profilesById.set(p.user_id, {
+        prenom: p.prenom,
+        is_copine: p.is_copine ?? null,
+        copine_since: p.copine_since ?? null,
+      })
     }
     // On ne garde que le statut côté view-model (le reste pas utile ici)
     gamifByUser = new Map(
@@ -154,9 +175,10 @@ export default async function RecommandationPage({
     const rawTags = r.tags ?? []
     const diets = rawTags.filter((t) => t in DIET_TAGS_MAP).map((t) => dietTagLabel(t))
     const tags = rawTags.filter((t) => !(t in DIET_TAGS_MAP)).map((t) => recTagLabel(t))
+    const profile = profilesById.get(r.user_id)
     return {
       id: r.id,
-      prenom: profilesById.get(r.user_id)?.prenom ?? 'Une copine',
+      prenom: profile?.prenom ?? 'Une copine',
       avatar: avatarFor(r.user_id),
       date: relativeDate(r.created_at),
       rating: r.rating,
@@ -166,6 +188,8 @@ export default async function RecommandationPage({
       priceIndicator: r.price_indicator,
       photos: r.photo_urls ?? [],
       statut: gamifByUser.get(r.user_id)?.statut ?? null,
+      isCopine: profile?.is_copine ?? null,
+      copineSince: profile?.copine_since ?? null,
     }
   })
 
@@ -308,7 +332,11 @@ export default async function RecommandationPage({
                         />
                         <div>
                           <p className="text-[14px] font-medium text-vert">
-                            {r.prenom}
+                            <MemberName
+                              prenom={r.prenom}
+                              isCopine={r.isCopine}
+                              copineSince={r.copineSince}
+                            />
                             {r.statut && (
                               <span
                                 className={`ml-1.5 font-serif text-[13px] italic font-light ${
@@ -456,7 +484,12 @@ export default async function RecommandationPage({
                           style={{ background: r.avatar }}
                         />
                         <span className="text-[12px] font-medium text-vert">
-                          {r.prenom}
+                          <MemberName
+                            prenom={r.prenom}
+                            isCopine={r.isCopine}
+                            copineSince={r.copineSince}
+                            badgeSize={10}
+                          />
                           {r.statut && (
                             <span
                               className={`ml-1 font-serif text-[11px] italic font-light ${

--- a/components/badges/CopineBadge.tsx
+++ b/components/badges/CopineBadge.tsx
@@ -1,0 +1,43 @@
+import { Star } from 'lucide-react'
+
+interface CopineBadgeProps {
+  copineSince: Date | string | null
+  /** Taille icône en px. */
+  size?: number
+  className?: string
+}
+
+function formatMonthYear(value: Date | string): string {
+  const d = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  return new Intl.DateTimeFormat('fr-FR', {
+    month: 'long',
+    year: 'numeric',
+  }).format(d)
+}
+
+/**
+ * Badge Copine — étoile or + tooltip natif.
+ *
+ * Affiche rien si copineSince est null (user non Copine ou copine_since
+ * jamais set). Pas de tooltip lib externe : title HTML natif suffit
+ * pour ce micro-affordance.
+ */
+export function CopineBadge({
+  copineSince,
+  size = 14,
+  className = '',
+}: CopineBadgeProps) {
+  if (!copineSince) return null
+  const since = formatMonthYear(copineSince)
+  const label = since ? `Copine Hilmy depuis ${since}` : 'Copine Hilmy'
+  return (
+    <span
+      title={label}
+      aria-label={label}
+      className={`inline-flex items-center justify-center text-or ${className}`}
+    >
+      <Star size={size} strokeWidth={1.75} fill="currentColor" aria-hidden="true" />
+    </span>
+  )
+}

--- a/components/badges/MemberName.tsx
+++ b/components/badges/MemberName.tsx
@@ -1,0 +1,47 @@
+import { CopineBadge } from './CopineBadge'
+
+interface MemberNameProps {
+  prenom: string | null
+  /** Si true, rend le CopineBadge (icône or) à droite du prénom. */
+  isCopine?: boolean | null
+  /** Date d'activation Copine pour le tooltip du badge (mois année). */
+  copineSince?: string | Date | null
+  /** Fallback si prenom est null/empty. Par défaut "Une copine". */
+  fallback?: string
+  /** Taille du badge en px (default 12 — discret pour ne pas dominer). */
+  badgeSize?: number
+  className?: string
+}
+
+/**
+ * Affichage unifié d'un prénom membre + badge Copine éventuel.
+ *
+ * Pattern : "Prénom ★" — badge APRÈS le prénom (convention Twitter/IG
+ * checkmark). Le badge reste discret (size 12 par défaut) pour ne pas
+ * dominer la card.
+ *
+ * Si !isCopine OU !copineSince, le badge n'est pas rendu — la
+ * sémantique "Copine" implique un abo actif ET un timestamp.
+ *
+ * `inline-flex items-baseline` + `gap-1.5` garantit que le badge
+ * vertical-aligne correctement avec la baseline du texte, quelle que
+ * soit la taille du parent.
+ */
+export function MemberName({
+  prenom,
+  isCopine = false,
+  copineSince = null,
+  fallback = 'Une copine',
+  badgeSize = 12,
+  className = '',
+}: MemberNameProps) {
+  const displayName = prenom && prenom.length > 0 ? prenom : fallback
+  return (
+    <span className={`inline-flex items-baseline gap-1.5 ${className}`}>
+      <span>{displayName}</span>
+      {isCopine && copineSince ? (
+        <CopineBadge copineSince={copineSince} size={badgeSize} />
+      ) : null}
+    </span>
+  )
+}

--- a/components/je-cherche/DemandeCard.tsx
+++ b/components/je-cherche/DemandeCard.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { CATEGORIES_MAP } from '@/lib/constants'
 import { formatRelativeTime } from '@/lib/format-relative-time'
+import { MemberName } from '@/components/badges/MemberName'
 import type { DemandeWithProfile } from '@/lib/types/je-cherche'
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -67,7 +68,11 @@ export function DemandeCard({ demande }: Props) {
         </div>
         <div className="min-w-0 flex-1">
           <p className="truncate text-[13px] font-medium text-vert">
-            {demande.prenom ?? 'Une copine'}
+            <MemberName
+              prenom={demande.prenom}
+              isCopine={demande.author_is_copine}
+              copineSince={demande.author_copine_since}
+            />
           </p>
           <p className="truncate text-[11px] text-texte-sec">
             {locationLabel(demande)} · {formatRelativeTime(demande.created_at)}

--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { LayoutDashboard } from 'lucide-react'
 import { useSession } from '@/components/auth/SessionProvider'
+import { CopineBadge } from '@/components/badges/CopineBadge'
 
 interface NavigationProps {
   /**
@@ -14,6 +15,13 @@ interface NavigationProps {
    * contenu (manifeste, contact, legal…) qui n'ont pas de hero sombre.
    */
   variant?: 'transparent' | 'solid'
+  /**
+   * Flag Pass Copine, fetché côté server via NavigationServer wrapper.
+   * Default false : pour les pages qui montent Navigation directement
+   * (sans wrapper), pas de badge ni d'item Copine — mode dégradé safe.
+   */
+  isCopine?: boolean
+  copineSince?: string | null
 }
 
 function dashboardPathFor(user: ReturnType<typeof useSession>['user']): string {
@@ -22,7 +30,11 @@ function dashboardPathFor(user: ReturnType<typeof useSession>['user']): string {
   return signupType === 'provider' ? '/dashboard/prestataire' : '/dashboard/utilisatrice'
 }
 
-export function Navigation({ variant = 'transparent' }: NavigationProps = {}) {
+export function Navigation({
+  variant = 'transparent',
+  isCopine = false,
+  copineSince = null,
+}: NavigationProps = {}) {
   const [scrolled, setScrolled] = useState(false)
   const { user } = useSession()
 
@@ -62,6 +74,19 @@ export function Navigation({ variant = 'transparent' }: NavigationProps = {}) {
             { href: '/recommandations', label: 'Recommandations' },
             { href: '/evenements-v2', label: 'Événements' },
             { href: '/tarifs', label: 'Tarifs' },
+            // Lien Pass Copine — visible si user connectée non-prestataire
+            // (les prestataires ont leur propre flow d'abo dans /tarifs).
+            // Label dynamique : prospect vs Copine.
+            ...(user && user.user_metadata?.signupType !== 'provider'
+              ? [
+                  {
+                    href: isCopine
+                      ? '/dashboard/utilisatrice/copine'
+                      : '/pass-copine',
+                    label: isCopine ? 'Mon Pass Copine' : 'Pass Copine',
+                  },
+                ]
+              : []),
             // Lien dashboard visible uniquement pour les comptes prestataire.
             // Approximation via signupType (set au signup) — si la fiche n'existe
             // pas encore, /mon-espace redirige proprement vers /onboarding.
@@ -96,17 +121,20 @@ export function Navigation({ variant = 'transparent' }: NavigationProps = {}) {
             </Link>
           )}
           {user ? (
-            <Link
-              href={dashboardPathFor(user)}
-              className={`inline-flex h-11 items-center gap-2 rounded-full border px-5 text-[13px] font-semibold transition-all ${
-                scrolled
-                  ? 'border-vert text-vert hover:bg-vert hover:text-creme'
-                  : 'border-or text-or hover:bg-or hover:text-vert'
-              }`}
-            >
-              <LayoutDashboard size={16} strokeWidth={1.75} aria-hidden="true" />
-              Mon espace
-            </Link>
+            <span className="flex items-center gap-2">
+              {isCopine && <CopineBadge copineSince={copineSince} size={14} />}
+              <Link
+                href={dashboardPathFor(user)}
+                className={`inline-flex h-11 items-center gap-2 rounded-full border px-5 text-[13px] font-semibold transition-all ${
+                  scrolled
+                    ? 'border-vert text-vert hover:bg-vert hover:text-creme'
+                    : 'border-or text-or hover:bg-or hover:text-vert'
+                }`}
+              >
+                <LayoutDashboard size={16} strokeWidth={1.75} aria-hidden="true" />
+                Mon espace
+              </Link>
+            </span>
           ) : (
             <>
               <Link

--- a/components/landing/NavigationServer.tsx
+++ b/components/landing/NavigationServer.tsx
@@ -1,0 +1,48 @@
+import { createClient } from '@/lib/supabase/server'
+import { Navigation } from './Navigation'
+
+interface NavigationServerProps {
+  variant?: 'transparent' | 'solid'
+}
+
+/**
+ * Wrapper Server de la Navigation publique : fetch is_copine + copine_since
+ * côté serveur et passe les props initiales au Client Component.
+ *
+ * Pourquoi un wrapper plutôt que d'étendre SessionProvider : on évite
+ * de toucher du code central + de payer un fetch supplémentaire sur
+ * chaque mount client. Le pattern Server fetch + Client interactive
+ * est le standard Next 14 (RSC).
+ *
+ * Note : si l'état Copine change pendant la session (souscription en
+ * cours d'onglet), la nav ne se met à jour qu'à la prochaine navigation
+ * (router.refresh côté checkout success → re-render du Server Component).
+ */
+export async function NavigationServer({
+  variant = 'transparent',
+}: NavigationServerProps) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  let isCopine = false
+  let copineSince: string | null = null
+  if (user) {
+    const { data } = await supabase
+      .from('user_profiles')
+      .select('is_copine, copine_since')
+      .eq('user_id', user.id)
+      .maybeSingle()
+    isCopine = data?.is_copine ?? false
+    copineSince = data?.copine_since ?? null
+  }
+
+  return (
+    <Navigation
+      variant={variant}
+      isCopine={isCopine}
+      copineSince={copineSince}
+    />
+  )
+}

--- a/components/pass-copine/CopineSubscriptionStatus.tsx
+++ b/components/pass-copine/CopineSubscriptionStatus.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+type Plan = 'monthly' | 'annual'
+
+interface CopineSubscriptionStatusProps {
+  copineSince: string | null
+  plan: Plan | null
+  currentPeriodEnd: string | null
+  cancelAtPeriodEnd: boolean
+}
+
+function formatLongDate(value: string | null): string {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  return new Intl.DateTimeFormat('fr-FR', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  }).format(d)
+}
+
+function formatMonthYear(value: string | null): string {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  return new Intl.DateTimeFormat('fr-FR', {
+    month: 'long',
+    year: 'numeric',
+  }).format(d)
+}
+
+function planLabel(plan: Plan | null): string {
+  if (plan === 'monthly') return 'Mensuel · 4,99 €/mois'
+  if (plan === 'annual') return 'Annuel · 49 €/an'
+  return '—'
+}
+
+export function CopineSubscriptionStatus({
+  copineSince,
+  plan,
+  currentPeriodEnd,
+  cancelAtPeriodEnd,
+}: CopineSubscriptionStatusProps) {
+  const [loading, setLoading] = useState(false)
+  const sinceLabel = formatMonthYear(copineSince)
+  const renewalLabel = formatLongDate(currentPeriodEnd)
+
+  async function handleOpenPortal() {
+    if (loading) return
+    setLoading(true)
+    try {
+      const res = await fetch('/api/stripe/portal?type=copine', {
+        method: 'POST',
+      })
+      const json = (await res.json().catch(() => null)) as
+        | { url?: string; error?: string }
+        | null
+
+      if (!res.ok || !json?.url) {
+        const msg =
+          json?.error ?? 'Impossible d\'ouvrir le portail. Réessaie dans une minute.'
+        toast.error(msg, { duration: 5000 })
+        setLoading(false)
+        return
+      }
+      window.location.href = json.url
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Erreur réseau.', {
+        duration: 5000,
+      })
+      setLoading(false)
+    }
+  }
+
+  return (
+    <section className="bg-creme pb-20 md:pb-28">
+      <div className="mx-auto max-w-2xl px-6 md:px-8">
+        {sinceLabel && (
+          <p className="text-center text-[15px] text-texte-sec md:text-[16px]">
+            Tu es Copine Hilmy depuis{' '}
+            <span className="font-medium text-vert">{sinceLabel}</span>.
+          </p>
+        )}
+
+        <div className="mt-8 rounded-md border border-creme-deep bg-white p-8 md:p-10">
+          <dl className="space-y-5">
+            <div className="flex flex-col gap-1 md:flex-row md:items-baseline md:justify-between md:gap-6">
+              <dt className="text-[11px] font-medium uppercase tracking-[0.22em] text-or">
+                Plan
+              </dt>
+              <dd className="font-serif text-[18px] font-light text-vert">
+                {planLabel(plan)}
+              </dd>
+            </div>
+            {renewalLabel && (
+              <div className="flex flex-col gap-1 md:flex-row md:items-baseline md:justify-between md:gap-6">
+                <dt className="text-[11px] font-medium uppercase tracking-[0.22em] text-or">
+                  {cancelAtPeriodEnd ? 'Fin du Pass' : 'Prochain renouvellement'}
+                </dt>
+                <dd className="text-[15px] text-texte">{renewalLabel}</dd>
+              </div>
+            )}
+          </dl>
+
+          {cancelAtPeriodEnd && renewalLabel && (
+            <div
+              role="status"
+              className="mt-6 rounded-md border border-or/40 bg-or/10 p-4 text-[13px] leading-[1.6] text-vert"
+            >
+              Ton Pass se termine le <span className="font-medium">{renewalLabel}</span>.
+              Tu redeviens utilisatrice classique après cette date — tes
+              favoris au-delà de 10 restent visibles mais tu ne pourras plus
+              en ajouter.
+            </div>
+          )}
+
+          <div className="mt-8">
+            <button
+              type="button"
+              onClick={handleOpenPortal}
+              disabled={loading}
+              className="block w-full rounded-full bg-or px-8 py-4 text-center text-[15px] font-semibold text-vert transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)] disabled:cursor-wait disabled:opacity-70"
+            >
+              {loading ? 'Ouverture du portail…' : 'Gérer mon abonnement'}
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-10 text-center">
+          <p className="text-[13px] italic text-texte-sec">
+            Une question ? Réponds à n&apos;importe quel email de Sara, on lit tout.
+          </p>
+          <p className="mt-2 text-[11px] font-medium uppercase tracking-[0.22em] text-or">
+            — La team Hilmy
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/pass-copine/FeaturesList.tsx
+++ b/components/pass-copine/FeaturesList.tsx
@@ -1,0 +1,64 @@
+import { Heart, Clock, Tag, Star, Mail, type LucideIcon } from 'lucide-react'
+
+interface Feature {
+  Icon: LucideIcon
+  title: string
+  description: string
+}
+
+const FEATURES: Feature[] = [
+  {
+    Icon: Heart,
+    title: 'Favoris illimités',
+    description: 'Sauvegarde sans compter.',
+  },
+  {
+    Icon: Clock,
+    title: 'Accès anticipé aux Rendez-vous Hilmy',
+    description: '48h avant tout le monde.',
+  },
+  {
+    Icon: Tag,
+    title: 'Coupons Cercle Pro',
+    description: "Réductions chez les pros qu'on adore.",
+  },
+  {
+    Icon: Star,
+    title: 'Badge Copine',
+    description: "Sur tes « Je cherche », tes réponses, ton profil.",
+  },
+  {
+    Icon: Mail,
+    title: 'Newsletter premium Sara',
+    description: "Une fois par semaine au lieu d'une fois par mois.",
+  },
+]
+
+export function FeaturesList() {
+  return (
+    <section className="bg-creme pb-20 md:pb-28">
+      <div className="mx-auto max-w-4xl px-6 md:px-8">
+        <ul className="grid grid-cols-1 gap-6 md:grid-cols-2 md:gap-8">
+          {FEATURES.map(({ Icon, title, description }) => (
+            <li
+              key={title}
+              className="flex items-start gap-4 rounded-md bg-white p-6 md:p-7"
+            >
+              <span className="mt-1 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-creme text-or">
+                <Icon size={18} strokeWidth={1.75} aria-hidden="true" />
+              </span>
+              <div className="min-w-0">
+                <p className="font-serif text-[18px] font-light leading-tight text-vert">
+                  {title}
+                </p>
+                <p className="mt-1.5 text-[14px] leading-[1.6] text-texte-sec">
+                  {description}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/components/pass-copine/PassCopineHero.tsx
+++ b/components/pass-copine/PassCopineHero.tsx
@@ -1,0 +1,27 @@
+import { GoldLine } from '@/components/ui/GoldLine'
+
+export function PassCopineHero() {
+  return (
+    <section className="bg-creme pt-32 pb-16 md:pt-40 md:pb-20">
+      <div className="mx-auto max-w-3xl px-6 text-center md:px-8">
+        <div className="flex items-center justify-center gap-4">
+          <GoldLine width={32} />
+          <span className="text-[11px] font-medium uppercase tracking-[0.32em] text-or">
+            Pass Copine
+          </span>
+          <GoldLine width={32} />
+        </div>
+
+        <h1 className="mt-8 font-serif text-[44px] font-light leading-[1.05] text-vert md:text-[64px]">
+          Le <span className="italic">Pass Copine</span>
+        </h1>
+
+        <p className="mt-6 text-[17px] leading-[1.7] text-texte-sec md:text-[19px]">
+          Tu fais déjà partie de la team.
+          <br className="hidden md:block" />
+          Le Pass, c&apos;est juste pour aller plus loin.
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/components/pass-copine/PricingCards.tsx
+++ b/components/pass-copine/PricingCards.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+type Plan = 'monthly' | 'annual'
+
+/**
+ * Cards de souscription Pass Copine. Appelle POST /api/stripe/checkout
+ * avec { plan } — le price_id est résolu server-side via les env vars
+ * STRIPE_PRICE_COPINE_* (décision A5 Phase 2).
+ *
+ * Pattern d'appel calqué sur components/SubscribeButton.tsx :
+ * fetch → window.location.href vers session.url Stripe Checkout.
+ */
+export function PricingCards() {
+  const [loading, setLoading] = useState<Plan | null>(null)
+
+  async function handleSubscribe(plan: Plan) {
+    if (loading) return
+    setLoading(plan)
+    try {
+      const res = await fetch('/api/stripe/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ plan }),
+      })
+
+      const json = (await res.json().catch(() => null)) as
+        | { url?: string; error?: string; redirect?: string }
+        | null
+
+      if (!res.ok) {
+        if (res.status === 409 && json?.redirect) {
+          window.location.href = json.redirect
+          return
+        }
+        const msg = json?.error ?? 'Impossible de démarrer la souscription.'
+        toast.error(msg, { duration: 5000 })
+        setLoading(null)
+        return
+      }
+
+      if (!json?.url) {
+        toast.error('Réponse Stripe invalide. Réessaie dans une minute.', {
+          duration: 5000,
+        })
+        setLoading(null)
+        return
+      }
+
+      window.location.href = json.url
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Erreur réseau.', {
+        duration: 5000,
+      })
+      setLoading(null)
+    }
+  }
+
+  return (
+    <section className="bg-creme pb-20 md:pb-28">
+      <div className="mx-auto max-w-4xl px-6 md:px-8">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 md:gap-8">
+          {/* Annuel — highlighted */}
+          <div className="relative flex h-full flex-col rounded-md border-2 border-or bg-creme p-8 shadow-[0_16px_40px_rgba(15,61,46,0.08)] md:p-10">
+            <span className="absolute -top-3 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-or px-4 py-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-vert">
+              Meilleur prix · 2 mois offerts
+            </span>
+            <p className="font-serif text-lg font-medium text-vert">Annuel</p>
+            <p className="mt-3 flex items-baseline gap-1.5">
+              <span className="font-serif text-[48px] font-light leading-none text-vert md:text-5xl">
+                49 €
+              </span>
+              <span className="text-sm text-texte-sec">/ an</span>
+            </p>
+            <p className="mt-4 text-[14px] leading-relaxed text-texte-sec">
+              Le choix des copines fidèles · 2 mois offerts.
+            </p>
+            <div className="mt-auto pt-8">
+              <button
+                type="button"
+                onClick={() => handleSubscribe('annual')}
+                disabled={loading !== null}
+                className="block w-full rounded-full bg-or px-8 py-4 text-center text-[15px] font-semibold text-vert transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)] disabled:cursor-wait disabled:opacity-70"
+              >
+                {loading === 'annual'
+                  ? 'Redirection vers le paiement…'
+                  : 'Devenir Copine'}
+              </button>
+            </div>
+          </div>
+
+          {/* Mensuel */}
+          <div className="relative flex h-full flex-col rounded-md border border-creme-deep bg-white p-8 md:p-10">
+            <p className="font-serif text-lg font-medium text-vert">Mensuel</p>
+            <p className="mt-3 flex items-baseline gap-1.5">
+              <span className="font-serif text-[48px] font-light leading-none text-vert md:text-5xl">
+                4,99 €
+              </span>
+              <span className="text-sm text-texte-sec">/ mois</span>
+            </p>
+            <p className="mt-4 text-[14px] leading-relaxed text-texte-sec">
+              Sans engagement.
+            </p>
+            <div className="mt-auto pt-8">
+              <button
+                type="button"
+                onClick={() => handleSubscribe('monthly')}
+                disabled={loading !== null}
+                className="block w-full rounded-full border border-vert bg-transparent px-8 py-4 text-center text-[15px] font-semibold text-vert transition-all hover:-translate-y-0.5 hover:bg-vert hover:text-creme disabled:cursor-wait disabled:opacity-70"
+              >
+                {loading === 'monthly'
+                  ? 'Redirection vers le paiement…'
+                  : 'Devenir Copine'}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-12 text-center">
+          <p className="text-[13px] italic text-texte-sec">
+            Tu peux annuler quand tu veux. Promis, on ne fait pas la tête.
+          </p>
+          <p className="mt-2 text-[11px] font-medium uppercase tracking-[0.22em] text-or">
+            — La team Hilmy
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/pass-copine/PricingCards.tsx
+++ b/components/pass-copine/PricingCards.tsx
@@ -86,7 +86,7 @@ export function PricingCards() {
               >
                 {loading === 'annual'
                   ? 'Redirection vers le paiement…'
-                  : 'Devenir Copine'}
+                  : 'Je prends mon Pass'}
               </button>
             </div>
           </div>
@@ -112,7 +112,7 @@ export function PricingCards() {
               >
                 {loading === 'monthly'
                   ? 'Redirection vers le paiement…'
-                  : 'Devenir Copine'}
+                  : 'Je prends mon Pass'}
               </button>
             </div>
           </div>

--- a/components/paywalls/EventPaywallSheet.tsx
+++ b/components/paywalls/EventPaywallSheet.tsx
@@ -89,7 +89,7 @@ export function EventPaywallSheet({
               onClick={() => onOpenChange(false)}
               className="inline-flex items-center justify-center rounded-full bg-or px-8 py-4 text-[15px] font-semibold text-vert transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)]"
             >
-              Devenir Copine — 4,99 €/mois
+              Je prends mon Pass — 4,99 €/mois
             </Link>
             <button
               type="button"

--- a/components/paywalls/EventPaywallSheet.tsx
+++ b/components/paywalls/EventPaywallSheet.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import Link from 'next/link'
+import { Clock } from 'lucide-react'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+
+interface EventPaywallSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** ISO date à laquelle l'event ouvre au public (fin de la fenêtre
+   *  Copines). Si null/undefined, le composant ne montre pas la date. */
+  earlyAccessUntil: string | Date | null
+}
+
+function formatLongDate(value: string | Date | null): string {
+  if (!value) return ''
+  const d = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  return new Intl.DateTimeFormat('fr-FR', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+  }).format(d)
+}
+
+function formatShortDate(value: string | Date | null): string {
+  if (!value) return ''
+  const d = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  return new Intl.DateTimeFormat('fr-FR', {
+    day: 'numeric',
+    month: 'short',
+  }).format(d)
+}
+
+/**
+ * Paywall events — déclenché quand une non-Copine tente de s'inscrire
+ * à un event en fenêtre d'accès anticipé (events.early_access_until >
+ * now()).
+ *
+ * Le texte est calibré pour ne pas frustrer : option claire de devenir
+ * Copine OU d'attendre la date d'ouverture publique. Le secondary CTA
+ * porte la date pour rendre l'attente concrète.
+ */
+export function EventPaywallSheet({
+  open,
+  onOpenChange,
+  earlyAccessUntil,
+}: EventPaywallSheetProps) {
+  const longDate = formatLongDate(earlyAccessUntil)
+  const shortDate = formatShortDate(earlyAccessUntil)
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="bg-creme border-t border-or/20 rounded-t-2xl px-6 pt-8 pb-10 md:px-10 md:pt-10 md:pb-12"
+      >
+        <div className="mx-auto flex max-w-lg flex-col items-center text-center">
+          <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-or/15 text-or">
+            <Clock size={20} strokeWidth={1.75} aria-hidden="true" />
+          </span>
+
+          <SheetHeader className="mt-5 gap-3">
+            <SheetTitle className="font-serif text-[28px] font-light leading-tight text-vert md:text-[32px]">
+              Les Copines y vont en premier.
+            </SheetTitle>
+            <SheetDescription className="text-[15px] leading-[1.65] text-texte-sec md:text-[16px]">
+              Cet event ouvre aux Copines 48h avant tout le monde. Tu peux les
+              rejoindre maintenant
+              {longDate ? (
+                <>
+                  , ou attendre <span className="font-medium text-vert">{longDate}</span>
+                </>
+              ) : null}
+              .
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="mt-8 flex w-full flex-col items-stretch gap-3 md:flex-row md:justify-center">
+            <Link
+              href="/pass-copine"
+              onClick={() => onOpenChange(false)}
+              className="inline-flex items-center justify-center rounded-full bg-or px-8 py-4 text-[15px] font-semibold text-vert transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)]"
+            >
+              Devenir Copine — 4,99 €/mois
+            </Link>
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="inline-flex items-center justify-center px-4 py-3 text-[13px] font-medium text-texte-sec transition-colors hover:text-vert"
+            >
+              {shortDate ? `J'attends le ${shortDate}` : 'Plus tard'}
+            </button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/components/paywalls/FavorisPaywallSheet.tsx
+++ b/components/paywalls/FavorisPaywallSheet.tsx
@@ -55,7 +55,7 @@ export function FavorisPaywallSheet({
               onClick={() => onOpenChange(false)}
               className="inline-flex items-center justify-center rounded-full bg-or px-8 py-4 text-[15px] font-semibold text-vert transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)]"
             >
-              Voir le Pass — 4,99 €/mois
+              Je prends mon Pass — 4,99 €/mois
             </Link>
             <button
               type="button"

--- a/components/paywalls/FavorisPaywallSheet.tsx
+++ b/components/paywalls/FavorisPaywallSheet.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import Link from 'next/link'
+import { Heart } from 'lucide-react'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+
+interface FavorisPaywallSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Paywall favoris — déclenché quand une non-Copine tente d'ajouter un
+ * 11e favori (trigger SQL check_favoris_limit_for_non_copine renvoie
+ * P0001 'FAVORITES_LIMIT_REACHED').
+ *
+ * Bottom sheet sobre, voix Sara : pas culpabilisant, juste une
+ * proposition naturelle. Le CTA renvoie vers /pass-copine — le
+ * checkout Stripe se fait après.
+ */
+export function FavorisPaywallSheet({
+  open,
+  onOpenChange,
+}: FavorisPaywallSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="bg-creme border-t border-or/20 rounded-t-2xl px-6 pt-8 pb-10 md:px-10 md:pt-10 md:pb-12"
+      >
+        <div className="mx-auto flex max-w-lg flex-col items-center text-center">
+          <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-or/15 text-or">
+            <Heart size={20} strokeWidth={1.75} aria-hidden="true" />
+          </span>
+
+          <SheetHeader className="mt-5 gap-3">
+            <SheetTitle className="font-serif text-[28px] font-light leading-tight text-vert md:text-[32px]">
+              T&apos;as bon goût.
+            </SheetTitle>
+            <SheetDescription className="text-[15px] leading-[1.65] text-texte-sec md:text-[16px]">
+              Tu peux sauvegarder autant d&apos;adresses que tu veux avec le
+              Pass Copine. Plus de limite, plus de panique de devoir choisir.
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="mt-8 flex w-full flex-col items-stretch gap-3 md:flex-row md:justify-center">
+            <Link
+              href="/pass-copine"
+              onClick={() => onOpenChange(false)}
+              className="inline-flex items-center justify-center rounded-full bg-or px-8 py-4 text-[15px] font-semibold text-vert transition-all hover:-translate-y-0.5 hover:bg-or-light hover:shadow-[0_8px_24px_rgba(201,169,97,0.3)]"
+            >
+              Voir le Pass — 4,99 €/mois
+            </Link>
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="inline-flex items-center justify-center px-4 py-3 text-[13px] font-medium text-texte-sec transition-colors hover:text-vert"
+            >
+              Plus tard
+            </button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/components/v2/AvisSection.tsx
+++ b/components/v2/AvisSection.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'motion/react'
 import { createClient } from '@/lib/supabase/client'
 import { GoldLine } from '@/components/ui/GoldLine'
+import { MemberName } from '@/components/badges/MemberName'
 
 export type AvisItem = {
   id: string
@@ -13,7 +14,13 @@ export type AvisItem = {
   created_at: string
   reponse_pro: string | null
   reponse_date: string | null
-  user: { prenom: string | null; avatar_url: string | null } | null
+  user: {
+    prenom: string | null
+    avatar_url: string | null
+    /** Pass Copine (mig 50, Phase 6). NULL = inconnu (badge masqué). */
+    is_copine?: boolean | null
+    copine_since?: string | null
+  } | null
   likes_count: number
   liked_by_me: boolean
 }
@@ -123,10 +130,10 @@ export function AvisSection({
       return
     }
 
-    // Fetch user_profile pour nom + avatar
+    // Fetch user_profile pour nom + avatar + flags Pass Copine
     const { data: prof } = await supabase
       .from('user_profiles')
-      .select('prenom, avatar_url')
+      .select('prenom, avatar_url, is_copine, copine_since')
       .eq('user_id', user.id)
       .maybeSingle()
 
@@ -141,6 +148,8 @@ export function AvisSection({
       user: {
         prenom: prof?.prenom ?? null,
         avatar_url: prof?.avatar_url ?? null,
+        is_copine: prof?.is_copine ?? null,
+        copine_since: prof?.copine_since ?? null,
       },
       likes_count: 0,
       liked_by_me: false,
@@ -398,7 +407,11 @@ export function AvisSection({
                     />
                     <div>
                       <p className="text-[14px] font-medium text-vert">
-                        {a.user?.prenom ?? 'Une copine'}
+                        <MemberName
+                          prenom={a.user?.prenom ?? null}
+                          isCopine={a.user?.is_copine ?? null}
+                          copineSince={a.user?.copine_since ?? null}
+                        />
                       </p>
                       <p className="text-[11px] text-texte-sec">{dateFr}</p>
                     </div>

--- a/components/v2/EvenementCard.tsx
+++ b/components/v2/EvenementCard.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { motion } from 'framer-motion'
+import { Lock } from 'lucide-react'
 import type { Evenement } from '@/lib/mock-data'
 
 interface Props {
@@ -20,6 +21,13 @@ export function EvenementCard({ e, index = 0, variant = 'default' }: Props) {
   const flyerUrl = isUrl(e.flyer) ? e.flyer : null
 
   const complet = e.inscrites >= e.places
+  // Badge "Accès anticipé Copines" — visible si l'event est dans sa
+  // fenêtre Copines (mig 50) ET pas encore complet. Si complet, on
+  // privilégie l'info "Complet" (priorité business).
+  const earlyAccessActive =
+    !complet &&
+    !!e.early_access_until &&
+    new Date(e.early_access_until).getTime() > Date.now()
 
   return (
     <motion.article
@@ -74,6 +82,15 @@ export function EvenementCard({ e, index = 0, variant = 'default' }: Props) {
           {complet && (
             <div className="absolute right-5 top-5 rounded-full bg-texte/85 px-3 py-1 text-[10px] tracking-[0.22em] text-creme uppercase backdrop-blur">
               Complet
+            </div>
+          )}
+          {earlyAccessActive && (
+            <div
+              className="absolute right-5 top-5 inline-flex items-center gap-1.5 rounded-full bg-creme/95 px-3 py-1 text-[10px] font-medium tracking-[0.22em] text-or uppercase backdrop-blur"
+              title="Cet event ouvre aux Copines 48h avant tout le monde"
+            >
+              <Lock size={11} strokeWidth={1.75} aria-hidden="true" />
+              Accès anticipé Copines
             </div>
           )}
         </div>

--- a/components/v2/EventInscriptionCTA.tsx
+++ b/components/v2/EventInscriptionCTA.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'motion/react'
+import { EventPaywallSheet } from '@/components/paywalls/EventPaywallSheet'
 
 interface Props {
   eventId: string
@@ -18,6 +19,12 @@ interface Props {
   registrationMode?: 'internal' | 'external' | 'info_only'
   /** URL externe à utiliser pour 'external' ou 'info_only'. */
   externalUrl?: string | null
+  /** Pass Copine (mig 50). ISO date. Si > now() ET isCopine=false, le
+   *  click "S'inscrire" ouvre le EventPaywallSheet au lieu de POSTer. */
+  earlyAccessUntil?: string | null
+  /** Pass Copine. Si true, accès anticipé OK ; si false, l'inscription
+   *  est gatée tant qu'on est dans la fenêtre early_access. */
+  isCopine?: boolean
 }
 
 export function EventInscriptionCTA({
@@ -31,6 +38,8 @@ export function EventInscriptionCTA({
   variant = 'solid',
   registrationMode = 'internal',
   externalUrl = null,
+  earlyAccessUntil = null,
+  isCopine = false,
 }: Props) {
   const router = useRouter()
   const [inscrite, setInscrite] = useState(initiallyInscrite)
@@ -38,8 +47,16 @@ export function EventInscriptionCTA({
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [toast, setToast] = useState<string | null>(null)
+  const [paywallOpen, setPaywallOpen] = useState(false)
 
   const complet = placesMax !== null && count >= placesMax
+  // Paywall actif tant qu'on est dans la fenêtre Copines ET que la
+  // user n'est pas Copine. Le check passe aussi côté server-side dans
+  // l'API route inscription (defense-in-depth).
+  const earlyAccessBlocked =
+    !!earlyAccessUntil &&
+    !isCopine &&
+    new Date(earlyAccessUntil).getTime() > Date.now()
 
   const showToast = (msg: string) => {
     setToast(msg)
@@ -54,6 +71,11 @@ export function EventInscriptionCTA({
       return
     }
     if (inscrite || complet || isOwner) return
+    // Gate client : early access Copines en cours, user non Copine.
+    if (earlyAccessBlocked) {
+      setPaywallOpen(true)
+      return
+    }
     setSubmitting(true)
     setError(null)
     try {
@@ -62,6 +84,16 @@ export function EventInscriptionCTA({
       })
       const body = await res.json().catch(() => ({}))
       if (!res.ok) {
+        // Defense-in-depth : si le server gate intercepte avec
+        // EARLY_ACCESS_COPINE_ONLY (cas où le client gate aurait été
+        // contourné), on ouvre quand même le paywall.
+        if (
+          res.status === 403 &&
+          body.error === 'EARLY_ACCESS_COPINE_ONLY'
+        ) {
+          setPaywallOpen(true)
+          return
+        }
         setError(body.error ?? 'Impossible de t\'inscrire pour l\'instant.')
         return
       }
@@ -218,6 +250,11 @@ export function EventInscriptionCTA({
       )}
       {error && <p className="text-[12px] text-red-900">{error}</p>}
       <Toast message={toast} />
+      <EventPaywallSheet
+        open={paywallOpen}
+        onOpenChange={setPaywallOpen}
+        earlyAccessUntil={earlyAccessUntil}
+      />
     </div>
   )
 }

--- a/components/v2/FavoriteButton.tsx
+++ b/components/v2/FavoriteButton.tsx
@@ -8,6 +8,7 @@ import {
   removeFavori,
 } from '@/lib/supabase/queries/favoris'
 import type { FavoriType } from '@/lib/supabase/types'
+import { FavorisPaywallSheet } from '@/components/paywalls/FavorisPaywallSheet'
 
 interface FavoriteButtonProps {
   /** Quel type d'item est sauvegardé (mig 05 + mig 16) :
@@ -48,6 +49,7 @@ export function FavoriteButton({
   const [saved, setSaved] = useState(false)
   const [loading, setLoading] = useState(true)
   const [pending, setPending] = useState(false)
+  const [paywallOpen, setPaywallOpen] = useState(false)
 
   // Lecture initiale de l'état (existe-t-il déjà un favori pour cet item ?).
   // Fail silencieux : si erreur réseau, on assume "pas favori" et on
@@ -80,8 +82,16 @@ export function FavoriteButton({
       : await removeFavori(itemType, itemId)
 
     if (op.error) {
-      // Revert
+      // Revert l'optimistic toggle puis route l'erreur :
+      // - 'FAVORITES_LIMIT_REACHED' → ouvre le paywall Pass Copine
+      //   (trigger SQL mig 50 §7 raise exception P0001 avec ce texte
+      //   exact pour les non-Copines au 11e favori).
+      // - Autre erreur → fail silencieux (la user retentera, le toggle
+      //   reflète déjà l'état réel).
       setSaved(previous)
+      if (next && op.error.includes('FAVORITES_LIMIT_REACHED')) {
+        setPaywallOpen(true)
+      }
     }
     setPending(false)
   }
@@ -101,27 +111,30 @@ export function FavoriteButton({
         : 'border border-or/40 bg-transparent text-vert hover:border-or hover:bg-creme-deep'
 
   return (
-    <button
-      type="button"
-      onClick={handleToggle}
-      disabled={loading || pending}
-      className={`group inline-flex items-center gap-2.5 rounded-full font-medium tracking-[0.22em] uppercase transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-60 ${base} ${styles}`}
-      aria-pressed={saved}
-      aria-busy={pending || loading}
-    >
-      <AnimatePresence mode="wait" initial={false}>
-        <motion.span
-          key={saved ? 'on' : 'off'}
-          initial={{ scale: 0.7, opacity: 0 }}
-          animate={{ scale: 1, opacity: 1 }}
-          exit={{ scale: 0.7, opacity: 0 }}
-          transition={{ duration: 0.2 }}
-          aria-hidden="true"
-        >
-          {saved ? '♥' : '♡'}
-        </motion.span>
-      </AnimatePresence>
-      <span>{saved ? labelActive : label}</span>
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={handleToggle}
+        disabled={loading || pending}
+        className={`group inline-flex items-center gap-2.5 rounded-full font-medium tracking-[0.22em] uppercase transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-60 ${base} ${styles}`}
+        aria-pressed={saved}
+        aria-busy={pending || loading}
+      >
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.span
+            key={saved ? 'on' : 'off'}
+            initial={{ scale: 0.7, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.7, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            aria-hidden="true"
+          >
+            {saved ? '♥' : '♡'}
+          </motion.span>
+        </AnimatePresence>
+        <span>{saved ? labelActive : label}</span>
+      </button>
+      <FavorisPaywallSheet open={paywallOpen} onOpenChange={setPaywallOpen} />
+    </>
   )
 }

--- a/lib/email/transactional.ts
+++ b/lib/email/transactional.ts
@@ -1003,3 +1003,51 @@ export async function sendPerkRejected({
     }),
   });
 }
+
+/* ───────────────────────────────────────────────────────────────
+   Pass Copine welcome (mig 50 — Phase 6)
+
+   Déclenché par le webhook Stripe customer.subscription.created (et
+   par checkout.session.completed via persistCopineSubscription) à la
+   PREMIÈRE activation Copine — détecté côté webhook par
+   `copine_since IS NULL avant l'UPDATE`. Pas de table dédiée pour
+   l'idempotence — risque résiduel de doublon en cas de re-trigger
+   Stripe en parallèle (acceptable cf décision D2 Phase 6).
+   ─────────────────────────────────────────────────────────────── */
+
+/**
+ * Email de bienvenue Pass Copine — envoyé au premier abo réussi.
+ * Best-effort : la fonction lève si Resend/Brevo down ; le caller
+ * (webhook) catch et log pour ne pas faire échouer le webhook lui-même.
+ */
+export async function sendCopineWelcome({
+  to,
+  prenom,
+  dashboardUrl,
+}: {
+  to: string;
+  /** Prénom de la Copine — fallback "coucou" si absent. */
+  prenom: string | null;
+  dashboardUrl: string;
+}) {
+  const safePrenom = prenom && prenom.length > 0 ? prenom : "coucou";
+  await sendEmail({
+    to,
+    subject: "Bienvenue dans la team Copines",
+    html: buildRichLayout({
+      preview: "Tu es officiellement Copine Hilmy",
+      title: `Coucou ${safePrenom},`,
+      paragraphs: [
+        "Te voilà officiellement Copine Hilmy. Ton badge est posé, tes favoris débloqués, tes avantages Cercle Pro t'attendent.",
+        "Voici ce que tu peux faire dès maintenant :",
+        "1. Découvrir les avantages Copines de tes prestataires préférées",
+        "2. T'inscrire aux Rendez-vous Hilmy en accès anticipé, 48h avant tout le monde",
+        "3. Sauvegarder toutes les adresses qui te font envie, sans limite",
+        "Si tu as une question, réponds à cet email. On lit tout.",
+      ],
+      ctaLabel: "Voir mes avantages",
+      ctaHref: dashboardUrl,
+      footer: "La team Hilmy.",
+    }),
+  });
+}

--- a/lib/email/transactional.ts
+++ b/lib/email/transactional.ts
@@ -889,3 +889,117 @@ export async function sendDevisExpressEmail({
     }),
   });
 }
+
+/* ───────────────────────────────────────────────────────────────
+   Pro Perks (mig 50 — Phase 5)
+
+   Trois notifications encadrent le workflow de modération :
+   1. sendPerkPendingReview  → admins/founders quand un presta soumet
+   2. sendPerkApproved        → presta quand admin valide
+   3. sendPerkRejected        → presta quand admin refuse (+ raison)
+
+   Recipients admins via getFounderRecipients() — décision D3 Phase 5
+   (un seul canal admin/founders, cf sendNewEventToFounders pattern).
+   ─────────────────────────────────────────────────────────────── */
+
+/**
+ * Notification founders : un prestataire vient de soumettre un perk
+ * pour modération. Best-effort : no-op si FOUNDER_NOTIFICATION_EMAILS
+ * absent.
+ */
+export async function sendPerkPendingReview({
+  perkTitle,
+  prestaNom,
+  discountLabel,
+  adminUrl,
+}: {
+  perkTitle: string;
+  prestaNom: string;
+  discountLabel: string;
+  adminUrl: string;
+}) {
+  const recipients = getFounderRecipients();
+  if (recipients.length === 0) return;
+
+  await sendEmail({
+    to: recipients,
+    subject: `Nouvelle offre Cercle Pro à modérer — ${perkTitle}`,
+    html: buildRichLayout({
+      preview: `${prestaNom} vient de soumettre une offre pour les Copines`,
+      title: "Une offre Cercle Pro à modérer.",
+      paragraphs: [
+        `${prestaNom} vient de créer une nouvelle offre pour les Copines : « ${perkTitle} » — ${discountLabel}.`,
+        "Elle est en file de modération. Valide-la pour qu'elle apparaisse aux Copines, ou refuse-la avec une raison si elle ne convient pas.",
+      ],
+      ctaLabel: "Voir la queue de modération",
+      ctaHref: adminUrl,
+      footer: "Tu reçois ce mail parce que ton email est listé dans FOUNDER_NOTIFICATION_EMAILS.",
+    }),
+  });
+}
+
+/**
+ * Notification prestataire : son perk a été approuvé et est en ligne
+ * pour les Copines. Copy Sara stricte (cf brief Phase 5).
+ */
+export async function sendPerkApproved({
+  to,
+  prestaPrenom,
+  perkTitle,
+  dashboardUrl,
+}: {
+  to: string;
+  prestaPrenom: string;
+  perkTitle: string;
+  dashboardUrl: string;
+}) {
+  await sendEmail({
+    to,
+    subject: `Ton offre Copines est en ligne — ${perkTitle}`,
+    html: buildRichLayout({
+      preview: `Ton offre ${perkTitle} est validée`,
+      title: `${prestaPrenom}, ton offre est en ligne.`,
+      paragraphs: [
+        `Ton offre « ${perkTitle} » est en ligne. Les Copines peuvent maintenant en profiter.`,
+        "Elles vont la voir apparaître dans leurs avantages, et chaque code utilisé sera tracé dans ton dashboard.",
+      ],
+      ctaLabel: "Voir mon offre",
+      ctaHref: dashboardUrl,
+      footer: "La team Hilmy.",
+    }),
+  });
+}
+
+/**
+ * Notification prestataire : son perk a été refusé avec une raison.
+ * La raison est obligatoire côté UI admin (cf PerkModerationRow).
+ */
+export async function sendPerkRejected({
+  to,
+  prestaPrenom,
+  perkTitle,
+  rejectionReason,
+  dashboardUrl,
+}: {
+  to: string;
+  prestaPrenom: string;
+  perkTitle: string;
+  rejectionReason: string;
+  dashboardUrl: string;
+}) {
+  await sendEmail({
+    to,
+    subject: `Ton offre Copines n'a pas pu être validée — ${perkTitle}`,
+    html: buildRichLayout({
+      preview: `Ton offre ${perkTitle} n'a pas été validée`,
+      title: `${prestaPrenom}, on a une remarque sur ton offre.`,
+      paragraphs: [
+        `Ton offre « ${perkTitle} » n'a pas pu être validée. Raison : ${rejectionReason}.`,
+        "Tu peux la modifier et la resoumettre quand tu veux. Si tu veux en discuter, réponds à ce mail — on lit tout.",
+      ],
+      ctaLabel: "Modifier mon offre",
+      ctaHref: dashboardUrl,
+      footer: "La team Hilmy.",
+    }),
+  });
+}

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -510,6 +510,10 @@ export type Evenement = {
    *  PostgREST sur event_seasonal_categories. Drive le badge card +
    *  filtre chips /evenements-v2. */
   seasonal_category?: { slug: string; label: string; emoji: string } | null;
+  /** Pass Copine (mig 50). ISO date. Si > now(), badge "Accès anticipé
+   *  Copines" sur la card et paywall sur l'inscription pour les
+   *  non-Copines. Optionnel : les mock data legacy n'ont pas le champ. */
+  early_access_until?: string | null;
 };
 
 export const evenements: Evenement[] = [

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -11,6 +11,7 @@
 
 import Stripe from 'stripe'
 import type { Palier, Duree } from '@/app/tarifs/_lib/pricing'
+import type { CopinePlan } from '@/lib/supabase/types'
 
 /**
  * Lazy singleton — initialise Stripe au 1er appel uniquement.
@@ -125,6 +126,77 @@ export function getPriceIdForCombo(
 /** Vérifie qu'un priceId est référencé — gating server-side. */
 export function isKnownPriceId(priceId: string): boolean {
   return PRICE_ID_MAP.has(priceId)
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   COPINE_PRICE_ID_MAP — décodage Stripe priceId → plan Pass Copine
+
+   Map distinct du PRICE_ID_MAP prestataire ci-dessus pour deux raisons :
+   (1) éviter qu'un priceId Copine soit accepté par isKnownPriceId()
+   côté flow prestataire (qui ferait crasher decodage palier/duree) ;
+   (2) garder les deux flows découplés — toute modif côté prestataire
+   ne touche pas le flow Copine et vice-versa.
+
+   Pricing Pass Copine (mig 50) :
+     • monthly : 4,99€/mois
+     • annual  : 49€/an (2 mois offerts vs monthly)
+   ────────────────────────────────────────────────────────────────── */
+
+function buildCopinePriceIdMap(): Map<string, CopinePlan> {
+  const m = new Map<string, CopinePlan>()
+  const add = (envKey: string, plan: CopinePlan) => {
+    const id = process.env[envKey]
+    if (id && id.startsWith('price_')) m.set(id, plan)
+  }
+  add('STRIPE_PRICE_COPINE_MONTHLY', 'monthly')
+  add('STRIPE_PRICE_COPINE_ANNUAL', 'annual')
+  return m
+}
+
+const COPINE_PRICE_ID_MAP = buildCopinePriceIdMap()
+
+/** Vrai si le priceId correspond à un price Pass Copine. */
+export function isCopinePriceId(priceId: string): boolean {
+  return COPINE_PRICE_ID_MAP.has(priceId)
+}
+
+/** Décode un priceId Copine en plan. Null si inconnu. */
+export function getCopinePlan(priceId: string): CopinePlan | null {
+  return COPINE_PRICE_ID_MAP.get(priceId) ?? null
+}
+
+/**
+ * Résout un plan Copine en priceId. Utilisé par /api/stripe/checkout
+ * quand le body contient { plan } au lieu de { price_id } — flow Pass
+ * Copine où le client n'a pas accès aux env vars STRIPE_PRICE_COPINE_*
+ * (server-only par décision A5).
+ *
+ * Retourne null si la var d'env correspondante est absente côté
+ * runtime — le caller doit retourner 503/server-config error.
+ */
+export function getCopinePriceIdForPlan(plan: CopinePlan): string | null {
+  for (const [priceId, p] of COPINE_PRICE_ID_MAP) {
+    if (p === plan) return priceId
+  }
+  return null
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   URLs success / cancel Pass Copine
+
+   Origin dynamique depuis request.url côté handler. Le user_id est
+   redondant ici (cookie session Supabase suffit pour identifier la
+   user dans /dashboard/utilisatrice/copine), mais on garde
+   stripe_success=1 pour distinguer le retour Stripe d'une visite
+   directe (UX message "Bienvenue dans la team Copines").
+   ────────────────────────────────────────────────────────────────── */
+
+export function buildCopineSuccessUrl(origin: string): string {
+  return `${origin}/dashboard/utilisatrice/copine?stripe_success=1`
+}
+
+export function buildCopineCancelUrl(origin: string): string {
+  return `${origin}/pass-copine?stripe_canceled=1`
 }
 
 /* ──────────────────────────────────────────────────────────────────

--- a/lib/supabase/je-cherche.ts
+++ b/lib/supabase/je-cherche.ts
@@ -117,9 +117,24 @@ export async function getDemandesFeed(
     const { data, error } = await query
     if (error) return fail(error.message, error.code)
 
-    const rows = (data ?? []) as DemandeWithProfile[]
-    const hasMore = rows.length > limit
-    const items = hasMore ? rows.slice(0, limit) : rows
+    const rawRows = (data ?? []) as Array<
+      Omit<DemandeWithProfile, 'author_is_copine' | 'author_copine_since'>
+    >
+    const hasMore = rawRows.length > limit
+    const sliced = hasMore ? rawRows.slice(0, limit) : rawRows
+
+    // Pass Copine (Phase 6) : fetch séparé is_copine/copine_since par
+    // user_id. La vue demandes_feed ne les expose pas, on évite une
+    // migration en Phase 6 — pattern fallback identique à getResponsesFallback.
+    const copineByUserId = await fetchCopineFlagsByUserIds(
+      sliced.map((r) => r.user_id),
+    )
+    const items: DemandeWithProfile[] = sliced.map((r) => ({
+      ...r,
+      author_is_copine: copineByUserId.get(r.user_id)?.is_copine ?? null,
+      author_copine_since: copineByUserId.get(r.user_id)?.copine_since ?? null,
+    }))
+
     const nextCursor =
       hasMore && items.length > 0 ? items[items.length - 1].created_at : null
 
@@ -149,7 +164,20 @@ export async function getDemandeById(
       .eq('id', id)
       .maybeSingle()
     if (error) return fail(error.message, error.code)
-    return { ok: true, data: (data as DemandeWithProfile | null) ?? null }
+    if (!data) return { ok: true, data: null }
+
+    // Enrichit is_copine/copine_since via fetch séparé (Phase 6).
+    const raw = data as Omit<
+      DemandeWithProfile,
+      'author_is_copine' | 'author_copine_since'
+    >
+    const copineByUserId = await fetchCopineFlagsByUserIds([raw.user_id])
+    const enriched: DemandeWithProfile = {
+      ...raw,
+      author_is_copine: copineByUserId.get(raw.user_id)?.is_copine ?? null,
+      author_copine_since: copineByUserId.get(raw.user_id)?.copine_since ?? null,
+    }
+    return { ok: true, data: enriched }
   } catch (err) {
     return fail(err instanceof Error ? err.message : String(err))
   }
@@ -175,7 +203,7 @@ export async function getDemandeResponsesByDemandeId(
         `
         id, demande_id, user_id, content, prestataire_id,
         flag_count, is_hidden, helpful_count, created_at, updated_at,
-        author:user_profiles!demande_responses_user_id_fkey ( prenom, avatar_url ),
+        author:user_profiles!demande_responses_user_id_fkey ( prenom, avatar_url, is_copine, copine_since ),
         prestataire:profiles!demande_responses_prestataire_id_fkey (
           id, slug, nom, ville, note_moyenne, nb_avis, photos, galerie
         )
@@ -194,7 +222,12 @@ export async function getDemandeResponsesByDemandeId(
 
     const rows = (data ?? []) as Array<
       DemandeResponse & {
-        author: { prenom: string | null; avatar_url: string | null } | null
+        author: {
+          prenom: string | null
+          avatar_url: string | null
+          is_copine: boolean | null
+          copine_since: string | null
+        } | null
         prestataire: {
           id: string
           slug: string
@@ -226,6 +259,8 @@ export async function getDemandeResponsesByDemandeId(
         updated_at: r.updated_at,
         author_prenom: r.author?.prenom ?? null,
         author_avatar_url: r.author?.avatar_url ?? null,
+        author_is_copine: r.author?.is_copine ?? null,
+        author_copine_since: r.author?.copine_since ?? null,
         prestataire: r.prestataire
           ? {
               id: r.prestataire.id,
@@ -280,7 +315,7 @@ async function getResponsesFallback(
   const [authorsRes, prestaRes] = await Promise.all([
     supabase
       .from('user_profiles')
-      .select('user_id, prenom, avatar_url')
+      .select('user_id, prenom, avatar_url, is_copine, copine_since')
       .in('user_id', userIds),
     prestaIds.length > 0
       ? supabase
@@ -292,12 +327,25 @@ async function getResponsesFallback(
 
   const authorsByUserId = new Map<
     string,
-    { prenom: string | null; avatar_url: string | null }
+    {
+      prenom: string | null
+      avatar_url: string | null
+      is_copine: boolean | null
+      copine_since: string | null
+    }
   >()
-  for (const a of authorsRes.data ?? []) {
+  for (const a of (authorsRes.data ?? []) as Array<{
+    user_id: string
+    prenom: string | null
+    avatar_url: string | null
+    is_copine: boolean | null
+    copine_since: string | null
+  }>) {
     authorsByUserId.set(a.user_id, {
       prenom: a.prenom ?? null,
       avatar_url: a.avatar_url ?? null,
+      is_copine: a.is_copine ?? null,
+      copine_since: a.copine_since ?? null,
     })
   }
 
@@ -342,12 +390,55 @@ async function getResponsesFallback(
     ...r,
     author_prenom: authorsByUserId.get(r.user_id)?.prenom ?? null,
     author_avatar_url: authorsByUserId.get(r.user_id)?.avatar_url ?? null,
+    author_is_copine: authorsByUserId.get(r.user_id)?.is_copine ?? null,
+    author_copine_since: authorsByUserId.get(r.user_id)?.copine_since ?? null,
     prestataire: r.prestataire_id
       ? (prestaById.get(r.prestataire_id) ?? null)
       : null,
   }))
 
   return { ok: true, data: items }
+}
+
+/**
+ * Helper Phase 6 : fetch séparé de is_copine/copine_since pour un set
+ * de user_ids. Utilisé par les queries demandes (vue demandes_feed
+ * n'expose pas ces colonnes — pas de migration en Phase 6).
+ *
+ * Lecture RLS authenticated (les colonnes Copine sont readable sur
+ * user_profiles policies select existantes).
+ */
+async function fetchCopineFlagsByUserIds(
+  userIds: string[],
+): Promise<
+  Map<string, { is_copine: boolean | null; copine_since: string | null }>
+> {
+  const map = new Map<
+    string,
+    { is_copine: boolean | null; copine_since: string | null }
+  >()
+  const unique = Array.from(new Set(userIds.filter(Boolean)))
+  if (unique.length === 0) return map
+  try {
+    const supabase = await createClient()
+    const { data } = await supabase
+      .from('user_profiles')
+      .select('user_id, is_copine, copine_since')
+      .in('user_id', unique)
+    for (const row of (data ?? []) as Array<{
+      user_id: string
+      is_copine: boolean | null
+      copine_since: string | null
+    }>) {
+      map.set(row.user_id, {
+        is_copine: row.is_copine ?? null,
+        copine_since: row.copine_since ?? null,
+      })
+    }
+  } catch {
+    // Fail silencieux : badge non affiché, prénom toujours visible.
+  }
+  return map
 }
 
 /**

--- a/lib/supabase/queries/copine-subscriptions.ts
+++ b/lib/supabase/queries/copine-subscriptions.ts
@@ -1,0 +1,291 @@
+/**
+ * Queries Pass Copine (mig 50).
+ *
+ * Lecture : RLS owner_read autorise authenticated à lire son propre abo
+ * Copine via createClient() (cookie session Supabase). Voir aussi
+ * user_profiles.is_copine pour le fast-path gating (mirror denormalisé
+ * mis à jour par le webhook).
+ *
+ * Écriture : exclusivement via createAdminClient() depuis le webhook
+ * /api/stripe/webhook (service_role bypass RLS). Tous les helpers
+ * d'écriture sont préfixés `Admin` pour empêcher un appel accidentel
+ * depuis un contexte non admin.
+ *
+ * Parallèle stricte à lib/supabase/queries/subscriptions.ts qui couvre
+ * les paliers prestataires (mig 49). Pas de fusion polymorphique : les
+ * deux flows restent indépendants pour éviter de toucher au code
+ * prestataire en production.
+ */
+
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import type {
+  CopinePlan,
+  CopineSubscription,
+  QueryResult,
+  SubscriptionStatus,
+} from '@/lib/supabase/types'
+
+const COPINE_SUBSCRIPTION_SELECT = `
+  id,
+  user_id,
+  stripe_customer_id,
+  stripe_subscription_id,
+  stripe_price_id,
+  plan,
+  status,
+  current_period_start,
+  current_period_end,
+  cancel_at_period_end,
+  canceled_at,
+  ended_at,
+  created_at,
+  updated_at
+`
+
+/**
+ * Abo Copine actif d'un user (status='active' OR 'trialing' OR
+ * 'past_due'). Past_due = Stripe Smart Retries en cours, on garde
+ * is_copine appliqué jusqu'à confirmation d'échec final.
+ *
+ * Utilise createClient (RLS owner_read filtre déjà sur user_id =
+ * auth.uid()), pas besoin de passer user_id en arg côté caller.
+ */
+export async function getActiveCopineSubscription(): Promise<
+  QueryResult<CopineSubscription | null>
+> {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('copine_subscriptions')
+      .select(COPINE_SUBSCRIPTION_SELECT)
+      .in('status', ['active', 'trialing', 'past_due'])
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    if (error) return { data: null, error: error.message }
+    return { data: (data as CopineSubscription | null) ?? null, error: null }
+  } catch (err) {
+    return { data: null, error: errorMessage(err) }
+  }
+}
+
+/**
+ * Lookup d'une row Copine par stripe_subscription_id. Utilisé par les
+ * handlers webhook (subscription.updated/deleted) pour retrouver le
+ * user_id quand la metadata n'est plus présente (resync à postériori).
+ */
+export async function getCopineSubscriptionByStripeIdAdmin(
+  stripeSubId: string,
+): Promise<CopineSubscription | null> {
+  try {
+    const admin = createAdminClient()
+    const { data, error } = await admin
+      .from('copine_subscriptions')
+      .select(COPINE_SUBSCRIPTION_SELECT)
+      .eq('stripe_subscription_id', stripeSubId)
+      .maybeSingle()
+    if (error || !data) return null
+    return data as CopineSubscription
+  } catch {
+    return null
+  }
+}
+
+export interface UpsertCopineSubscriptionInput {
+  user_id: string
+  stripe_customer_id: string
+  stripe_subscription_id: string
+  stripe_price_id: string
+  plan: CopinePlan
+  status: SubscriptionStatus
+  current_period_start: string
+  current_period_end: string
+  cancel_at_period_end: boolean
+  canceled_at?: string | null
+  ended_at?: string | null
+}
+
+/**
+ * Upsert idempotent (ON CONFLICT stripe_subscription_id). Stripe peut
+ * re-sender un event 3-7 jours après en cas de timeout — le UNIQUE
+ * absorbe les rejeux sans doublon.
+ */
+export async function upsertCopineSubscriptionAdmin(
+  input: UpsertCopineSubscriptionInput,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const admin = createAdminClient()
+    const { error } = await admin
+      .from('copine_subscriptions')
+      .upsert(
+        {
+          user_id: input.user_id,
+          stripe_customer_id: input.stripe_customer_id,
+          stripe_subscription_id: input.stripe_subscription_id,
+          stripe_price_id: input.stripe_price_id,
+          plan: input.plan,
+          status: input.status,
+          current_period_start: input.current_period_start,
+          current_period_end: input.current_period_end,
+          cancel_at_period_end: input.cancel_at_period_end,
+          canceled_at: input.canceled_at ?? null,
+          ended_at: input.ended_at ?? null,
+        },
+        { onConflict: 'stripe_subscription_id' },
+      )
+    if (error) return { ok: false, error: error.message }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) }
+  }
+}
+
+/**
+ * Marque un abo Copine comme canceled (event customer.subscription.
+ * deleted). Le webhook appellera aussi setUserProfileCopineInactiveAdmin
+ * pour repasser is_copine=false côté fast-path.
+ */
+export async function markCopineSubscriptionCanceledAdmin(
+  stripeSubId: string,
+  canceledAt?: string | null,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const admin = createAdminClient()
+    const nowIso = new Date().toISOString()
+    const { error } = await admin
+      .from('copine_subscriptions')
+      .update({
+        status: 'canceled',
+        canceled_at: canceledAt ?? nowIso,
+        ended_at: nowIso,
+      })
+      .eq('stripe_subscription_id', stripeSubId)
+    if (error) return { ok: false, error: error.message }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) }
+  }
+}
+
+/**
+ * Set copine_stripe_customer_id sur user_profiles à la 1ère
+ * souscription Copine. Utilise admin client (la policy update sur
+ * user_profiles peut bloquer ces colonnes pour authenticated).
+ */
+export async function setUserProfileCopineStripeCustomerIdAdmin(
+  userId: string,
+  stripeCustomerId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const admin = createAdminClient()
+    const { error } = await admin
+      .from('user_profiles')
+      .update({ copine_stripe_customer_id: stripeCustomerId })
+      .eq('user_id', userId)
+    if (error) return { ok: false, error: error.message }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) }
+  }
+}
+
+/**
+ * Active le flag fast-path is_copine + set copine_since (jamais
+ * écrasé : coalesce avec la valeur existante). Appelé par le webhook
+ * sur status entitling (active/trialing/past_due).
+ *
+ * Implémentation : on lit d'abord copine_since pour ne le set que si
+ * NULL — plus simple que coalesce SQL côté Supabase JS client.
+ */
+export async function setUserProfileCopineActiveAdmin(
+  userId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const admin = createAdminClient()
+    const { data: existing, error: readErr } = await admin
+      .from('user_profiles')
+      .select('copine_since')
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (readErr) return { ok: false, error: readErr.message }
+
+    const patch: { is_copine: boolean; copine_since?: string } = {
+      is_copine: true,
+    }
+    if (!existing?.copine_since) {
+      patch.copine_since = new Date().toISOString()
+    }
+
+    const { error } = await admin
+      .from('user_profiles')
+      .update(patch)
+      .eq('user_id', userId)
+    if (error) return { ok: false, error: error.message }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) }
+  }
+}
+
+/**
+ * Désactive le flag fast-path is_copine. copine_since est préservé
+ * intentionnellement pour analytics fidélité (durée totale en tant
+ * que Copine, taux de réabonnement).
+ */
+export async function setUserProfileCopineInactiveAdmin(
+  userId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const admin = createAdminClient()
+    const { error } = await admin
+      .from('user_profiles')
+      .update({ is_copine: false })
+      .eq('user_id', userId)
+    if (error) return { ok: false, error: error.message }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) }
+  }
+}
+
+/**
+ * Lookup user_profiles par user_id (admin) avec colonnes Copine.
+ * Utilisé par le checkout (avant création Stripe customer) et le
+ * portal (lookup customer_id).
+ */
+export async function getUserProfileCopineByUserIdAdmin(
+  userId: string,
+): Promise<{
+  id: string
+  user_id: string
+  prenom: string | null
+  is_copine: boolean
+  copine_since: string | null
+  copine_stripe_customer_id: string | null
+} | null> {
+  try {
+    const admin = createAdminClient()
+    const { data, error } = await admin
+      .from('user_profiles')
+      .select('id, user_id, prenom, is_copine, copine_since, copine_stripe_customer_id')
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (error || !data) return null
+    return data as {
+      id: string
+      user_id: string
+      prenom: string | null
+      is_copine: boolean
+      copine_since: string | null
+      copine_stripe_customer_id: string | null
+    }
+  } catch {
+    return null
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return String(err)
+}

--- a/lib/supabase/queries/events.ts
+++ b/lib/supabase/queries/events.ts
@@ -34,6 +34,7 @@ const EVENT_SELECT = `
   inscrites_count,
   status,
   registration_mode,
+  early_access_until,
   created_at,
   updated_at
 `;

--- a/lib/supabase/queries/pro-perks.ts
+++ b/lib/supabase/queries/pro-perks.ts
@@ -1,0 +1,280 @@
+/**
+ * Queries Pro Perks (mig 50).
+ *
+ * 3 audiences distinctes :
+ *   • Prestataire (owner_all RLS) : ses propres perks, tous statuts.
+ *   • Copine (public_active_select RLS) : perks status='active' + dans
+ *     leur fenêtre temporelle (starts_at <= now <= ends_at).
+ *   • Admin (admin_all RLS) : queue de modération + override pour
+ *     debug.
+ *
+ * Lectures via createClient() (cookie session) quand RLS suffit ; admin
+ * client (service_role) UNIQUEMENT pour les helpers préfixés `Admin`,
+ * notamment pour la queue pending_review et l'incrément atomique de
+ * used_count au claim.
+ *
+ * Race-safety : l'incrément used_count utilise une UPDATE conditionnée
+ * (cf incrementPerkUsedCountAdmin) — Postgres garantit l'atomicité
+ * row-level. Voir Phase 5 D5.
+ */
+
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type {
+  ProPerk,
+  ProPerkClaim,
+  ProPerkStatus,
+  QueryResult,
+} from "@/lib/supabase/types";
+
+const PERK_SELECT = `
+  id,
+  prestataire_profile_id,
+  title,
+  description,
+  discount_type,
+  discount_value,
+  conditions,
+  max_uses,
+  used_count,
+  starts_at,
+  ends_at,
+  status,
+  rejection_reason,
+  created_at,
+  updated_at
+`;
+
+const CLAIM_SELECT = `
+  id,
+  perk_id,
+  user_id,
+  code_displayed,
+  marked_used_at,
+  created_at
+`;
+
+/* ─── Lectures prestataire (RLS owner_all) ─────────────────────── */
+
+/** Liste les perks créés par un prestataire (profil donné), tous
+ *  statuts confondus. RLS owner_all filtre déjà — on garde le filtre
+ *  explicite sur prestataire_profile_id pour clarté. */
+export async function listPerksForPrestataire(
+  prestataireProfileId: string,
+): Promise<QueryResult<ProPerk[]>> {
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from("pro_perks")
+      .select(PERK_SELECT)
+      .eq("prestataire_profile_id", prestataireProfileId)
+      .order("created_at", { ascending: false });
+    if (error) return { data: null, error: error.message };
+    return { data: (data ?? []) as unknown as ProPerk[], error: null };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
+/* ─── Lectures Copine (RLS public_active_select) ──────────────── */
+
+export interface ActivePerkWithPrestataire extends ProPerk {
+  prestataire: {
+    id: string;
+    nom: string;
+    slug: string | null;
+    ville: string | null;
+    categorie: string | null;
+  } | null;
+}
+
+/** Liste les perks actifs ouverts au public (Copines). RLS filtre
+ *  déjà sur status='active' + dans la fenêtre — on garde un filtre
+ *  côté query pour le défensif et l'ORDER BY. Embed prestataire via
+ *  FK pour afficher le nom/ville sur la card. */
+export async function listActivePerks(): Promise<
+  QueryResult<ActivePerkWithPrestataire[]>
+> {
+  try {
+    const supabase = await createClient();
+    const nowIso = new Date().toISOString();
+    const { data, error } = await supabase
+      .from("pro_perks")
+      .select(
+        `${PERK_SELECT}, prestataire:profiles!prestataire_profile_id(id, nom, slug, ville, categorie)`,
+      )
+      .eq("status", "active")
+      .lte("starts_at", nowIso)
+      .or(`ends_at.is.null,ends_at.gt.${nowIso}`)
+      .order("created_at", { ascending: false });
+    if (error) return { data: null, error: error.message };
+    // PostgREST renvoie la relation embed sous forme d'objet (1:1 FK) ;
+    // on normalise pour éviter le cas array si PostgREST hésite.
+    const rows = (data ?? []).map((row) => {
+      const r = row as unknown as ProPerk & {
+        prestataire?:
+          | { id: string; nom: string; slug: string | null; ville: string | null; categorie: string | null }
+          | { id: string; nom: string; slug: string | null; ville: string | null; categorie: string | null }[]
+          | null;
+      };
+      const presta = Array.isArray(r.prestataire) ? r.prestataire[0] ?? null : r.prestataire ?? null;
+      return { ...r, prestataire: presta } as ActivePerkWithPrestataire;
+    });
+    return { data: rows, error: null };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
+/** Liste les claims d'une Copine (ses propres codes). RLS self_select. */
+export async function listMyClaims(): Promise<QueryResult<ProPerkClaim[]>> {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return { data: [], error: null };
+    const { data, error } = await supabase
+      .from("pro_perk_claims")
+      .select(CLAIM_SELECT)
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false });
+    if (error) return { data: null, error: error.message };
+    return { data: (data ?? []) as unknown as ProPerkClaim[], error: null };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
+/* ─── Lectures admin (service_role) ───────────────────────────── */
+
+/** Queue de modération admin — perks par statut. service_role pour
+ *  voir TOUS les perks (RLS public_active_select cache les pending). */
+export async function listPerksByStatusAdmin(
+  status: ProPerkStatus,
+): Promise<ProPerk[]> {
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("pro_perks")
+      .select(PERK_SELECT)
+      .eq("status", status)
+      .order("created_at", { ascending: false });
+    if (error || !data) return [];
+    return data as unknown as ProPerk[];
+  } catch {
+    return [];
+  }
+}
+
+/** Count pending_review pour le badge nav admin. */
+export async function countPendingPerksAdmin(): Promise<number> {
+  try {
+    const admin = createAdminClient();
+    const { count } = await admin
+      .from("pro_perks")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "pending_review");
+    return count ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Récupère un perk par id (admin, bypass RLS). Utilisé par les API
+ *  routes admin pour fetch contexte (nom prestataire, email, etc.). */
+export async function getPerkByIdAdmin(perkId: string): Promise<ProPerk | null> {
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("pro_perks")
+      .select(PERK_SELECT)
+      .eq("id", perkId)
+      .maybeSingle();
+    if (error || !data) return null;
+    return data as unknown as ProPerk;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Incrément ATOMIQUE de used_count avec garde max_uses (cf Phase 5 D5).
+ *
+ * UPDATE conditionné : la row n'est patchée que si
+ * `max_uses IS NULL OR used_count < max_uses`. Si la condition est
+ * fausse au moment du UPDATE (ex : 2 Copines qui claim en parallèle au
+ * tout dernier slot), PostgreSQL renvoie 0 row affectée — on retourne
+ * { ok: false } et le caller doit rollback le claim qui vient d'être
+ * inséré (DELETE par id).
+ *
+ * Retourne aussi le used_count post-incrément pour permettre au caller
+ * de détecter le "dernier slot" si besoin UI.
+ */
+export async function incrementPerkUsedCountAdmin(
+  perkId: string,
+): Promise<{ ok: true; usedCount: number } | { ok: false; error: string }> {
+  try {
+    const admin = createAdminClient();
+    // .select() après .update() retourne les rows modifiées — vide si
+    // la condition WHERE a filtré la row au max.
+    const { data, error } = await admin
+      .from("pro_perks")
+      .update({ used_count: (await readUsedCount(perkId)) + 1 })
+      .eq("id", perkId)
+      .or("max_uses.is.null,used_count.lt.max_uses")
+      .select("used_count")
+      .maybeSingle();
+    if (error) return { ok: false, error: error.message };
+    if (!data) return { ok: false, error: "Plus de places disponibles." };
+    return { ok: true, usedCount: (data as { used_count: number }).used_count };
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) };
+  }
+}
+
+// Helper interne : lecture used_count courant pour construire le patch.
+// Note : entre cette read et le UPDATE, une autre transaction peut
+// incrémenter. La condition WHERE .or(...) protège quand même contre
+// le dépassement de max_uses (le UPDATE n'écrira pas si la condition
+// est fausse). Le pire cas est un skip d'un incrément (perte mineure
+// de stats used_count) — pas de dépassement de max_uses.
+async function readUsedCount(perkId: string): Promise<number> {
+  try {
+    const admin = createAdminClient();
+    const { data } = await admin
+      .from("pro_perks")
+      .select("used_count")
+      .eq("id", perkId)
+      .maybeSingle();
+    return (data as { used_count: number } | null)?.used_count ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/* ─── Mutation admin : modération ─────────────────────────────── */
+
+export async function setPerkStatusAdmin(
+  perkId: string,
+  status: ProPerkStatus,
+  rejectionReason?: string | null,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const admin = createAdminClient();
+    const { error } = await admin
+      .from("pro_perks")
+      .update({
+        status,
+        rejection_reason: status === "rejected" ? (rejectionReason ?? null) : null,
+      })
+      .eq("id", perkId);
+    if (error) return { ok: false, error: error.message };
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) };
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -331,6 +331,16 @@ export interface UserProfile {
   /** Préférences évolutives (jsonb, default {}). Clés notifications dans .notifications.
    *  Type ouvert pour autres clés futures sans casser le typage. */
   preferences: { notifications?: Partial<NotificationPrefs>; [key: string]: unknown } | null;
+  /** Pass Copine (mig 50). is_copine=true ⇔ abo Stripe Copine actif/trialing/past_due.
+   *  Modifié exclusivement par /api/stripe/webhook. À ne pas confondre avec
+   *  GamificationStatut='Copine' (niveau 20-99 points, free). */
+  is_copine: boolean;
+  /** Timestamp du premier checkout Copine réussi. Préservé après unsubscribe
+   *  pour analytics fidélité. NULL si jamais souscrit. */
+  copine_since: string | null;
+  /** FK vers Stripe customer attaché au flow Pass Copine. Peut être identique
+   *  à profiles.stripe_customer_id si la même personne est aussi prestataire. */
+  copine_stripe_customer_id: string | null;
   created_at: string;
 }
 
@@ -520,6 +530,34 @@ export interface Subscription {
   stripe_price_id: string;
   palier: SubscriptionPalier;
   duree_months: SubscriptionDureeMonths;
+  status: SubscriptionStatus;
+  current_period_start: string;
+  current_period_end: string;
+  cancel_at_period_end: boolean;
+  canceled_at: string | null;
+  ended_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+
+/* ─────────────────────────────────────────────────────────────
+   copine_subscriptions (mig 50) — Pass Copine utilisatrices
+
+   Mirror local des abos Stripe Pass Copine. Parallèle à Subscription
+   ci-dessus qui couvre les paliers prestataires (mig 49). Updates
+   exclusivement via /api/stripe/webhook (service_role bypass RLS).
+   ───────────────────────────────────────────────────────────── */
+
+export type CopinePlan = 'monthly' | 'annual';
+
+export interface CopineSubscription {
+  id: string;
+  user_id: string;
+  stripe_customer_id: string;
+  stripe_subscription_id: string;
+  stripe_price_id: string;
+  plan: CopinePlan;
   status: SubscriptionStatus;
   current_period_start: string;
   current_period_end: string;

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -575,6 +575,62 @@ export interface CopineSubscription {
 
 
 /* ─────────────────────────────────────────────────────────────
+   pro_perks + pro_perk_claims (mig 50) — Offres Cercle Pro
+   pour les Copines.
+
+   Les prestataires Cercle Pro créent des perks (status='pending_review'),
+   un admin modère (→ 'active' OU 'rejected' + rejection_reason), puis
+   les Copines actives peuvent claim chaque perk une fois (UNIQUE perk_id
+   × user_id), recevant un code unique HILMY-XXXX-YYYY.
+
+   ⚠️ INSERT pro_perk_claims est gaté DB-side par la SECURITY DEFINER
+   function is_user_copine(auth.uid()) — voir mig 50 §3. Tout INSERT
+   doit aussi être gaté côté API route (defense-in-depth Phase 5 D5).
+   ───────────────────────────────────────────────────────────── */
+
+export type ProPerkStatus =
+  | 'pending_review'
+  | 'active'
+  | 'paused'
+  | 'expired'
+  | 'rejected';
+
+export type ProPerkDiscountType = 'percentage' | 'fixed';
+
+export interface ProPerk {
+  id: string;
+  prestataire_profile_id: string;
+  title: string;
+  description: string | null;
+  discount_type: ProPerkDiscountType;
+  /** numeric côté DB — exposé en number côté TS. % si discount_type =
+   *  'percentage' (0-100), montant absolu si 'fixed' (devise = celle du
+   *  prestataire — non typée ici, le front affiche "X €" par défaut). */
+  discount_value: number;
+  conditions: string | null;
+  max_uses: number | null;
+  used_count: number;
+  starts_at: string;
+  ends_at: string | null;
+  status: ProPerkStatus;
+  rejection_reason: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProPerkClaim {
+  id: string;
+  perk_id: string;
+  user_id: string;
+  /** Format HILMY-XXXX-YYYY (contrainte CHECK regex côté DB). Généré
+   *  côté server-side via crypto.randomBytes — jamais côté client. */
+  code_displayed: string;
+  marked_used_at: string | null;
+  created_at: string;
+}
+
+
+/* ─────────────────────────────────────────────────────────────
    Gamification utilisatrices (mig 16 + backfill mig 48 — Sprint U1.5)
    ─────────────────────────────────────────────────────────────
    Aligné sur la BDD réelle :

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -217,6 +217,11 @@ export interface HilmyEvent {
 
   status: EventStatus;
   registration_mode: EventRegistrationMode;
+  /** Pass Copine (mig 50). Si non-NULL et > now(), seules les
+   *  utilisatrices Copines peuvent s'inscrire jusqu'à cette date.
+   *  Passé cette date, ouvert à tout le monde. NULL = pas de fenêtre
+   *  Copines. */
+  early_access_until: string | null;
   created_at: string;
   updated_at: string;
 

--- a/lib/types/je-cherche.ts
+++ b/lib/types/je-cherche.ts
@@ -56,6 +56,9 @@ export interface Demande {
 export interface DemandeWithProfile extends Demande {
   prenom: string | null
   avatar_url: string | null
+  /** Pass Copine (mig 50). Phase 6 : drive le badge `<MemberName>`. */
+  author_is_copine: boolean | null
+  author_copine_since: string | null
 }
 
 export interface DemandeResponse {
@@ -78,6 +81,9 @@ export interface DemandeResponse {
 export interface DemandeResponseWithProfile extends DemandeResponse {
   author_prenom: string | null
   author_avatar_url: string | null
+  /** Pass Copine (mig 50). Phase 6 : drive le badge `<MemberName>`. */
+  author_is_copine: boolean | null
+  author_copine_since: string | null
   prestataire?: {
     id: string
     slug: string

--- a/supabase/migrations/50_pass_copine.sql
+++ b/supabase/migrations/50_pass_copine.sql
@@ -1,0 +1,627 @@
+-- =====================================================================
+-- HILMY · 50 — Pass Copine (abonnement utilisatrices 4,99€/mois ou 49€/an)
+--
+-- Pose le schéma pour le Pass Copine — abonnement OPTIONNEL côté
+-- utilisatrices (PAS un paywall d'accès, juste deux paywalls hard :
+-- favoris > 10 et events accès anticipé).
+--
+-- Architecture (validée Jiji 2026-05-13) :
+--   • user_profiles : colonnes denormalisées is_copine + copine_since +
+--     copine_stripe_customer_id (fast-path gating, mirror du pattern
+--     profiles.palier mig 19)
+--   • copine_subscriptions : table mirror Stripe parallèle à
+--     subscriptions (mig 49) — FK user_id → auth.users, historique
+--     préservé pour analytics
+--   • Fonction is_user_copine() SECURITY DEFINER : réutilisée par le
+--     trigger favoris ET par la policy INSERT sur pro_perk_claims
+--   • pro_perks + pro_perk_claims : offres créées par prestataires
+--     Cercle Pro (modération admin via status='pending_review'),
+--     consommées par les Copines (1 code unique par perk × user)
+--   • events.early_access_until : paywall accès anticipé Copines 48h
+--   • Trigger favoris : 10 max si non-Copine, illimité si Copine
+--
+-- Décisions clés :
+--   • is_copine est strictement piloté par le webhook Stripe sur events
+--     Copine — JAMAIS modifiable côté authenticated (RLS sans update)
+--   • Cercle Pro (prestataire) ≠ Copine (utilisatrice). Une même
+--     personne physique peut être les deux (deux abos distincts).
+--     Le founder gift Cercle Pro ne donne PAS le Pass Copine.
+--   • PROMO_LANCEMENT-50% ne s'applique pas au Pass Copine.
+--
+-- Idempotente. Rollback complet en bas de fichier.
+--
+-- ⚠️ Application en prod : SUR DEMANDE EXPLICITE de Jiji, après backup.
+-- =====================================================================
+
+
+-- =====================================================================
+-- 1. user_profiles — colonnes Copine
+-- =====================================================================
+-- Fast-path gating column. Source de vérité = ces colonnes. Le mirror
+-- copine_subscriptions (section 2) garde l'historique mais le UI lit
+-- user_profiles directement pour les checks "is_copine ?".
+--
+-- copine_stripe_customer_id UNIQUE pour empêcher 2 utilisatrices de
+-- partager le même customer Stripe (1 customer = 1 user_profile).
+-- Une copine peut PARTAGER un customer Stripe avec sa fiche prestataire
+-- (même email donc même customer côté Stripe), mais ici on stocke
+-- uniquement le customer attaché au flow d'abonnement Copine.
+
+alter table public.user_profiles
+  add column if not exists is_copine boolean not null default false;
+
+alter table public.user_profiles
+  add column if not exists copine_since timestamptz;
+
+alter table public.user_profiles
+  add column if not exists copine_stripe_customer_id text;
+
+-- UNIQUE séparée pour idempotence (drop+recreate possible).
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.user_profiles'::regclass
+      and conname = 'user_profiles_copine_stripe_customer_id_key'
+  ) then
+    alter table public.user_profiles
+      add constraint user_profiles_copine_stripe_customer_id_key
+      unique (copine_stripe_customer_id);
+  end if;
+end $$;
+
+-- Index partiel : la majorité des user_profiles n'auront pas de
+-- copine_stripe_customer_id. Aussi : index sur is_copine pour les
+-- requêtes admin / analytics ("combien de Copines actives ?").
+create index if not exists user_profiles_copine_stripe_customer_id_idx
+  on public.user_profiles (copine_stripe_customer_id)
+  where copine_stripe_customer_id is not null;
+
+create index if not exists user_profiles_is_copine_idx
+  on public.user_profiles (is_copine)
+  where is_copine = true;
+
+comment on column public.user_profiles.is_copine is
+  'Vrai si abonnement Pass Copine actif. Modifié uniquement via webhook '
+  'Stripe (/api/stripe/webhook). Pas de policy UPDATE authenticated.';
+comment on column public.user_profiles.copine_since is
+  'Timestamp du premier checkout Copine réussi. Conservé après '
+  'unsubscribe pour analytics (réabonnement, fidélité).';
+comment on column public.user_profiles.copine_stripe_customer_id is
+  'FK vers Stripe customer (cus_xxx) attaché au flow Pass Copine. '
+  'Peut être identique à profiles.stripe_customer_id si la personne '
+  'est aussi prestataire avec le même email Stripe (1 customer Stripe '
+  '= 1 email, mais 2 subs distinctes côté Hilmy).';
+
+
+-- =====================================================================
+-- 2. copine_subscriptions — mirror Stripe parallèle à subscriptions
+-- =====================================================================
+-- Structure miroir de public.subscriptions (mig 49) mais :
+--   • FK user_id → auth.users (pas profile_id → profiles)
+--   • plan text in ('monthly','annual') au lieu de palier+duree_months
+--   • Mêmes statuts Stripe officiels
+--
+-- stripe_subscription_id UNIQUE = idempotency key des webhooks. La
+-- contrainte UNIQUE crée un index btree implicite — pas besoin d'en
+-- créer un explicite supplémentaire (cf risque 4 plan : redondance
+-- évitée).
+
+create table if not exists public.copine_subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+
+  -- Identifiants Stripe
+  stripe_customer_id text not null,
+  stripe_subscription_id text not null unique,
+  stripe_price_id text not null,
+
+  -- Décodage business
+  plan text not null,
+  status text not null,
+
+  -- Cycle de vie (timestamps Stripe)
+  current_period_start timestamptz not null,
+  current_period_end timestamptz not null,
+  cancel_at_period_end boolean not null default false,
+  canceled_at timestamptz,
+  ended_at timestamptz,
+
+  -- Audit
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint copine_subscriptions_plan_check
+    check (plan in ('monthly', 'annual')),
+
+  constraint copine_subscriptions_status_check
+    check (status in (
+      'active', 'past_due', 'canceled', 'incomplete',
+      'incomplete_expired', 'trialing', 'unpaid'
+    ))
+);
+
+-- Active sub par user (lookup le plus fréquent : "cette user paie-t-elle
+-- actuellement ?"). Partial index = compact + rapide.
+create index if not exists copine_subscriptions_user_active_idx
+  on public.copine_subscriptions (user_id, status)
+  where status = 'active';
+
+-- Ordre temporel : utile reporting + analytics churn
+create index if not exists copine_subscriptions_current_period_start_idx
+  on public.copine_subscriptions (current_period_start desc);
+
+
+-- ─── RLS ─────────────────────────────────────────────────────────────
+-- Owner read = la copine voit son propre abo dans son espace.
+-- Admin all = debug + audit.
+-- Pas de policy INSERT/UPDATE/DELETE pour authenticated : seul l'admin
+-- client (service_role via webhook) écrit.
+
+alter table public.copine_subscriptions enable row level security;
+
+drop policy if exists "copine_subscriptions_owner_read" on public.copine_subscriptions;
+create policy "copine_subscriptions_owner_read"
+  on public.copine_subscriptions
+  for select
+  to authenticated
+  using (user_id = auth.uid());
+
+drop policy if exists "copine_subscriptions_admin_all" on public.copine_subscriptions;
+create policy "copine_subscriptions_admin_all"
+  on public.copine_subscriptions
+  for all
+  to authenticated
+  using (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  )
+  with check (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+
+-- ─── Trigger updated_at ──────────────────────────────────────────────
+
+create or replace function public.bump_copine_subscriptions_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists copine_subscriptions_updated_at_trg on public.copine_subscriptions;
+create trigger copine_subscriptions_updated_at_trg
+  before update on public.copine_subscriptions
+  for each row execute function public.bump_copine_subscriptions_updated_at();
+
+
+comment on table public.copine_subscriptions is
+  'Mirror local des abonnements Stripe Pass Copine (mig 50). Updates '
+  'exclusivement via /api/stripe/webhook avec service_role. Parallèle '
+  'à public.subscriptions (mig 49) qui gère les abos prestataires.';
+
+comment on column public.copine_subscriptions.plan is
+  'monthly = 4,99€/mois · annual = 49€/an (2 mois offerts). Aligné sur '
+  'les 2 prices Stripe LIVE STRIPE_PRICE_COPINE_MONTHLY/ANNUAL.';
+
+
+-- =====================================================================
+-- 3. is_user_copine(uuid) — fonction réutilisable
+-- =====================================================================
+-- SECURITY DEFINER pour bypass RLS (le trigger favoris et la policy
+-- pro_perk_claims doivent pouvoir lire user_profiles.is_copine même
+-- quand le caller n'a pas de droit SELECT sur le row).
+--
+-- search_path explicite = parade contre l'attaque par hijacking
+-- (un schéma dans le path pourrait shadow public.user_profiles).
+--
+-- STABLE = même valeur dans une même transaction → optimisation planner.
+
+create or replace function public.is_user_copine(p_user_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select coalesce(
+    (select is_copine from public.user_profiles where user_id = p_user_id limit 1),
+    false
+  );
+$$;
+
+revoke all on function public.is_user_copine(uuid) from public;
+grant execute on function public.is_user_copine(uuid) to authenticated, anon;
+
+comment on function public.is_user_copine(uuid) is
+  'Retourne true si user_profiles.is_copine = true pour ce user_id. '
+  'SECURITY DEFINER : utilisable depuis triggers et RLS policies sans '
+  'que le caller ait besoin de droit SELECT direct sur user_profiles.';
+
+
+-- =====================================================================
+-- 4. pro_perks — offres prestataires Cercle Pro pour Copines
+-- =====================================================================
+-- Workflow modération :
+--   created → status='pending_review' (admin email envoyé via Resend)
+--   admin valide → status='active'
+--   admin refuse → status='rejected' + rejection_reason
+--   prestataire peut pauser → status='paused' (revisitable)
+--   ends_at < now() ou used_count >= max_uses → status='expired'
+--     (script cron ou check à la lecture)
+--
+-- prestataire_profile_id pointe sur profiles.id (la fiche prestataire),
+-- pas sur auth.users(id). Cohérent avec le pattern Hilmy (profiles
+-- = prestataires, user_profiles = membres).
+
+create table if not exists public.pro_perks (
+  id uuid primary key default gen_random_uuid(),
+  prestataire_profile_id uuid not null references public.profiles(id) on delete cascade,
+
+  -- Contenu
+  title text not null,
+  description text,
+  discount_type text not null,
+  discount_value numeric not null,
+  conditions text,
+
+  -- Limites
+  max_uses integer,
+  used_count integer not null default 0,
+
+  -- Fenêtre temporelle
+  starts_at timestamptz not null default now(),
+  ends_at timestamptz,
+
+  -- Workflow modération
+  status text not null default 'pending_review',
+  rejection_reason text,
+
+  -- Audit
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint pro_perks_title_length_check
+    check (char_length(title) between 1 and 80),
+  constraint pro_perks_description_length_check
+    check (description is null or char_length(description) <= 300),
+  constraint pro_perks_discount_type_check
+    check (discount_type in ('percentage', 'fixed')),
+  constraint pro_perks_discount_value_positive
+    check (discount_value > 0),
+  constraint pro_perks_max_uses_positive
+    check (max_uses is null or max_uses > 0),
+  constraint pro_perks_used_count_positive
+    check (used_count >= 0),
+  constraint pro_perks_status_check
+    check (status in ('pending_review', 'active', 'paused', 'expired', 'rejected')),
+  constraint pro_perks_window_check
+    check (ends_at is null or ends_at > starts_at)
+);
+
+-- Lookup principal côté Copines : "perks actives consultables maintenant"
+create index if not exists pro_perks_active_window_idx
+  on public.pro_perks (status, ends_at)
+  where status = 'active';
+
+-- Lookup côté prestataire : "mes offres"
+create index if not exists pro_perks_prestataire_idx
+  on public.pro_perks (prestataire_profile_id);
+
+-- Lookup admin modération : queue pending_review
+create index if not exists pro_perks_pending_review_idx
+  on public.pro_perks (created_at desc)
+  where status = 'pending_review';
+
+
+-- ─── RLS pro_perks ───────────────────────────────────────────────────
+-- SELECT public si active + dans la fenêtre temporelle (lecture par
+-- les Copines depuis /dashboard/utilisatrice/avantages).
+-- ALL owner si auth.uid() = profiles.user_id de la prestataire owner.
+-- ALL admin via jwt.
+
+alter table public.pro_perks enable row level security;
+
+drop policy if exists "pro_perks_public_active_select" on public.pro_perks;
+create policy "pro_perks_public_active_select"
+  on public.pro_perks
+  for select
+  to authenticated
+  using (
+    status = 'active'
+    and starts_at <= now()
+    and (ends_at is null or ends_at > now())
+  );
+
+drop policy if exists "pro_perks_owner_all" on public.pro_perks;
+create policy "pro_perks_owner_all"
+  on public.pro_perks
+  for all
+  to authenticated
+  using (
+    prestataire_profile_id in (
+      select id from public.profiles where user_id = auth.uid()
+    )
+  )
+  with check (
+    prestataire_profile_id in (
+      select id from public.profiles where user_id = auth.uid()
+    )
+  );
+
+drop policy if exists "pro_perks_admin_all" on public.pro_perks;
+create policy "pro_perks_admin_all"
+  on public.pro_perks
+  for all
+  to authenticated
+  using (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  )
+  with check (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+
+-- ─── Trigger updated_at pro_perks ────────────────────────────────────
+
+create or replace function public.bump_pro_perks_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists pro_perks_updated_at_trg on public.pro_perks;
+create trigger pro_perks_updated_at_trg
+  before update on public.pro_perks
+  for each row execute function public.bump_pro_perks_updated_at();
+
+
+comment on table public.pro_perks is
+  'Offres créées par prestataires Cercle Pro pour les Copines (mig 50). '
+  'Workflow modération admin (status pending_review → active). '
+  'Lecture publique uniquement si active + dans la fenêtre temporelle.';
+
+
+-- =====================================================================
+-- 5. pro_perk_claims — consommations Copines (1 code par perk × user)
+-- =====================================================================
+-- UNIQUE(perk_id, user_id) = une Copine ne peut claim qu'une fois la
+-- même perk. Re-visit du détail = retourne le code existant.
+--
+-- code_displayed format HILMY-XXXX-YYYY (4 hex chars + 4 hex chars
+-- uppercase). 16^8 = 4.3 milliards de combinaisons par perk. Collision
+-- attendue après ~65k claims (anniversaire), mais UNIQUE(perk_id,
+-- user_id) garantit qu'aucune Copine n'aura 2 codes — pas de risque
+-- pratique de collision. Génération côté server-only via crypto.
+--
+-- INSERT policy : seuls les Copines actives peuvent claim
+-- (is_user_copine(auth.uid()) = true).
+
+create table if not exists public.pro_perk_claims (
+  id uuid primary key default gen_random_uuid(),
+  perk_id uuid not null references public.pro_perks(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  code_displayed text not null,
+  marked_used_at timestamptz,
+  created_at timestamptz not null default now(),
+
+  constraint pro_perk_claims_unique_per_user_perk
+    unique (perk_id, user_id),
+
+  constraint pro_perk_claims_code_format_check
+    check (code_displayed ~ '^HILMY-[A-F0-9]{4}-[A-F0-9]{4}$')
+);
+
+create index if not exists pro_perk_claims_user_idx
+  on public.pro_perk_claims (user_id, created_at desc);
+
+create index if not exists pro_perk_claims_perk_idx
+  on public.pro_perk_claims (perk_id);
+
+
+-- ─── RLS pro_perk_claims ─────────────────────────────────────────────
+-- SELECT : la Copine voit ses propres claims (pour afficher le code).
+-- INSERT : la Copine peut claim une perk UNIQUEMENT si elle est
+--          actuellement Copine active (is_user_copine = true).
+-- UPDATE : la Copine peut marquer "utilisé" (marked_used_at).
+-- DELETE : interdit (pas de policy) — anti-fraude. Si besoin, admin via
+--          service_role.
+
+alter table public.pro_perk_claims enable row level security;
+
+drop policy if exists "pro_perk_claims_self_select" on public.pro_perk_claims;
+create policy "pro_perk_claims_self_select"
+  on public.pro_perk_claims
+  for select
+  to authenticated
+  using (user_id = auth.uid());
+
+drop policy if exists "pro_perk_claims_copine_insert" on public.pro_perk_claims;
+create policy "pro_perk_claims_copine_insert"
+  on public.pro_perk_claims
+  for insert
+  to authenticated
+  with check (
+    user_id = auth.uid()
+    and public.is_user_copine(auth.uid())
+  );
+
+drop policy if exists "pro_perk_claims_self_update" on public.pro_perk_claims;
+create policy "pro_perk_claims_self_update"
+  on public.pro_perk_claims
+  for update
+  to authenticated
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+drop policy if exists "pro_perk_claims_admin_all" on public.pro_perk_claims;
+create policy "pro_perk_claims_admin_all"
+  on public.pro_perk_claims
+  for all
+  to authenticated
+  using (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  )
+  with check (
+    coalesce(((auth.jwt() -> 'user_metadata') ->> 'is_admin')::boolean, false)
+  );
+
+
+comment on table public.pro_perk_claims is
+  'Consommation d''une pro_perk par une Copine (mig 50). UNIQUE(perk_id, '
+  'user_id) = 1 code par perk × user. code_displayed généré server-side '
+  'via crypto.randomBytes, format HILMY-XXXX-YYYY. INSERT gated par '
+  'is_user_copine() — RLS bloque les non-Copines.';
+
+
+-- =====================================================================
+-- 6. events.early_access_until — paywall accès anticipé Copines
+-- =====================================================================
+-- NULL (par défaut sur les events existants) = pas d'accès anticipé,
+-- inscriptions ouvertes à tout le monde immédiatement.
+-- NOT NULL = inscriptions ouvertes aux Copines depuis maintenant et au
+-- reste du monde à partir de cette date.
+--
+-- Vérification doublée :
+--   1. Côté UI : EventPaywallSheet si early_access_until > now() AND
+--      !is_copine
+--   2. Côté server action inscription : 403 si check côté serveur fail
+--
+-- Aucune valeur backfillée — toutes les rows existantes restent à NULL.
+
+alter table public.events
+  add column if not exists early_access_until timestamptz;
+
+create index if not exists events_early_access_until_idx
+  on public.events (early_access_until)
+  where early_access_until is not null;
+
+comment on column public.events.early_access_until is
+  'Si non-NULL et > now(), seules les Copines (user_profiles.is_copine = '
+  'true) peuvent s''inscrire à l''event jusqu''à cette date. Passé cette '
+  'date, ouvert à tout le monde. NULL = pas de fenêtre Copines (default).';
+
+
+-- =====================================================================
+-- 7. Trigger favoris : 10 max si non-Copine
+-- =====================================================================
+-- BEFORE INSERT sur public.favoris. Si user est Copine → pass. Sinon
+-- compte les favoris existants : ≥ 10 → exception P0001.
+--
+-- SECURITY DEFINER + search_path explicite : on doit pouvoir compter
+-- les favoris d'un user même si le contexte d'exécution n'a pas le
+-- droit SELECT direct (cas service_role ou trigger chained).
+--
+-- Erreur capturée côté server action favori : on retourne un payload
+-- { ok: false, code: 'FAVORITES_LIMIT_REACHED' } pour permettre au
+-- client d'ouvrir le FavorisPaywallSheet (UX paywall propre).
+--
+-- Edge case : un user qui avait 50 favoris en étant Copine, puis qui
+-- unsubscribe, conserve ses 50 favoris (pas de delete rétroactif). Mais
+-- il ne peut plus en ajouter tant qu'il n'a pas re-souscrit OU
+-- supprimé pour redescendre sous 10. Comportement intentionnel.
+
+create or replace function public.check_favoris_limit_for_non_copine()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_count integer;
+begin
+  -- Copine : aucune limite
+  if public.is_user_copine(NEW.user_id) then
+    return NEW;
+  end if;
+
+  -- Non-Copine : compte les favoris existants
+  select count(*) into v_count
+  from public.favoris
+  where user_id = NEW.user_id;
+
+  if v_count >= 10 then
+    raise exception 'FAVORITES_LIMIT_REACHED'
+      using errcode = 'P0001',
+            hint = 'Limite 10 favoris atteinte pour user non-Copine. Pass Copine = illimité.';
+  end if;
+
+  return NEW;
+end;
+$$;
+
+drop trigger if exists favoris_limit_for_non_copine_trg on public.favoris;
+create trigger favoris_limit_for_non_copine_trg
+  before insert on public.favoris
+  for each row execute function public.check_favoris_limit_for_non_copine();
+
+
+comment on function public.check_favoris_limit_for_non_copine() is
+  'Trigger BEFORE INSERT sur favoris (mig 50). Bloque l''insert avec '
+  'P0001 si user non-Copine a déjà 10 favoris. Copines = illimité. '
+  'SECURITY DEFINER pour count fiable indépendamment du contexte RLS.';
+
+
+-- =====================================================================
+-- 8. NOTIFY PostgREST — recharger le schéma exposé par l'API
+-- =====================================================================
+
+notify pgrst, 'reload schema';
+
+
+-- =====================================================================
+-- ROLLBACK (à exécuter en SQL si besoin de défaire la mig 50)
+-- =====================================================================
+-- Ordre inverse strict pour respecter les dépendances FK + functions.
+--
+-- -- Triggers + fonctions trigger
+-- drop trigger if exists favoris_limit_for_non_copine_trg on public.favoris;
+-- drop function if exists public.check_favoris_limit_for_non_copine();
+-- drop trigger if exists pro_perks_updated_at_trg on public.pro_perks;
+-- drop function if exists public.bump_pro_perks_updated_at();
+-- drop trigger if exists copine_subscriptions_updated_at_trg on public.copine_subscriptions;
+-- drop function if exists public.bump_copine_subscriptions_updated_at();
+--
+-- -- events column
+-- drop index if exists public.events_early_access_until_idx;
+-- alter table public.events drop column if exists early_access_until;
+--
+-- -- pro_perk_claims (FK vers pro_perks → drop avant pro_perks)
+-- drop policy if exists "pro_perk_claims_admin_all" on public.pro_perk_claims;
+-- drop policy if exists "pro_perk_claims_self_update" on public.pro_perk_claims;
+-- drop policy if exists "pro_perk_claims_copine_insert" on public.pro_perk_claims;
+-- drop policy if exists "pro_perk_claims_self_select" on public.pro_perk_claims;
+-- drop table if exists public.pro_perk_claims cascade;
+--
+-- -- pro_perks
+-- drop policy if exists "pro_perks_admin_all" on public.pro_perks;
+-- drop policy if exists "pro_perks_owner_all" on public.pro_perks;
+-- drop policy if exists "pro_perks_public_active_select" on public.pro_perks;
+-- drop table if exists public.pro_perks cascade;
+--
+-- -- is_user_copine (utilisée par trigger favoris + RLS pro_perk_claims —
+-- -- doit être dropée APRÈS ces deux)
+-- drop function if exists public.is_user_copine(uuid);
+--
+-- -- copine_subscriptions
+-- drop policy if exists "copine_subscriptions_admin_all" on public.copine_subscriptions;
+-- drop policy if exists "copine_subscriptions_owner_read" on public.copine_subscriptions;
+-- drop table if exists public.copine_subscriptions cascade;
+--
+-- -- user_profiles : drop columns (préserver constraint en commentaire
+-- -- au cas où des rows ont copine_since/customer_id à archiver)
+-- drop index if exists public.user_profiles_is_copine_idx;
+-- drop index if exists public.user_profiles_copine_stripe_customer_id_idx;
+-- alter table public.user_profiles drop constraint if exists user_profiles_copine_stripe_customer_id_key;
+-- alter table public.user_profiles drop column if exists copine_stripe_customer_id;
+-- alter table public.user_profiles drop column if exists copine_since;
+-- alter table public.user_profiles drop column if exists is_copine;
+--
+-- notify pgrst, 'reload schema';


### PR DESCRIPTION
Implémentation complète du Pass Copine (abonnement utilisatrices 4,99€/mois ou 49€/an).

## 6 phases

- **Phase 1** (`2c2c99c`) : schéma DB — `copine_subscriptions`, `pro_perks`, `pro_perk_claims`, colonnes `user_profiles`, trigger favoris
- **Phase 2** (`c4dfd67`) : Stripe checkout/portal/webhook, dispatch par price_id
- **Phase 3** (`ed6a02c`) : pages `/pass-copine` + `/dashboard/utilisatrice/copine` + nav + badge
- **Phase 4** (`f6803b6`) : paywalls favoris + events accès anticipé + defense-in-depth API
- **Phase 5** (`1d6a206`) : Pro Perks — création prestataire + modération admin + claim Copine
- **Phase 6** (`aa66465`) : badge Copine sur surfaces sociales + email welcome

## Volumétrie

Total : **54 fichiers, +5108 / -110**. Migration 50 déjà appliquée sur Supabase prod.

## ⚠️ NE PAS MERGER avant validation des tests sur preview Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)