### PR TITLE
fix(queries): laisse la RLS gater la visibilité publique (Modèle B)

### DIFF
--- a/lib/supabase/queries/prestataires.ts
+++ b/lib/supabase/queries/prestataires.ts
@@ -1,7 +1,11 @@
 /**
  * Queries prestataires (table : profiles).
- * Respecte les RLS : seules les fiches status='approved' sont visibles
- * publiquement. Pas de bypass admin côté client.
+ * Respecte les RLS (Modèle B) : la visibilité publique est gérée par la
+ * policy "public read visible profiles" (status hors
+ * suspended/rejected/ghost/draft ET (paywall_exempt OU abonnement actif)).
+ * Une fiche payée est donc visible dès le paiement, même en status
+ * 'pending' — on ne filtre plus status='approved' côté requête, c'est la
+ * RLS qui gate la visibilité. Pas de bypass admin côté client.
  *
  * ⚠️ Privacy is_founder : tous les helpers de ce fichier appliquent
  * `toPublicPrestataire` qui strippe le champ `is_founder` et substitue
@@ -87,7 +91,7 @@ export async function getPionnieres(
     const { data, error } = await supabase
       .from("profiles")
       .select(PRESTATAIRE_SELECT)
-      .eq("status", "approved")
+      // Modèle B : visibilité gérée par la RLS (plus de filtre status='approved')
       .not("user_id", "is", null)
       .order("created_at", { ascending: true })
       .limit(limit);
@@ -107,7 +111,7 @@ export async function getAllPrestataires(): Promise<QueryResult<Prestataire[]>> 
     const { data, error } = await supabase
       .from("profiles")
       .select(PRESTATAIRE_SELECT)
-      .eq("status", "approved")
+      // Modèle B : visibilité gérée par la RLS (plus de filtre status='approved')
       .order("approved_at", { ascending: false, nullsFirst: false });
 
     if (error) return { data: null, error: error.message };
@@ -194,7 +198,7 @@ export async function getPublicPrestataire(
       .from('profiles')
       .select(PUBLIC_PRESTATAIRE_SELECT)
       .eq('slug', slug)
-      .eq('status', 'approved')
+      // Modèle B : visibilité gérée par la RLS (plus de filtre status='approved')
       .maybeSingle()
 
     if (error) return { data: null, error: error.message }
@@ -224,7 +228,7 @@ export async function getPrestataireBySlug(
       .from("profiles")
       .select(PRESTATAIRE_SELECT)
       .eq("slug", slug)
-      .eq("status", "approved")
+      // Modèle B : visibilité gérée par la RLS (plus de filtre status='approved')
       .maybeSingle();
 
     if (error) return { data: null, error: error.message };
@@ -280,7 +284,7 @@ export async function getPrestatairesByCategorie(
     const { data, error } = await supabase
       .from("profiles")
       .select(PRESTATAIRE_SELECT)
-      .eq("status", "approved")
+      // Modèle B : visibilité gérée par la RLS (plus de filtre status='approved')
       .eq("categorie", categorie)
       .order("approved_at", { ascending: false, nullsFirst: false });
 
@@ -301,7 +305,7 @@ export async function getPrestatairesByVille(
     const { data, error } = await supabase
       .from("profiles")
       .select(PRESTATAIRE_SELECT)
-      .eq("status", "approved")
+      // Modèle B : visibilité gérée par la RLS (plus de filtre status='approved')
       .ilike("ville", ville)
       .order("approved_at", { ascending: false, nullsFirst: false });
 


### PR DESCRIPTION
## Contexte
Le Modèle B (modération `status` découplée de la monétisation, visibilité pilotée par l'abonnement via RLS) est appliqué en base mais **6 requêtes applicatives filtraient encore en dur `status='approved'`** (ancien Modèle A). Résultat sur une fiche payée en `pending` :
- page publique → **404**
- absente du **listing** annuaire
- **coordonnées de contact masquées**

Diagnostic prod confirmé sur la fiche test `TENDANCES COIFFURES` : abonnement actif, `profile_has_active_subscription` = TRUE, anon_visible = 1 au niveau DB — donc le paiement + webhook + RLS fonctionnent, seul le filtre applicatif cassait l'affichage.

## Changement
On retire `.eq('status','approved')` des 6 fonctions et on laisse la policy RLS `public read visible profiles` gater la visibilité (`status` hors suspended/rejected/ghost/draft **ET** (`paywall_exempt` OU abonnement actif)).

Fonctions touchées :
- `getPionnieres`
- `getAllPrestataires`
- `getPublicPrestataire`
- `getPrestataireBySlug`
- `getPrestatairesByCategorie`
- `getPrestatairesByVille`

+ en-tête du fichier réécrit pour décrire le Modèle B.

## Sécurité
Pas d'affaiblissement : c'est toujours la RLS qui décide. Une fiche non payée / suspended / draft ne remontera jamais. On supprime juste un double-filtre applicatif redondant et désormais incorrect.

## Test plan
- [ ] `/prestataires/tendances-coiffures-mqjd` → HTTP 200 (plus de 404)
- [ ] La fiche remonte dans le listing public
- [ ] Coordonnées de contact affichées pour la fiche payée

## Hors-scope (rappels)
- 9,50 CHF réellement débités sur l'abo test Stripe (coupon 100% non appliqué) → à vérifier/rembourser + annuler l'abo test.
- Le webhook `handleCheckoutCompleted` ignore le résultat de `upsertSubscriptionAdmin` et renvoie 200 même en échec silencieux → robustesse à planifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)