### PR TITLE
fix(onboarding): câble le paiement dans le funnel d'inscription (Modèle B)

### DIFF
--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -87,9 +87,18 @@ export async function POST(request: Request) {
   // Body shape 1 : { plan: 'monthly' | 'annual' } → résolution Copine
   // Body shape 2 : { price_id } → flow Copine si isCopinePriceId, sinon
   //                prestataire si isKnownPriceId, sinon 422.
-  const bodyObj = body as { price_id?: unknown; plan?: unknown }
+  const bodyObj = body as {
+    price_id?: unknown
+    plan?: unknown
+    context?: unknown
+  }
   let priceId: string
   let isCopineFlow = false
+  // Contexte funnel d'inscription : si présent, le retour de paiement
+  // pointe vers /onboarding/prestataire/publiee au lieu du dashboard
+  // fiche. N'affecte que le flow prestataire (le Pass Copine a ses
+  // propres URLs). Toute autre valeur est ignorée (= checkout dashboard).
+  const isOnboarding = bodyObj.context === 'onboarding'
 
   if (typeof bodyObj.plan === 'string') {
     if (bodyObj.plan !== 'monthly' && bodyObj.plan !== 'annual') {
@@ -203,8 +212,15 @@ export async function POST(request: Request) {
       mode: 'subscription',
       customer: stripeCustomerId,
       line_items: [{ price: priceId, quantity: 1 }],
-      success_url: buildStripeSuccessUrl(origin, profile.id as string),
-      cancel_url: buildStripeCancelUrl(origin),
+      success_url: buildStripeSuccessUrl(
+        origin,
+        profile.id as string,
+        isOnboarding ? 'onboarding' : undefined,
+      ),
+      cancel_url: buildStripeCancelUrl(
+        origin,
+        isOnboarding ? 'onboarding' : undefined,
+      ),
       ...(discounts && discounts.length > 0
         ? { discounts }
         : { allow_promotion_codes: true }),

--- a/app/onboarding/prestataire/google/page.tsx
+++ b/app/onboarding/prestataire/google/page.tsx
@@ -166,7 +166,11 @@ export default function GoogleOnboardingPage() {
       setError(insErr.message)
       return
     }
-    router.push('/onboarding/prestataire/publiee')
+    // Modèle B : la fiche est créée en 'pending' (invisible). C'est le
+    // PAIEMENT qui la rend visible. On enchaîne sur le choix de formule
+    // → Stripe Checkout → /publiee. Tant qu'elle n'a pas payé, la fiche
+    // reste pending invisible (voulu).
+    router.push('/tarifs?from=onboarding')
   }
 
   if (checking) {

--- a/app/onboarding/prestataire/manuel/page.tsx
+++ b/app/onboarding/prestataire/manuel/page.tsx
@@ -226,7 +226,11 @@ export default function ManuelOnboardingPage() {
       setError(insErr.message)
       return
     }
-    router.push('/onboarding/prestataire/publiee')
+    // Modèle B : la fiche est créée en 'pending' (invisible). C'est le
+    // PAIEMENT qui la rend visible. On enchaîne sur le choix de formule
+    // → Stripe Checkout → /publiee. Tant qu'elle n'a pas payé, la fiche
+    // reste pending invisible (voulu).
+    router.push('/tarifs?from=onboarding')
   }
 
   const current = steps[etape]

--- a/app/onboarding/prestataire/publiee/page.tsx
+++ b/app/onboarding/prestataire/publiee/page.tsx
@@ -20,7 +20,7 @@ export default function PubliePage() {
           className="flex items-center gap-4"
         >
           <GoldLine width={40} />
-          <span className="overline text-or">Écran 3 · Bien envoyé</span>
+          <span className="overline text-or">C'est en ligne · Bienvenue dans la team</span>
           <GoldLine width={40} />
         </motion.div>
 
@@ -39,9 +39,9 @@ export default function PubliePage() {
           transition={{ duration: 0.9, delay: 0.4, ease: [0.22, 1, 0.36, 1] }}
           className="font-serif text-[clamp(2.5rem,5vw,4rem)] font-light leading-[1.05]"
         >
-          Ta fiche est partie,
+          Ta fiche est en ligne ! <span aria-hidden>🎉</span>
           <br />
-          <em className="italic text-or">entre nos mains.</em>
+          <em className="italic text-or">Les copines peuvent déjà te trouver.</em>
         </motion.h1>
 
         <motion.p
@@ -50,8 +50,9 @@ export default function PubliePage() {
           transition={{ duration: 1, delay: 0.7 }}
           className="max-w-lg font-serif text-[17px] italic leading-[1.6] text-creme/80"
         >
-          On la regarde à la main, tranquillement. Tu reçois un email dès qu&apos;elle
-          est en ligne — 48h max, souvent moins.
+          Elle est visible dans l&apos;annuaire Hilmy dès maintenant. Tu peux la
+          peaufiner quand tu veux depuis ton espace — photos, services, ton
+          histoire.
         </motion.p>
 
         <motion.div
@@ -61,15 +62,13 @@ export default function PubliePage() {
           className="grid w-full gap-4 sm:grid-cols-3"
         >
           {[
-            { k: 'Étape 1', v: 'Fiche reçue ✓' },
-            { k: 'Étape 2', v: 'Relecture par l\'équipe' },
-            { k: 'Étape 3', v: 'Mise en ligne + email' },
-          ].map((s, i) => (
+            { k: 'Fiche créée', v: 'C\'est fait ✓' },
+            { k: 'Paiement confirmé', v: 'Merci à toi ✓' },
+            { k: 'En ligne', v: 'Visible dans l\'annuaire ✓' },
+          ].map((s) => (
             <div
               key={s.k}
-              className={`rounded-sm border border-or/20 p-5 text-left backdrop-blur ${
-                i === 0 ? 'bg-or/10' : 'bg-vert-dark/40'
-              }`}
+              className="rounded-sm border border-or/20 bg-or/10 p-5 text-left backdrop-blur"
             >
               <p className="overline text-or">{s.k}</p>
               <p className="mt-2 text-[14px] text-creme">{s.v}</p>

--- a/app/tarifs/_components/WizardSection.tsx
+++ b/app/tarifs/_components/WizardSection.tsx
@@ -45,6 +45,11 @@ interface WizardSectionProps {
    *  on cache le SubscribeButton (l'API /api/stripe/checkout refuserait
    *  de toute façon avec 403, mais on évite la friction UX). */
   isFounder?: boolean
+  /** True quand la prestataire arrive du funnel d'inscription
+   *  (/tarifs?from=onboarding). Propage le contexte 'onboarding' au
+   *  checkout pour que le retour de paiement la mène à
+   *  /onboarding/prestataire/publiee. */
+  fromOnboarding?: boolean
 }
 
 const STEPS: {
@@ -142,7 +147,7 @@ function computeReco(answers: Record<number, WizardKey>): Palier {
   return best
 }
 
-export function WizardSection({ initialPalier, initialPromo, stripePriceIds, isFounder }: WizardSectionProps = {}) {
+export function WizardSection({ initialPalier, initialPromo, stripePriceIds, isFounder, fromOnboarding }: WizardSectionProps = {}) {
   const [currentStep, setCurrentStep] = useState<1 | 2 | 3>(1)
   const [answers, setAnswers] = useState<Record<number, WizardKey>>({})
   // Si un palier vient du deep-link, on saute le wizard et on affiche
@@ -637,6 +642,7 @@ export function WizardSection({ initialPalier, initialPromo, stripePriceIds, isF
                       priceId={priceId}
                       label="Je choisis cette formule"
                       ariaLabel={aria}
+                      context={fromOnboarding ? 'onboarding' : undefined}
                     />
                   )
                 }

--- a/app/tarifs/page.tsx
+++ b/app/tarifs/page.tsx
@@ -71,6 +71,7 @@ type SearchParams = Promise<{
   palier?: string
   promo?: string
   utm_source?: string
+  from?: string
 }>
 
 export const metadata: Metadata = {
@@ -208,6 +209,12 @@ export default async function TarifsPage({
   const initialPalier = normalizePalier(params.palier)
   const initialPromo = params.promo?.trim().toUpperCase() || undefined
   const isFounder = await isAuthenticatedFounder()
+  // Funnel d'inscription : la prestataire arrive de manuel/google après
+  // avoir créé sa fiche (pending invisible). On masque les éléments hors
+  // contexte (sélecteur d'audience, sections "lieux") — elle est déjà
+  // prestataire — et on propage le contexte au checkout pour qu'elle
+  // atterrisse sur /publiee après paiement.
+  const fromOnboarding = params.from === 'onboarding'
 
   // Log analytics dev mode (deep-link mobile UTM tracking).
   if (process.env.NODE_ENV !== 'production' && params.utm_source) {
@@ -224,37 +231,67 @@ export default async function TarifsPage({
         {/* HERO */}
         <section className="overflow-hidden px-6 py-28 text-center md:px-20 md:py-32">
           <div className="mx-auto max-w-[780px]">
-            <span className="mb-7 inline-block text-[13px] font-medium uppercase tracking-[.28em] text-or">
-              Tarifs Hilmy
-            </span>
-            <h1 className="mb-7 font-serif text-[clamp(44px,6.5vw,80px)] font-light leading-[1.05] tracking-tight">
-              Ce que tu fais avec amour mérite{' '}
-              <em className="font-normal italic text-or">d'être vu</em>.
-            </h1>
-            <p className="mx-auto mb-11 max-w-[540px] text-[19px] leading-relaxed text-texte-sec">
-              Visibilité, entraide, bonnes adresses entre copines. Trouve ta place dans la team Hilmy.
-            </p>
-            <div className="flex flex-wrap justify-center gap-3.5">
-              <a
-                href="#audience"
-                className="inline-block rounded-full bg-vert px-8 py-4 text-[15px] font-medium text-creme transition-all hover:-translate-y-0.5 hover:bg-vert/90 hover:shadow-[0_8px_24px_rgba(15,61,46,0.18)]"
-              >
-                Trouver ma formule
-              </a>
-              <a
-                href="#lieux"
-                className="inline-block rounded-full border border-vert bg-transparent px-8 py-4 text-[15px] font-medium text-vert transition-all hover:bg-vert hover:text-creme"
-              >
-                Je tiens un lieu
-              </a>
-            </div>
+            {fromOnboarding ? (
+              <>
+                <span className="mb-7 inline-block text-[13px] font-medium uppercase tracking-[.28em] text-or">
+                  Dernière étape
+                </span>
+                <h1 className="mb-7 font-serif text-[clamp(44px,6.5vw,80px)] font-light leading-[1.05] tracking-tight">
+                  Ta fiche est prête.{' '}
+                  <em className="font-normal italic text-or">
+                    Choisis ta formule pour la publier.
+                  </em>
+                </h1>
+                <p className="mx-auto mb-11 max-w-[540px] text-[19px] leading-relaxed text-texte-sec">
+                  Tu as rempli ta fiche, il ne reste qu'à choisir ton
+                  abonnement. Dès le paiement, elle est en ligne et les copines
+                  peuvent te trouver.
+                </p>
+                <div className="flex flex-wrap justify-center gap-3.5">
+                  <a
+                    href="#wizard"
+                    className="inline-block rounded-full bg-vert px-8 py-4 text-[15px] font-medium text-creme transition-all hover:-translate-y-0.5 hover:bg-vert/90 hover:shadow-[0_8px_24px_rgba(15,61,46,0.18)]"
+                  >
+                    Choisir ma formule
+                  </a>
+                </div>
+              </>
+            ) : (
+              <>
+                <span className="mb-7 inline-block text-[13px] font-medium uppercase tracking-[.28em] text-or">
+                  Tarifs Hilmy
+                </span>
+                <h1 className="mb-7 font-serif text-[clamp(44px,6.5vw,80px)] font-light leading-[1.05] tracking-tight">
+                  Ce que tu fais avec amour mérite{' '}
+                  <em className="font-normal italic text-or">d'être vu</em>.
+                </h1>
+                <p className="mx-auto mb-11 max-w-[540px] text-[19px] leading-relaxed text-texte-sec">
+                  Visibilité, entraide, bonnes adresses entre copines. Trouve ta place dans la team Hilmy.
+                </p>
+                <div className="flex flex-wrap justify-center gap-3.5">
+                  <a
+                    href="#audience"
+                    className="inline-block rounded-full bg-vert px-8 py-4 text-[15px] font-medium text-creme transition-all hover:-translate-y-0.5 hover:bg-vert/90 hover:shadow-[0_8px_24px_rgba(15,61,46,0.18)]"
+                  >
+                    Trouver ma formule
+                  </a>
+                  <a
+                    href="#lieux"
+                    className="inline-block rounded-full border border-vert bg-transparent px-8 py-4 text-[15px] font-medium text-vert transition-all hover:bg-vert hover:text-creme"
+                  >
+                    Je tiens un lieu
+                  </a>
+                </div>
+              </>
+            )}
             <div className="mt-16 flex justify-center opacity-60">
               <span aria-hidden className="block h-px w-20 bg-or" />
             </div>
           </div>
         </section>
 
-        {/* AUDIENCE SELECTOR */}
+        {/* AUDIENCE SELECTOR — masqué en mode inscription (déjà prestataire) */}
+        {!fromOnboarding && (
         <section
           id="audience"
           className="bg-[#f0e3d0] px-6 py-20 scroll-mt-24 md:px-20"
@@ -314,6 +351,7 @@ export default async function TarifsPage({
             </div>
           </div>
         </section>
+        )}
 
         {/* WIZARD GUIDÉ */}
         <section id="wizard" className="bg-creme py-24 scroll-mt-24 md:py-28">
@@ -334,9 +372,14 @@ export default async function TarifsPage({
             initialPromo={initialPromo}
             stripePriceIds={buildStripePriceIds()}
             isFounder={isFounder}
+            fromOnboarding={fromOnboarding}
           />
         </section>
 
+        {/* CTA STRIP 1 + SECTION LIEUX — masqués en mode inscription
+            (la prestataire est déjà sur son parcours, pas un lieu) */}
+        {!fromOnboarding && (
+        <>
         {/* CTA STRIP 1 */}
         <section className="bg-creme-deep px-6 py-16 text-center md:px-20">
           <div className="mx-auto max-w-[1200px]">
@@ -402,6 +445,8 @@ export default async function TarifsPage({
             <LieuPricing />
           </div>
         </section>
+        </>
+        )}
 
         {/* POURQUOI HILMY */}
         <section className="bg-white px-6 py-24 md:px-20 md:py-28">
@@ -439,12 +484,14 @@ export default async function TarifsPage({
               >
                 Trouver ma formule
               </a>
-              <a
-                href="#lieux"
-                className="inline-block rounded-full border border-vert bg-transparent px-8 py-4 text-[15px] font-medium text-vert transition-all hover:bg-vert hover:text-creme"
-              >
-                Je tiens un lieu
-              </a>
+              {!fromOnboarding && (
+                <a
+                  href="#lieux"
+                  className="inline-block rounded-full border border-vert bg-transparent px-8 py-4 text-[15px] font-medium text-vert transition-all hover:bg-vert hover:text-creme"
+                >
+                  Je tiens un lieu
+                </a>
+              )}
             </div>
           </div>
         </section>
@@ -518,12 +565,14 @@ export default async function TarifsPage({
               >
                 Je choisis ma formule
               </a>
-              <a
-                href="#lieux"
-                className="inline-block rounded-full border border-creme bg-transparent px-8 py-4 text-[15px] font-medium text-creme transition-all hover:bg-creme hover:text-vert"
-              >
-                Je veux ma fiche lieu
-              </a>
+              {!fromOnboarding && (
+                <a
+                  href="#lieux"
+                  className="inline-block rounded-full border border-creme bg-transparent px-8 py-4 text-[15px] font-medium text-creme transition-all hover:bg-creme hover:text-vert"
+                >
+                  Je veux ma fiche lieu
+                </a>
+              )}
             </div>
           </div>
         </section>

--- a/components/SubscribeButton.tsx
+++ b/components/SubscribeButton.tsx
@@ -12,6 +12,11 @@ interface Props {
   ariaLabel?: string
   /** ClassName optionnelle pour custom styling (sinon défaut Hilmy or). */
   className?: string
+  /** Contexte du checkout. 'onboarding' = la prestataire arrive du
+   *  funnel d'inscription (/tarifs?from=onboarding) → le retour de
+   *  paiement la mène à /onboarding/prestataire/publiee. Absent =
+   *  checkout depuis le dashboard d'une fiche existante. */
+  context?: 'onboarding'
 }
 
 /**
@@ -29,6 +34,7 @@ export function SubscribeButton({
   label,
   ariaLabel,
   className,
+  context,
 }: Props) {
   const [loading, setLoading] = useState(false)
 
@@ -38,7 +44,10 @@ export function SubscribeButton({
       const res = await fetch('/api/stripe/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ price_id: priceId }),
+        body: JSON.stringify({
+          price_id: priceId,
+          ...(context ? { context } : {}),
+        }),
       })
 
       if (!res.ok) {

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -206,13 +206,37 @@ export function buildCopineCancelUrl(origin: string): string {
    NEXT_PUBLIC_SITE_URL qui peut diverger entre Preview/Prod). Le
    profile_id est injecté en query param pour détecter côté client si
    le user actuel matche celui qui a payé (cas multi-comptes browser).
+
+   `context` distingue le retour de paiement :
+     • undefined (défaut) — checkout depuis le dashboard d'une fiche
+       existante → retour sur la fiche.
+     • 'onboarding' — checkout branché à la fin du funnel d'inscription
+       (manuel/google → /tarifs?from=onboarding → Stripe). Le paiement
+       rend la fiche visible (Modèle B : abo actif = visible via RLS),
+       on atterrit sur l'écran de confirmation d'inscription /publiee.
    ────────────────────────────────────────────────────────────────── */
 
-export function buildStripeSuccessUrl(origin: string, profileId: string): string {
+export function buildStripeSuccessUrl(
+  origin: string,
+  profileId: string,
+  context?: 'onboarding',
+): string {
+  if (context === 'onboarding') {
+    return `${origin}/onboarding/prestataire/publiee?stripe_success=1`
+  }
   return `${origin}/dashboard/prestataire/fiche?stripe_success=1&profile_id=${encodeURIComponent(profileId)}`
 }
 
-export function buildStripeCancelUrl(origin: string): string {
+export function buildStripeCancelUrl(
+  origin: string,
+  context?: 'onboarding',
+): string {
+  if (context === 'onboarding') {
+    // Abandon au checkout pendant l'inscription : la fiche reste en
+    // 'pending' invisible (voulu). On ramène la prestataire sur le
+    // choix de formule pour réessayer, sans perdre le contexte.
+    return `${origin}/tarifs?from=onboarding&stripe_canceled=1`
+  }
   return `${origin}/tarifs?stripe_canceled=1`
 }
 

--- a/supabase/migrations/54_paywall_visibility_and_unlock.sql
+++ b/supabase/migrations/54_paywall_visibility_and_unlock.sql
@@ -1,0 +1,328 @@
+-- =====================================================================
+-- HILMY · 54 — Paywall = visibilité publique, pas entrée du funnel
+--                + déverrouillage de l'inscription prestataire
+--
+-- CONTEXTE
+--   Depuis le verrouillage paywall (~2026-05-11, posé en live SANS
+--   migration versionnée), l'inscription prestataire est cassée :
+--   le trigger BEFORE INSERT `lock_profile_insert()` réécrit le
+--   status de TOUTE insertion authenticated en 'draft'. Or 'draft'
+--   est un état orphelin :
+--     - invisible dans l'annuaire (RLS public = status='approved'),
+--     - absent de la file admin (`prestataires-a-valider` = 'pending'),
+--     - jamais touché par le webhook Stripe (qui ne set que `palier`).
+--   Résultat : fiche écrite nulle part + 404. 0 inscription réussie
+--   depuis le lock (live : 0 pending, 1 draft, 22 approved, 4 rejected).
+--
+-- DÉCISION (Modèle B, validée Jiji)
+--   Le PAIEMENT — et non la validation admin — déclenche la visibilité.
+--   La validation admin devient un pouvoir de SUSPENSION a posteriori
+--   (retirer une fiche si la prestataire n'est pas une femme ou ne
+--   respecte pas les règles).
+--     1. L'inscription recrée un `status='pending'` (état neutre, plus
+--        un point de blocage : une pending PAYÉE est déjà visible).
+--     2. Une fiche est publique SSI :
+--          status NOT IN ('suspended','rejected','ghost','draft')
+--          AND ( paywall_exempt=true
+--                OR abonnement actif/trialing/past_due )
+--        ⮑ la visibilité NE DÉPEND PLUS de status='approved'.
+--     3. Les 22 fiches approved actuelles (fondatrices incluses) sont
+--        grandfathered À VIE via `paywall_exempt=true`.
+--     4. La fenêtre founders est fermée (plus d'auto-flag is_founder).
+--
+--   DÉVIATION ASSUMÉE (à valider) : la règle demandée était
+--   `status NOT IN ('suspended','rejected')`. J'ajoute 'ghost' et
+--   'draft' à l'exclusion par défense en profondeur :
+--     - 'ghost'  = fiches importées de l'annuaire, non réclamées →
+--                  ne doivent jamais devenir publiques par accident.
+--     - 'draft'  = brouillons → idem.
+--   En pratique ces fiches n'ont ni abo ni paywall_exempt donc la 2e
+--   condition les exclut déjà, mais l'exclusion explicite évite toute
+--   fuite si un flag leur était posé un jour par erreur.
+--
+--   ⚠️ Le paywall N'EST PAS désactivé : une fiche SANS abonnement actif
+--   et SANS exemption reste invisible, quel que soit son status. Le
+--   paiement reste le cœur du business model.
+--
+-- TRAÇABILITÉ ("plus de SQL posé en live sans trace")
+--   Cette migration re-déclare AUSSI les objets posés en live hors
+--   versioning (lock_profile_insert corrigé, lock_profile_update
+--   inchangé, CHECK status, policies publiques nettoyées de leurs
+--   doublons) pour resynchroniser git ↔ prod.
+--
+-- ⚠️ NE PAS APPLIQUER sans demande explicite de Jiji + backup.
+--    Artefact en revue. Idempotente.
+-- =====================================================================
+
+
+-- =====================================================================
+-- B.5 — Colonne paywall_exempt (grandfathering)
+-- =====================================================================
+-- Flag dédié plutôt que réutiliser is_founder : live is_founder=17
+-- mais approved=22 → réutiliser is_founder laisserait 5 fiches
+-- approuvées invisibles. On découple grandfathering ↔ statut founder.
+
+alter table public.profiles
+  add column if not exists paywall_exempt boolean not null default false;
+
+comment on column public.profiles.paywall_exempt is
+  'mig 54 — Grandfathering paywall. true = fiche publique sans abo '
+  'Stripe actif (acquis historique). Posé à true pour les 22 fiches '
+  'approved au moment du fix. Les nouvelles fiches restent à false : '
+  'leur visibilité dépend d''un abonnement actif.';
+
+-- Index partial : la grande majorité des profiles resteront false.
+create index if not exists profiles_paywall_exempt_idx
+  on public.profiles (paywall_exempt)
+  where paywall_exempt = true;
+
+-- Grandfathering des fiches déjà approuvées (capture les 22).
+-- WHERE status='approved' = idempotent et borné aux acquis.
+update public.profiles
+  set paywall_exempt = true
+  where status = 'approved';
+
+
+-- =====================================================================
+-- B.1 — lock_profile_insert() : clamp en 'pending' (et non 'draft')
+-- =====================================================================
+-- SEULE ligne changée vs le live : NEW.status := 'pending'.
+-- Tous les autres garde-fous anti-tamper sont CONSERVÉS : une
+-- inscription authenticated ne peut toujours pas s'auto-approuver,
+-- se donner un palier, un stripe_customer_id, le flag founder, etc.
+-- L'exception 'ghost' (imports admin) reste intacte.
+
+create or replace function public.lock_profile_insert()
+  returns trigger
+  language plpgsql
+  security definer
+  set search_path to 'public'
+as $$
+begin
+  if auth.role() = 'authenticated' then
+    -- Modération : toute inscription entre en file de validation.
+    -- 'ghost' (fiches importées) garde son statut ; tout le reste
+    -- est forcé en 'pending' (← FIX : était 'draft', état orphelin).
+    if new.status is distinct from 'ghost' then
+      new.status := 'pending';
+    end if;
+
+    -- Monétisation & anti-tamper : valeurs imposées server-side.
+    new.palier             := 'standard';
+    new.stripe_customer_id := null;
+    new.is_founder         := false;
+    new.approved_at        := null;
+    new.note_moyenne       := 0;
+    new.nb_avis            := 0;
+    new.nb_vues            := 0;
+    -- paywall_exempt suit son DEFAULT false : aucune nouvelle fiche
+    -- ne peut s'auto-exempter du paywall.
+    new.paywall_exempt     := false;
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.lock_profile_insert() is
+  'mig 54 — BEFORE INSERT profiles. Force status=pending (file de '
+  'validation) pour les inscriptions authenticated + verrouille les '
+  'champs monétisation/réputation. ''ghost'' (imports) exempté.';
+
+
+-- =====================================================================
+-- B.3 — lock_profile_update() : re-déclaration À L'IDENTIQUE
+-- =====================================================================
+-- Aucun changement fonctionnel. Re-déclaré uniquement pour la
+-- traçabilité git (l'objet vit en prod hors versioning). Empêche une
+-- prestataire de s'auto-approuver / changer son palier via UPDATE.
+-- On y ajoute paywall_exempt côté anti-tamper : impossible de se
+-- l'octroyer soi-même par UPDATE.
+
+create or replace function public.lock_profile_update()
+  returns trigger
+  language plpgsql
+  security definer
+  set search_path to 'public'
+as $$
+begin
+  if auth.role() = 'authenticated' then
+    new.status            := old.status;
+    new.palier            := old.palier;
+    new.slug              := old.slug;
+    new.user_id           := old.user_id;
+    new.stripe_customer_id := old.stripe_customer_id;
+    new.is_founder        := old.is_founder;
+    new.approved_at       := old.approved_at;
+    new.note_moyenne      := old.note_moyenne;
+    new.nb_avis           := old.nb_avis;
+    new.nb_vues           := old.nb_vues;
+    new.source_import     := old.source_import;
+    new.paywall_exempt    := old.paywall_exempt;
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.lock_profile_update() is
+  'mig 54 — BEFORE UPDATE profiles. Anti-self-approval : fige les '
+  'champs sensibles (status, palier, stripe, founder, paywall_exempt…) '
+  'pour les UPDATE authenticated. Re-déclaré pour traçabilité git.';
+
+
+-- =====================================================================
+-- B.7 — CHECK constraint status : re-déclaration (traçabilité)
+-- =====================================================================
+-- Identique au live. 'draft' + 'suspended' CONSERVÉS (décision Jiji) :
+-- 'draft' n'est plus produit par l'inscription mais reste un état
+-- valide pour d'éventuels usages futurs ; 'suspended' = levier modé.
+
+do $$
+begin
+  if exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.profiles'::regclass
+      and conname = 'profiles_status_check'
+  ) then
+    alter table public.profiles drop constraint profiles_status_check;
+  end if;
+
+  alter table public.profiles
+    add constraint profiles_status_check
+    check (status in (
+      'draft', 'pending', 'approved', 'rejected', 'suspended', 'ghost'
+    ));
+end $$;
+
+
+-- =====================================================================
+-- B.4 — Visibilité publique : helper abo actif + policy SELECT unique
+-- =====================================================================
+-- Pourquoi un helper SECURITY DEFINER ?
+--   La RLS de `subscriptions` interdit toute lecture à anon
+--   (subscriptions_owner_read = authenticated owner only). Une
+--   sous-requête `subscriptions` dans la policy SELECT de `profiles`
+--   échouerait donc côté visiteur anonyme. Le helper, en SECURITY
+--   DEFINER, lit subscriptions avec les droits du propriétaire de la
+--   fonction et expose UNIQUEMENT un booléen "abo actif ?". Aucune
+--   donnée Stripe n'est divulguée.
+--
+-- DÉVIATION ASSUMÉE (à valider) : le helper est volontairement scopé
+--   aux subscriptions (`profile_has_active_subscription`) et NON nommé
+--   `profile_is_publicly_visible`. Raison : un helper qui relirait
+--   `profiles` (pour status + paywall_exempt) créerait une récursion
+--   RLS sur la table qu'on est en train de policer. On inline donc
+--   `status` et `paywall_exempt` directement dans la policy (lecture
+--   de la row courante, pas de récursion) et on ne délègue au helper
+--   que la partie subscriptions inaccessible à anon.
+
+create or replace function public.profile_has_active_subscription(p_profile_id uuid)
+  returns boolean
+  language sql
+  security definer
+  stable
+  set search_path to 'public'
+as $$
+  select exists (
+    select 1
+    from public.subscriptions s
+    where s.profile_id = p_profile_id
+      and s.status in ('active', 'trialing', 'past_due')
+      and s.current_period_end > now()
+  );
+$$;
+
+comment on function public.profile_has_active_subscription(uuid) is
+  'mig 54 — SECURITY DEFINER. Retourne true si le profile a un abo '
+  'Stripe actif/trialing/past_due non expiré. Lecture seule, n''expose '
+  'qu''un booléen (anon ne peut pas lire subscriptions en direct). '
+  'Utilisé par la policy SELECT publique de profiles.';
+
+-- Révoquer l'accès large puis n'autoriser que les rôles applicatifs.
+revoke all on function public.profile_has_active_subscription(uuid) from public;
+grant execute on function public.profile_has_active_subscription(uuid)
+  to anon, authenticated;
+
+-- ─── Nettoyage des policies SELECT publiques en double ──────────────
+-- Live = 2 policies publiques redondantes sur status='approved' :
+--   "public read approved profiles" + "Public peut voir les profils
+--   approuves". On les remplace par UNE seule policy gated paywall.
+-- Les policies owner-select et ghost-select ne sont PAS touchées.
+
+drop policy if exists "public read approved profiles" on public.profiles;
+drop policy if exists "Public peut voir les profils approuves" on public.profiles;
+drop policy if exists "public read visible profiles" on public.profiles;
+
+create policy "public read visible profiles"
+  on public.profiles
+  for select
+  to anon, authenticated
+  using (
+    status not in ('suspended', 'rejected', 'ghost', 'draft')
+    and (
+      paywall_exempt = true
+      or public.profile_has_active_subscription(id)
+    )
+  );
+
+comment on policy "public read visible profiles" on public.profiles is
+  'mig 54 (Modèle B) — Visibilité publique = status non suspendu/refusé/'
+  'ghost/draft ET (grandfathered OU abo actif). Le PAIEMENT déclenche la '
+  'visibilité, plus la validation admin. Une pending payée est visible ; '
+  'une approved non payée ne l''est pas. Remplace les 2 anciennes '
+  'policies publiques (doublon, gating sur status=approved).';
+
+
+-- =====================================================================
+-- B.6 — Récupération de la fiche orpheline (Lucie Mathieu)
+-- =====================================================================
+-- Seule inscription post-lock : forcée en 'draft' par le bug. On la
+-- replace en 'pending' (état neutre). Sous Modèle B elle restera
+-- invisible tant qu'elle n'a pas d'abo actif — cohérent : elle n'a
+-- jamais payé. Si on veut lui offrir la visibilité, poser
+-- paywall_exempt=true manuellement (décision commerciale, hors mig).
+-- Borné par id + status='draft' = idempotent, sans effet de bord.
+
+update public.profiles
+  set status = 'pending'
+  where id = '128b0b66-9de1-43c8-8d1a-d764abd7f216'
+    and status = 'draft';
+
+
+-- =====================================================================
+-- Fermeture de la fenêtre founders
+-- =====================================================================
+-- Décision Jiji : plus de nouveaux founders auto-flaggés. Le trigger
+-- trg_auto_flag_founder lit app_config.founders_window_open ; on le
+-- passe à false. Les 17 founders existants restent founders.
+
+update public.app_config
+  set founders_window_open = false,
+      updated_at = now()
+  where id = true;
+
+
+-- =====================================================================
+-- NOTIFY PostgREST — recharger le schéma exposé
+-- =====================================================================
+notify pgrst, 'reload schema';
+
+
+-- =====================================================================
+-- ROLLBACK (manuel, si besoin de défaire la mig 54)
+-- =====================================================================
+-- -- 1. Restaurer la policy publique simple (sans paywall) :
+-- drop policy if exists "public read visible profiles" on public.profiles;
+-- create policy "public read approved profiles" on public.profiles
+--   for select to anon, authenticated using (status = 'approved');
+-- -- 2. Helper :
+-- drop function if exists public.profile_has_active_subscription(uuid);
+-- -- 3. Re-forcer 'draft' à l'insertion (revenir au comportement buggé) :
+-- --    (déconseillé — recasse l'inscription)
+-- -- 4. Colonne grandfathering :
+-- drop index if exists public.profiles_paywall_exempt_idx;
+-- alter table public.profiles drop column if exists paywall_exempt;
+-- -- 5. Ré-ouvrir la fenêtre founders :
+-- update public.app_config set founders_window_open = true where id = true;
+-- notify pgrst, 'reload schema';

--- a/supabase/migrations/55_drop_legacy_status_sync_trigger.sql
+++ b/supabase/migrations/55_drop_legacy_status_sync_trigger.sql
@@ -1,0 +1,75 @@
+-- =====================================================================
+-- HILMY · 55 — Suppression du trigger legacy sync_profile_status
+--
+-- CONTEXTE
+--   Objet posé en live SANS migration versionnée (découvert au test de
+--   la mig 54). Vestige du MODÈLE A, où `profiles.status` portait la
+--   visibilité publique : le statut d'abonnement Stripe pilotait
+--   directement le statut de modération.
+--
+--   Trigger : sync_profile_status_trigger
+--             AFTER INSERT OR UPDATE OF status ON public.subscriptions
+--   Fonction : public.sync_profile_status_from_subscription()
+--
+--   Comportement (re-déclaré ici pour traçabilité avant suppression) :
+--     - abo canceled/unpaid/incomplete_expired
+--         + profil NOT IN (draft,rejected)  → profiles.status='suspended'
+--     - abo active/trialing + profil='suspended' → profiles.status='approved'
+--     (founders exemptés : RETURN sans rien faire)
+--
+-- POURQUOI ON LE SUPPRIME (Modèle B)
+--   Sous le Modèle B (mig 54), la visibilité est gérée par la RLS
+--   policy "public read visible profiles" qui interroge directement
+--   l'abonnement (`profile_has_active_subscription`). `profiles.status`
+--   redevient un axe PUREMENT modération (humain). Ce trigger :
+--     1. ANNULE le pouvoir de suspension admin : si on suspend une
+--        fiche qui paie encore, le prochain webhook Stripe (active)
+--        la repasse en 'approved'. Inacceptable.
+--     2. CONFOND « a arrêté de payer » et « suspendue par modération »
+--        en écrivant 'suspended' sur lapse d'abo — redondant avec la
+--        policy (abo inactif = déjà invisible) et polluant pour la modé.
+--
+--   → On découple les axes : status = modération, abo = monétisation.
+--     Le webhook continue de gérer profiles.palier (features), pas le
+--     status. La visibilité vit dans la policy.
+--
+-- ⚠️ Idempotente. DROP IF EXISTS. À appliquer après backup, sur
+--    demande explicite Jiji.
+-- =====================================================================
+
+drop trigger if exists sync_profile_status_trigger on public.subscriptions;
+drop function if exists public.sync_profile_status_from_subscription();
+
+-- =====================================================================
+-- NOTIFY PostgREST — recharger le schéma exposé
+-- =====================================================================
+notify pgrst, 'reload schema';
+
+-- =====================================================================
+-- ROLLBACK (manuel — restaure le trigger legacy tel qu'il était)
+-- =====================================================================
+-- create or replace function public.sync_profile_status_from_subscription()
+--   returns trigger language plpgsql security definer set search_path to 'public'
+-- as $$
+-- declare
+--   v_is_founder boolean;
+--   v_current_status text;
+-- begin
+--   select is_founder, status into v_is_founder, v_current_status
+--   from public.profiles where id = new.profile_id;
+--   if v_is_founder then return new; end if;
+--   if new.status in ('canceled','unpaid','incomplete_expired')
+--      and v_current_status not in ('draft','rejected') then
+--     update public.profiles set status='suspended', updated_at=now()
+--     where id = new.profile_id;
+--   end if;
+--   if new.status in ('active','trialing') and v_current_status = 'suspended' then
+--     update public.profiles set status='approved', updated_at=now()
+--     where id = new.profile_id;
+--   end if;
+--   return new;
+-- end; $$;
+-- create trigger sync_profile_status_trigger
+--   after insert or update of status on public.subscriptions
+--   for each row execute function public.sync_profile_status_from_subscription();
+-- notify pgrst, 'reload schema';


### PR DESCRIPTION
## Contexte

L'inscription prestataire était cassée depuis la pose du paywall (~2026-05-11) : la fiche n'était écrite nulle part / 404. Cette PR répare l'inscription **sans rouvrir la faille** qui permettrait de publier sans payer.

**Modèle B (validé)** : c'est le **paiement**, pas la validation admin, qui déclenche la visibilité. La modération devient un pouvoir de **suspension a posteriori**. La fiche naît `pending` invisible et ne devient visible qu'avec un abo actif (RLS mig 54). Aucun chemin ne publie sans paiement.

## Parcours câblé (manuel + google)

`INSERT pending` → `/tarifs?from=onboarding` → choix formule (wizard existant) → Stripe Checkout (`context: onboarding`) → succès → `/onboarding/prestataire/publiee`.

Abandon au checkout → retour `/tarifs?from=onboarding&stripe_canceled=1`, fiche reste **pending invisible** (voulu, relance hors scope).

## Changements

**Funnel / paiement**
- `lib/stripe.ts` — `buildStripeSuccessUrl` / `buildStripeCancelUrl` acceptent `context?: 'onboarding'` → success = `/publiee`, cancel = retour funnel.
- `app/api/stripe/checkout/route.ts` — lit `body.context`, le passe aux builders (flow **prestataire only** ; Pass Copine intact). Valeur inconnue ignorée = comportement dashboard.
- `components/SubscribeButton.tsx` — prop `context` optionnelle ajoutée au POST.
- `app/tarifs/_components/WizardSection.tsx` — prop `fromOnboarding`, propage le contexte au bouton.
- `app/tarifs/page.tsx` — détecte `from=onboarding` : hero adapté (« Dernière étape / Choisis ta formule pour la publier »), masque le hors-contexte (sélecteur d'audience, sections lieux, CTA « Je tiens un lieu »).
- `app/onboarding/prestataire/{manuel,google}/page.tsx` — redirect post-INSERT vers `/tarifs?from=onboarding`.
- `app/onboarding/prestataire/publiee/page.tsx` — copy Modèle B : la fiche est **en ligne immédiatement** (fini le « relecture → mise en ligne 48h »).

**Migrations versionnées (déjà appliquées en prod — « plus de SQL posé en live sans trace »)**
- `supabase/migrations/54_paywall_visibility_and_unlock.sql` — visibilité Modèle B (RLS), helper `profile_has_active_subscription`, clamp insert/update, colonne `paywall_exempt` + grandfathering des 22 fiches approuvées (dont 17 founders), fermeture fenêtre founders.
- `supabase/migrations/55_drop_legacy_status_sync_trigger.sql` — suppression du trigger legacy `sync_profile_status_from_subscription` (découplage modération / monétisation).

## Tests RLS (déjà passés sur prod, a→g)
clamp pending/standard/founder=f/exempt=f · exempt=22, approved-not-exempt=0, founders=17 · pending+abo visible · approved-sans-abo invisible · suspended+abo invisible · ghost+exempt invisible · founder UPDATE garde exempt + reste visible.

## Test plan
- [ ] Inscription manuelle : remplir fiche → atterrir sur `/tarifs?from=onboarding` (hero « Dernière étape », pas de section lieux)
- [ ] Choisir une formule → Stripe Checkout → payer (carte test) → retour `/publiee` « Ta fiche est en ligne »
- [ ] Vérifier la fiche visible dans l'annuaire après paiement (webhook → abo actif → RLS)
- [ ] Abandon checkout → retour `/tarifs?from=onboarding&stripe_canceled=1`, fiche reste invisible
- [ ] Même parcours via google places
- [ ] `/tarifs` sans `from=onboarding` inchangé (audience + lieux visibles)
- [ ] Founder sur `/tarifs` voit toujours le message « accès Cercle Pro à vie »

🤖 Generated with [Claude Code](https://claude.com/claude-code)