### PR TITLE
fix(db): réintroduit 'paused' dans profiles_status_check (migration 58)

### DIFF
--- a/supabase/migrations/58_readd_paused_status.sql
+++ b/supabase/migrations/58_readd_paused_status.sql
@@ -1,0 +1,31 @@
+-- 58_readd_paused_status.sql
+--
+-- Réintroduit 'paused' dans le CHECK constraint profiles_status_check.
+--
+-- Contexte : la migration 54 a redéclaré profiles_status_check sans 'paused'
+-- (oubli — son commentaire ne mentionne que draft/suspended comme "conservés").
+-- Résultat : tout UPDATE status='paused' était rejeté par la DB depuis la 54,
+-- alors que le code (toggle de visibilité dans les paramètres prestataire,
+-- labelFor, canToggle) s'appuie sur ce statut. La mise en pause d'une fiche
+-- était donc cassée à la racine, indépendamment de la RLS.
+--
+-- Fix : on ré-ajoute 'paused' à la liste autorisée. Changement purement
+-- additif (aucune ligne existante invalidée) et idempotent (drop + recreate).
+-- Complète la migration 57 qui rend déjà 'paused' invisible côté RLS.
+
+do $$
+begin
+  if exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.profiles'::regclass
+      and conname = 'profiles_status_check'
+  ) then
+    alter table public.profiles drop constraint profiles_status_check;
+  end if;
+
+  alter table public.profiles
+    add constraint profiles_status_check
+    check (status in (
+      'draft', 'pending', 'approved', 'rejected', 'suspended', 'ghost', 'paused'
+    ));
+end $$;


### PR DESCRIPTION
## Problème
La **mise en pause d'une fiche est cassée en prod** depuis la migration 54.

En auditant le test pause (suite à #98), j'ai découvert que le CHECK constraint live est :
```
CHECK (status = ANY (ARRAY['draft','pending','approved','rejected','suspended','ghost']))
```
→ **`'paused'` absent.** La migration 54 a redéclaré le constraint sans `'paused'` (oubli : son commentaire ne liste que `draft`/`suspended` comme conservés). Résultat : tout `UPDATE status='paused'` est rejeté par la DB, alors que le toggle de visibilité (`app/dashboard/prestataire/parametres/page.tsx`), `labelFor` et `canToggle` s'appuient dessus.

C'est indépendant de la RLS : sans ce fix, la migration 57 (#98) et le code de pause ne peuvent rien faire — aucune ligne ne peut atteindre le statut `paused`.

## Fix
Migration 58 : ré-ajoute `'paused'` à la liste autorisée. **Additif** (aucune ligne existante invalidée), **idempotent** (drop + recreate).

## Test plan (après merge + application)
- [ ] `UPDATE status='paused'` accepté par la DB.
- [ ] Fiche `paused` → page publique 404 + absente de l'annuaire (web + app native, via RLS migration 57).
- [ ] Dé-pause → fiche revient en `pending` et redevient visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)