### PR TITLE
feat(stripe): code ENSEMBLE — essai gratuit à date fixe (1er sept 2026)

### DIFF
--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -91,6 +91,7 @@ export async function POST(request: Request) {
     price_id?: unknown
     plan?: unknown
     context?: unknown
+    promo_code?: unknown
   }
   let priceId: string
   let isCopineFlow = false
@@ -170,6 +171,38 @@ export async function POST(request: Request) {
     )
   }
 
+  // ─── Code trial (ex. ENSEMBLE) : essai gratuit à date fixe ────────
+  // Optionnel. Transmis par le front dans le body. Un code trial pose
+  // subscription_data.trial_end (date fixe identique pour toutes) et
+  // REMPLACE toute autre remise — pas de cumul LANCEMENT50. Résolu
+  // server-side contre la table promo_codes (type='trial', active).
+  // Code inconnu / expiré / trop proche de trial_end → ignoré
+  // silencieusement → le checkout retombe en paiement normal.
+  let trialEndUnix: number | null = null
+  const promoCodeRaw =
+    typeof bodyObj.promo_code === 'string' ? bodyObj.promo_code.trim() : ''
+  if (promoCodeRaw) {
+    const { data: trialRow } = await admin
+      .from('promo_codes')
+      .select('trial_end, valid_from, valid_until, active, type')
+      .ilike('code', promoCodeRaw)
+      .eq('type', 'trial')
+      .eq('active', true)
+      .maybeSingle()
+    if (trialRow?.trial_end) {
+      const end = Math.floor(new Date(trialRow.trial_end as string).getTime() / 1000)
+      const nowSec = Math.floor(Date.now() / 1000)
+      const validNow =
+        new Date(trialRow.valid_from as string).getTime() <= Date.now() &&
+        (!trialRow.valid_until ||
+          new Date(trialRow.valid_until as string).getTime() > Date.now())
+      // Stripe exige trial_end >= now + 48h.
+      if (validNow && end > nowSec + 48 * 3600) {
+        trialEndUnix = end
+      }
+    }
+  }
+
   // Crée ou retrouve un customer Stripe.
   let stripeCustomerId = profile.stripe_customer_id as string | null
   if (!stripeCustomerId) {
@@ -204,7 +237,8 @@ export async function POST(request: Request) {
 
   // Crée la Checkout Session
   // Stripe API : allow_promotion_codes et discounts sont mutuellement exclusifs.
-  const discounts = getActiveStripeDiscounts()
+  // Un trial actif désactive l'injection LANCEMENT50 (pas de cumul).
+  const discounts = trialEndUnix ? undefined : getActiveStripeDiscounts()
   const origin = new URL(request.url).origin
   let session
   try {
@@ -221,15 +255,25 @@ export async function POST(request: Request) {
         origin,
         isOnboarding ? 'onboarding' : undefined,
       ),
-      ...(discounts && discounts.length > 0
-        ? { discounts }
-        : { allow_promotion_codes: true }),
+      ...(trialEndUnix
+        ? { allow_promotion_codes: false }
+        : discounts && discounts.length > 0
+          ? { discounts }
+          : { allow_promotion_codes: true }),
       metadata: {
         profile_id: profile.id as string,
         palier: decoded.palier,
         duree_months: String(decoded.duree_months),
       },
       subscription_data: {
+        ...(trialEndUnix
+          ? {
+              trial_end: trialEndUnix,
+              trial_settings: {
+                end_behavior: { missing_payment_method: 'cancel' as const },
+              },
+            }
+          : {}),
         metadata: {
           profile_id: profile.id as string,
           palier: decoded.palier,

--- a/app/tarifs/_components/WizardSection.tsx
+++ b/app/tarifs/_components/WizardSection.tsx
@@ -188,7 +188,7 @@ export function WizardSection({ initialPalier, initialPromo, stripePriceIds, isF
       const supabase = createClient()
       const { data } = await supabase
         .from('promo_codes')
-        .select('id, code, discount_pct, applies_to_palier, valid_from, valid_until, max_uses, current_uses, active')
+        .select('id, code, type, trial_end, discount_pct, applies_to_palier, valid_from, valid_until, max_uses, current_uses, active')
         .ilike('code', trimmed)
         .maybeSingle()
 
@@ -197,7 +197,9 @@ export function WizardSection({ initialPalier, initialPromo, stripePriceIds, isF
         setAppliedPromo(result.code)
         setPromoStatus('valid')
         setPromoMessage(
-          `Code «${result.code.code}» appliqué : -${result.code.discount_pct}%.`,
+          result.code.type === 'trial'
+            ? `Code «${result.code.code}» : gratuit jusqu'au 1ᵉʳ septembre, puis prix plein. Carte demandée, rien débité avant.`
+            : `Code «${result.code.code}» appliqué : -${result.code.discount_pct}%.`,
         )
       } else {
         setAppliedPromo(null)
@@ -283,6 +285,9 @@ export function WizardSection({ initialPalier, initialPromo, stripePriceIds, isF
 
   const info = PALIER_INFO[palier]
   const price = PRICING[palier][duree]
+  // Code 'trial' (ENSEMBLE) : pas de remise %, on garde le prix plein
+  // affiché (l'essai est géré côté Stripe, pas un rabais sur le prix).
+  const isTrial = appliedPromo?.type === 'trial'
   const discountPct = appliedPromo?.discount_pct ?? 0
   const monthlyAfterDiscount = applyDiscount(price.m, discountPct)
   const totalAfterDiscount =
@@ -488,7 +493,7 @@ export function WizardSection({ initialPalier, initialPromo, stripePriceIds, isF
                 {info.tagline}
               </p>
               <div className="mb-7 border-b border-or/25 pb-7">
-                {appliedPromo ? (
+                {appliedPromo && !isTrial ? (
                   <div className="flex items-baseline gap-3">
                     <span className="font-serif text-[60px] font-light leading-none text-creme">
                       {formatPrice(monthlyAfterDiscount)}
@@ -522,7 +527,9 @@ export function WizardSection({ initialPalier, initialPromo, stripePriceIds, isF
                 {appliedPromo && (
                   <p className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-or/15 px-3 py-1 text-[11px] font-medium tracking-[0.18em] text-or uppercase">
                     <span aria-hidden>✓</span>
-                    Code «{appliedPromo.code}» −{appliedPromo.discount_pct}%
+                    {isTrial
+                      ? `Code «${appliedPromo.code}» · gratuit jusqu'au 1ᵉʳ sept`
+                      : `Code «${appliedPromo.code}» −${appliedPromo.discount_pct}%`}
                   </p>
                 )}
                 {promoLancActive && (
@@ -643,6 +650,7 @@ export function WizardSection({ initialPalier, initialPromo, stripePriceIds, isF
                       label="Je choisis cette formule"
                       ariaLabel={aria}
                       context={fromOnboarding ? 'onboarding' : undefined}
+                      promoCode={appliedPromo?.code}
                     />
                   )
                 }

--- a/components/SubscribeButton.tsx
+++ b/components/SubscribeButton.tsx
@@ -17,6 +17,10 @@ interface Props {
    *  paiement la mène à /onboarding/prestataire/publiee. Absent =
    *  checkout depuis le dashboard d'une fiche existante. */
   context?: 'onboarding'
+  /** Code promo Hilmy saisi sur /tarifs (ex. ENSEMBLE). Transmis au
+   *  serveur pour résoudre un essai gratuit (trial_end). Optionnel —
+   *  absent = checkout normal. */
+  promoCode?: string
 }
 
 /**
@@ -35,6 +39,7 @@ export function SubscribeButton({
   ariaLabel,
   className,
   context,
+  promoCode,
 }: Props) {
   const [loading, setLoading] = useState(false)
 
@@ -47,6 +52,7 @@ export function SubscribeButton({
         body: JSON.stringify({
           price_id: priceId,
           ...(context ? { context } : {}),
+          ...(promoCode ? { promo_code: promoCode } : {}),
         }),
       })
 

--- a/lib/promo-codes.ts
+++ b/lib/promo-codes.ts
@@ -18,7 +18,13 @@ import type { Palier } from '@/app/tarifs/_lib/pricing'
 export interface PromoCodeRow {
   id: string
   code: string
-  discount_pct: number
+  /** 'discount' = remise % (discount_pct) ; 'trial' = essai gratuit
+   *  jusqu'à trial_end. Ajouté en mig 61. */
+  type: 'discount' | 'trial'
+  /** Fin de l'essai gratuit (codes 'trial' uniquement). NULL sinon. */
+  trial_end: string | null
+  /** Pourcentage de remise (codes 'discount'). NULL pour les 'trial'. */
+  discount_pct: number | null
   applies_to_palier: 'standard' | 'premium' | 'cercle_pro' | 'all'
   valid_from: string
   valid_until: string | null

--- a/supabase/migrations/61_promo_codes_trial.sql
+++ b/supabase/migrations/61_promo_codes_trial.sql
@@ -1,0 +1,115 @@
+-- =====================================================================
+-- HILMY · 61 — promo_codes : support type='trial' (ENSEMBLE essai gratuit)
+--
+-- Étend la table promo_codes (mig 35) pour gérer des codes "essai gratuit
+-- à date fixe" en plus des codes "remise %". Seed du code ENSEMBLE :
+-- essai gratuit jusqu'au 1er septembre 2026 (date fixe, heure suisse),
+-- puis bascule auto en prix plein. Distribué manuellement par Jiji.
+--
+-- ENSEMBLE remplace LANCEMENT50 comme offre de lancement (LANCEMENT50
+-- s'éteint via le flag NEXT_PUBLIC_PROMO_LANCEMENT=false côté Vercel).
+--
+-- Kill switch : UPDATE promo_codes SET active=false WHERE lower(code)='ensemble';
+--   → coupe instantanément le preview front (RLS active=true) ET la
+--     résolution serveur du trial (.eq('active', true)).
+--
+-- Idempotente. Dry-run conseillé (BEGIN; \i ...; ROLLBACK;) avant prod.
+-- ⚠️ Ne pas exécuter en prod sans backup récent + validation Jiji.
+-- Exécuter via : bash scripts/run-migration.sh supabase/migrations/61_promo_codes_trial.sql
+-- =====================================================================
+
+-- ─── 1. Colonne type ─────────────────────────────────────────────────
+-- 'discount' par défaut → toutes les lignes existantes (COPINE10) restent
+-- des codes remise sans changement de comportement.
+alter table public.promo_codes
+  add column if not exists type text not null default 'discount';
+
+-- ─── 2. Colonne trial_end ────────────────────────────────────────────
+-- Date de fin de l'essai gratuit (fixe, identique pour toutes). NULL pour
+-- les codes 'discount'. Le webhook Stripe écrira current_period_end =
+-- trial_end ; profile_has_active_subscription reconnaît trialing.
+alter table public.promo_codes
+  add column if not exists trial_end timestamptz;
+
+-- ─── 3. discount_pct devient nullable ────────────────────────────────
+-- Un code 'trial' n'a pas de pourcentage.
+alter table public.promo_codes
+  alter column discount_pct drop not null;
+
+-- ─── 4. CHECK conditionnel par type ──────────────────────────────────
+-- On retire l'ancien CHECK inline (discount_pct>0 AND <=100), nommé
+-- automatiquement promo_codes_discount_pct_check, par lookup robuste,
+-- puis on pose un CHECK de forme conditionnelle.
+do $$
+declare c text;
+begin
+  for c in
+    select conname from pg_constraint
+    where conrelid = 'public.promo_codes'::regclass and contype = 'c'
+      and pg_get_constraintdef(oid) ilike '%discount_pct%'
+  loop
+    execute format('alter table public.promo_codes drop constraint %I', c);
+  end loop;
+end $$;
+
+alter table public.promo_codes
+  drop constraint if exists promo_codes_type_check;
+alter table public.promo_codes
+  add constraint promo_codes_type_check check (type in ('discount', 'trial'));
+
+alter table public.promo_codes
+  drop constraint if exists promo_codes_shape_check;
+alter table public.promo_codes
+  add constraint promo_codes_shape_check check (
+    (type = 'discount' and discount_pct between 1 and 100 and trial_end is null)
+    or
+    (type = 'trial'    and trial_end is not null)
+  );
+
+comment on column public.promo_codes.type is
+  'discount = remise % (discount_pct) ; trial = essai gratuit jusqu''à trial_end.';
+comment on column public.promo_codes.trial_end is
+  'Fin de l''essai gratuit (date fixe). Posé sur subscription_data.trial_end '
+  'au checkout Stripe. NULL pour les codes discount.';
+
+-- ─── 5. Seed ENSEMBLE ────────────────────────────────────────────────
+-- Essai gratuit jusqu'au 1er sept 2026 00:00 heure suisse (Europe/Zurich
+-- = UTC+02 en été). valid_until = 25 août 2026 : ferme la redemption ~1
+-- semaine avant trial_end pour respecter la contrainte Stripe
+-- "trial_end >= now + 48h". max_uses NULL = illimité (kill via active).
+insert into public.promo_codes
+  (code, type, discount_pct, trial_end, applies_to_palier,
+   valid_from, valid_until, max_uses, notes)
+values
+  ('ENSEMBLE', 'trial', null, '2026-09-01 00:00:00+02', 'all',
+   now(), '2026-08-25 23:59:59+02', null,
+   'Essai gratuit jusqu''au 1er sept 2026 (date fixe). Offre de lancement, '
+   'remplace LANCEMENT50. Distribué manuellement par Jiji.')
+on conflict ((lower(code))) do update
+  set type              = excluded.type,
+      discount_pct      = excluded.discount_pct,
+      trial_end         = excluded.trial_end,
+      applies_to_palier = excluded.applies_to_palier,
+      valid_until       = excluded.valid_until,
+      max_uses          = excluded.max_uses,
+      active            = true,
+      notes             = excluded.notes;
+
+-- ─── 6. Reload PostgREST schema cache ────────────────────────────────
+notify pgrst, 'reload schema';
+
+-- =====================================================================
+-- ROLLBACK
+-- =====================================================================
+-- delete from public.promo_codes where lower(code) = 'ensemble';
+-- alter table public.promo_codes drop constraint if exists promo_codes_shape_check;
+-- alter table public.promo_codes drop constraint if exists promo_codes_type_check;
+-- alter table public.promo_codes drop column if exists trial_end;
+-- alter table public.promo_codes drop column if exists type;
+-- -- Restaurer l'ancien CHECK + NOT NULL sur discount_pct (état mig 35) :
+-- alter table public.promo_codes
+--   add constraint promo_codes_discount_pct_check
+--   check (discount_pct > 0 and discount_pct <= 100);
+-- alter table public.promo_codes alter column discount_pct set not null;
+-- notify pgrst, 'reload schema';
+-- =====================================================================


### PR DESCRIPTION
## Résumé
Mécanisme d'essai gratuit Stripe (Lot 1 — gratuité d'été), **distinct du chantier IAP gelé** (PR1).

- Code promo **ENSEMBLE** distribué manuellement → carte enregistrée au checkout, **0€ débité** jusqu'au **1er septembre 2026** (Europe/Zurich), puis conversion auto en abonnement payant.
- La fiche devient visible dès le `trialing` (`profile_has_active_subscription` couvre déjà cet état).
- Un trial **désactive** l'injection LANCEMENT50 (`discounts` / `allow_promotion_codes` sont mutuellement exclusifs côté Stripe → racine du bug des 9.50€).
- Code inconnu/expiré → ignoré silencieusement → checkout payant normal.

## Fichiers
- `supabase/migrations/61_promo_codes_trial.sql` — étend `promo_codes` (`type` discount|trial, `trial_end`), seed ENSEMBLE (**déjà appliquée en prod** après dry-run + backup).
- `app/api/stripe/checkout/route.ts` — résolution server-side du code trial + `subscription_data.trial_end` + `trial_settings.end_behavior.missing_payment_method='cancel'`.
- `app/tarifs/_components/WizardSection.tsx`, `components/SubscribeButton.tsx`, `lib/promo-codes.ts` — front trial-aware + transmission du code au serveur.

## Tests (Stripe TEST-mode, 10/10 ✅)
- [x] Forme exacte des params Checkout acceptée par Stripe
- [x] Souscription réelle → `status=trialing`, **0€ débité**, `current_period_end == trial_end`
- [x] Checkout sans code → parcours payant normal
- [x] Résolution serveur de ENSEMBLE validée contre la prod
- [ ] Test à vraie carte LIVE (à la décision de la mainteneuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)