### PR TITLE
feat(copine): réduction copines Hilmy (web) + migration 62

### DIFF
--- a/app/dashboard/prestataire/fiche/page.tsx
+++ b/app/dashboard/prestataire/fiche/page.tsx
@@ -8,6 +8,8 @@ import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
 import { GoldLine } from '@/components/ui/GoldLine'
 import { VideosManager } from '@/components/v2/VideosManager'
 import { createClient } from '@/lib/supabase/client'
+import { CopineDiscountField } from '@/components/onboarding/CopineDiscountField'
+import { CopineDiscountBadge } from '@/components/v2/CopineDiscountBadge'
 import { CATEGORIES_MAP } from '@/lib/constants'
 import {
   PHOTO_LIMIT,
@@ -61,6 +63,9 @@ type Draft = {
   site_web: string
   prix_from: string
   devise: 'CHF' | 'EUR'
+  // Réduction copines Hilmy (mig 62). pct null = pas de réduction.
+  copine_discount_pct: number | null
+  copine_discount_note: string
   services: Service[]
   galerie: string[]
 }
@@ -107,6 +112,8 @@ export default function MaFichePage() {
     site_web: '',
     prix_from: '',
     devise: 'CHF',
+    copine_discount_pct: null,
+    copine_discount_note: '',
     services: [],
     galerie: [],
   })
@@ -171,6 +178,8 @@ export default function MaFichePage() {
         site_web: data.site_web ?? '',
         prix_from: data.prix_from !== null ? String(data.prix_from) : '',
         devise: data.devise ?? 'CHF',
+        copine_discount_pct: data.copine_discount_pct ?? null,
+        copine_discount_note: data.copine_discount_note ?? '',
         services: (data.services ?? []) as Service[],
         galerie: (data.galerie ?? []) as string[],
       })
@@ -281,6 +290,8 @@ export default function MaFichePage() {
       site_web: draft.site_web.trim() || null,
       prix_from: draft.prix_from ? Number(draft.prix_from) : null,
       devise: draft.devise,
+      copine_discount_pct: draft.copine_discount_pct,
+      copine_discount_note: draft.copine_discount_note.trim() || null,
       // Trim + filter pour éviter de polluer la BDD avec des services
       // {nom: "", prix: "", duree: ""} créés puis non remplis.
       services: draft.services
@@ -674,6 +685,19 @@ export default function MaFichePage() {
                   </Field>
                 </Group>
 
+                <Group kicker="Réduction copines">
+                  <CopineDiscountField
+                    pct={draft.copine_discount_pct}
+                    note={draft.copine_discount_note}
+                    onPctChange={(pct) =>
+                      setDraft((d) => ({ ...d, copine_discount_pct: pct }))
+                    }
+                    onNoteChange={(note) =>
+                      setDraft((d) => ({ ...d, copine_discount_note: note }))
+                    }
+                  />
+                </Group>
+
                 <Group
                   kicker="Services"
                   action={
@@ -913,26 +937,34 @@ export default function MaFichePage() {
                         'Ta description apparaîtra ici. Clique sur Modifier pour la rédiger.'}
                     </p>
                   </div>
-                  <div className="rounded-sm bg-creme-deep p-6">
-                    <p className="overline text-or">Services</p>
-                    {draft.services.length === 0 ? (
-                      <p className="mt-4 text-[12px] italic text-texte-sec">
-                        Aucun service ajouté.
-                      </p>
-                    ) : (
-                      <ul className="mt-4 divide-y divide-or/10 text-[13px]">
-                        {draft.services.map((s, i) => (
-                          <li
-                            key={i}
-                            className="flex items-center justify-between py-2"
-                          >
-                            <span className="text-vert">{s.nom}</span>
-                            <span className="font-serif italic text-or-deep">
-                              {s.prix}
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
+                  <div className="space-y-6">
+                    <div className="rounded-sm bg-creme-deep p-6">
+                      <p className="overline text-or">Services</p>
+                      {draft.services.length === 0 ? (
+                        <p className="mt-4 text-[12px] italic text-texte-sec">
+                          Aucun service ajouté.
+                        </p>
+                      ) : (
+                        <ul className="mt-4 divide-y divide-or/10 text-[13px]">
+                          {draft.services.map((s, i) => (
+                            <li
+                              key={i}
+                              className="flex items-center justify-between py-2"
+                            >
+                              <span className="text-vert">{s.nom}</span>
+                              <span className="font-serif italic text-or-deep">
+                                {s.prix}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                    {draft.copine_discount_pct != null && (
+                      <CopineDiscountBadge
+                        pct={draft.copine_discount_pct}
+                        note={draft.copine_discount_note || null}
+                      />
                     )}
                   </div>
                 </div>

--- a/app/onboarding/prestataire/google/page.tsx
+++ b/app/onboarding/prestataire/google/page.tsx
@@ -13,6 +13,7 @@ import {
   type AutocompletePlace,
 } from '@/components/google/PlaceAutocomplete'
 import { createClient } from '@/lib/supabase/client'
+import { CopineDiscountField } from '@/components/onboarding/CopineDiscountField'
 import { CATEGORIES_MAP } from '@/lib/constants'
 import { formatVilleDisplay } from '@/lib/geo/city-centroids'
 import { COUNTRY_CODES, toE164, nationalDigits } from '@/lib/phone'
@@ -73,6 +74,9 @@ export default function GoogleOnboardingPage() {
   const [waDial, setWaDial] = useState('')
   const [waNumber, setWaNumber] = useState('')
   const [instagram, setInstagram] = useState('')
+  // Réduction copines Hilmy (mig 62). pct null = pas de réduction.
+  const [copineDiscountPct, setCopineDiscountPct] = useState<number | null>(null)
+  const [copineDiscountNote, setCopineDiscountNote] = useState('')
 
   useEffect(() => {
     const run = async () => {
@@ -162,6 +166,8 @@ export default function GoogleOnboardingPage() {
       site_web: details.website,
       tagline: tagline.trim() || null,
       description: description.trim() || null,
+      copine_discount_pct: copineDiscountPct,
+      copine_discount_note: copineDiscountNote.trim() || null,
       galerie: details.photos,
       photos: details.photos,
       services: [],
@@ -416,6 +422,13 @@ export default function GoogleOnboardingPage() {
                       className="line resize-none"
                     />
                   </Field>
+
+                  <CopineDiscountField
+                    pct={copineDiscountPct}
+                    note={copineDiscountNote}
+                    onPctChange={setCopineDiscountPct}
+                    onNoteChange={setCopineDiscountNote}
+                  />
                 </div>
 
                 <div className="flex items-center justify-between">

--- a/app/onboarding/prestataire/manuel/page.tsx
+++ b/app/onboarding/prestataire/manuel/page.tsx
@@ -9,6 +9,7 @@ import {
   OnboardingHeader,
 } from '@/components/onboarding/OnboardingShell'
 import { createClient } from '@/lib/supabase/client'
+import { CopineDiscountField } from '@/components/onboarding/CopineDiscountField'
 import { CATEGORIES_MAP } from '@/lib/constants'
 import { villesSuggestions } from '@/lib/mock-data'
 import { formatVilleDisplay } from '@/lib/geo/city-centroids'
@@ -103,6 +104,9 @@ export default function ManuelOnboardingPage() {
   const [services, setServices] = useState<Service[]>([
     { nom: '', prix: '', duree: '' },
   ])
+  // Réduction copines Hilmy (mig 62). pct null = pas de réduction.
+  const [copineDiscountPct, setCopineDiscountPct] = useState<number | null>(null)
+  const [copineDiscountNote, setCopineDiscountNote] = useState('')
 
   // Step 4 - photos
   const [galerie, setGalerie] = useState<string[]>([])
@@ -218,6 +222,8 @@ export default function ManuelOnboardingPage() {
       description: description.trim(),
       prix_from: prixFrom ? Number(prixFrom) : null,
       devise,
+      copine_discount_pct: copineDiscountPct,
+      copine_discount_note: copineDiscountNote.trim() || null,
       services: cleanServices,
       galerie,
       photos: galerie,
@@ -612,6 +618,13 @@ export default function ManuelOnboardingPage() {
                       ))}
                     </ul>
                   </div>
+
+                  <CopineDiscountField
+                    pct={copineDiscountPct}
+                    note={copineDiscountNote}
+                    onPctChange={setCopineDiscountPct}
+                    onNoteChange={setCopineDiscountNote}
+                  />
                 </div>
               )}
 

--- a/app/prestataires/[slug]/page.tsx
+++ b/app/prestataires/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { CardOverlayGated } from '@/components/v2/CardOverlayGated'
 import { GalleryAutoplayCarousel } from '@/components/v2/GalleryAutoplayCarousel'
 import { PalierBadge } from '@/components/v2/PalierBadge'
 import { PastilleSelectionHilmy } from '@/components/v2/PastilleSelectionHilmy'
+import { CopineDiscountBadge } from '@/components/v2/CopineDiscountBadge'
 import { categoriesPrestataires } from '@/lib/mock-data'
 import {
   getPublicPrestataire,
@@ -170,6 +171,14 @@ export default async function PrestatairePage({
                   </span>
                 ) : null}
               </div>
+              {pub.copine_discount_pct != null && (
+                <div className="mt-5 max-w-sm">
+                  <CopineDiscountBadge
+                    pct={pub.copine_discount_pct}
+                    note={pub.copine_discount_note}
+                  />
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/components/onboarding/CopineDiscountField.tsx
+++ b/components/onboarding/CopineDiscountField.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+/**
+ * Champ « réduction copines Hilmy » factorisé (mig 62).
+ * Utilisé par les formulaires d'inscription prestataire (manuel, google) et
+ * l'édition de fiche dans le dashboard. Composant contrôlé, self-contained
+ * (n'utilise pas la classe `.line` page-scopée — styles Tailwind inline pour
+ * marcher partout, signup ET dashboard).
+ *
+ * Source de vérité = `pct` côté parent : `pct != null` ⟺ case cochée.
+ *  - cocher  → pct = 10 (1ère valeur sensée)
+ *  - décocher → pct = null + note vidée
+ * Les valeurs autorisées (5/10/15/20) reflètent le CHECK SQL côté DB.
+ */
+
+const PCT_OPTIONS = [5, 10, 15, 20] as const
+
+export function CopineDiscountField({
+  pct,
+  note,
+  onPctChange,
+  onNoteChange,
+}: {
+  pct: number | null
+  note: string
+  onPctChange: (pct: number | null) => void
+  onNoteChange: (note: string) => void
+}) {
+  const enabled = pct != null
+
+  return (
+    <div className="rounded-sm border border-or/20 bg-creme-soft p-4">
+      <label className="flex cursor-pointer items-start gap-3">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => {
+            if (e.target.checked) {
+              onPctChange(10)
+            } else {
+              onPctChange(null)
+              onNoteChange('')
+            }
+          }}
+          className="mt-1 h-4 w-4 shrink-0 accent-vert"
+        />
+        <span>
+          <span className="block text-[15px] text-vert">
+            Je fais un prix aux copines Hilmy 🌸
+          </span>
+          <span className="block text-[12px] text-texte-sec/80">
+            Une réduction pour les utilisatrices de l&apos;app. Tu peux la
+            changer ou la retirer quand tu veux.
+          </span>
+        </span>
+      </label>
+
+      {enabled && (
+        <div className="mt-4 space-y-4 pl-7">
+          <label className="flex flex-col gap-2">
+            <span className="overline text-or">Réduction</span>
+            <select
+              value={pct ?? 10}
+              onChange={(e) => onPctChange(Number(e.target.value))}
+              className="w-28 border-0 border-b border-or/20 bg-transparent py-2 text-[15px] text-vert outline-none focus:border-or"
+            >
+              {PCT_OPTIONS.map((v) => (
+                <option key={v} value={v}>
+                  −{v}%
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-2">
+            <span className="overline text-or">Conditions (optionnel)</span>
+            <input
+              type="text"
+              maxLength={120}
+              value={note}
+              onChange={(e) => onNoteChange(e.target.value)}
+              placeholder="Ex : sur les prestations à partir de 80 CHF"
+              className="w-full border-0 border-b border-or/20 bg-transparent py-2 text-[15px] text-vert outline-none placeholder:text-texte-sec/50 focus:border-or"
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/v2/CopineDiscountBadge.tsx
+++ b/components/v2/CopineDiscountBadge.tsx
@@ -1,0 +1,30 @@
+/**
+ * Badge « réduction copines Hilmy » sur la fiche publique (mig 62).
+ * Affiché uniquement quand la prestataire a renseigné un pourcentage.
+ * Charte : carte vert (#0F3D2E) + accent or (#C9A961), texte crème.
+ * Pas de mécanisme de claim côté web : la copine montre l'app en boutique.
+ */
+export function CopineDiscountBadge({
+  pct,
+  note,
+}: {
+  pct: number
+  note?: string | null
+}) {
+  return (
+    <div className="rounded-sm border border-or/40 bg-vert px-5 py-4">
+      <p className="flex items-center gap-2 font-serif text-[17px] font-light text-creme">
+        <span aria-hidden="true">🌸</span>
+        <span>
+          <span className="text-or">−{pct}%</span> pour les copines Hilmy
+        </span>
+      </p>
+      {note?.trim() && (
+        <p className="mt-2 text-[13px] leading-snug text-creme/80">{note.trim()}</p>
+      )}
+      <p className="mt-3 text-[12px] italic text-or-light">
+        Montre l&apos;app Hilmy pour en profiter
+      </p>
+    </div>
+  )
+}

--- a/lib/supabase/queries/prestataires.ts
+++ b/lib/supabase/queries/prestataires.ts
@@ -58,7 +58,9 @@ const PRESTATAIRE_SELECT = `
   nb_avis,
   nb_vues,
   palier,
-  is_founder
+  is_founder,
+  copine_discount_pct,
+  copine_discount_note
 `;
 
 /**
@@ -154,7 +156,9 @@ const PUBLIC_PRESTATAIRE_SELECT = `
   youtube,
   linkedin,
   site_web,
-  approved_at
+  approved_at,
+  copine_discount_pct,
+  copine_discount_note
 `
 
 export type PublicPrestataire = {
@@ -183,6 +187,8 @@ export type PublicPrestataire = {
   linkedin: string | null
   site_web: string | null
   approved_at: string | null
+  copine_discount_pct: number | null
+  copine_discount_note: string | null
 }
 
 /**

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -106,6 +106,12 @@ export interface Prestataire {
   // Founder flag — accès Cercle Pro à vie (gratuit, sans abonnement Stripe).
   // ⚠️ Ne JAMAIS exposer côté public : strippé via toPublicPrestataire().
   is_founder?: boolean;
+
+  // Réduction copines Hilmy (mig 62). pct ∈ {5,10,15,20} ou null (= pas de
+  // réduction). Note = conditions libres. Les deux éditables librement par la
+  // prestataire (volontairement HORS lock_profile_update).
+  copine_discount_pct?: number | null;
+  copine_discount_note?: string | null;
 }
 
 /* ─────────────────────────────────────────────────────────────

--- a/supabase/migrations/62_copine_discount.sql
+++ b/supabase/migrations/62_copine_discount.sql
@@ -1,0 +1,48 @@
+-- =====================================================================
+-- HILMY · 62 — Réduction « copines Hilmy » (Lot 2A · schéma)
+-- Idempotent. Purement additive : RLS et triggers INTOUCHÉS.
+--
+-- Contexte : une prestataire peut afficher sur sa fiche publique une
+-- réduction réservée aux copines Hilmy (« −X% pour les copines »).
+-- Deux champs, librement éditables par la prestataire (inscription +
+-- espace prestataire web). Coexiste avec le système pro_perks (mig 50)
+-- — on n'y touche PAS, ce sont deux mécanismes parallèles.
+--
+--   • copine_discount_pct  smallint  — 5/10/15/20 ou NULL (= pas de réduc)
+--   • copine_discount_note text      — conditions libres, NULL = vide
+--
+-- Anti-tamper : ces colonnes ne sont PAS ajoutées à lock_profile_update
+-- / lock_profile_insert (mig 54), donc volontairement modifiables par
+-- l'authenticated. Aucune resync de ces triggers ici (intouchés).
+-- =====================================================================
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS copine_discount_pct  smallint,
+  ADD COLUMN IF NOT EXISTS copine_discount_note text;
+
+-- CHECK idempotent : % dans {5,10,15,20} ou NULL.
+-- (NULL passe le CHECK : `x IN (...)` vaut UNKNOWN pour NULL, et un CHECK
+--  n'échoue que sur FALSE. La clause `IS NULL OR` est explicite par lisibilité.)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.profiles'::regclass
+      AND conname  = 'profiles_copine_discount_pct_check'
+  ) THEN
+    ALTER TABLE public.profiles
+      ADD CONSTRAINT profiles_copine_discount_pct_check
+      CHECK (copine_discount_pct IS NULL OR copine_discount_pct IN (5, 10, 15, 20));
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.profiles.copine_discount_pct IS
+  'mig 62 — Réduction copines Hilmy. smallint dans {5,10,15,20} ou NULL '
+  '(NULL = pas de réduction). Librement éditable par la prestataire.';
+
+COMMENT ON COLUMN public.profiles.copine_discount_note IS
+  'mig 62 — Conditions libres de la réduction copines (text, NULL = vide). '
+  'Librement éditable par la prestataire.';
+
+-- Recharge le schema cache PostgREST pour que les colonnes soient visibles immédiatement.
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Résumé

Permet à une prestataire d'offrir une **réduction aux utilisatrices Hilmy** (« copines »). Lot 2B (web). La migration 62 (sous-lot 2A) est incluse dans ce commit — **déjà appliquée en prod** via psql (procédure dry-run → backup → apply → vérif). Le mobile (2C) suivra dans une PR séparée.

### Schéma (mig 62, additif)
- 2 colonnes nullable sur `profiles` : `copine_discount_pct` (smallint, CHECK ∈ {5,10,15,20} ou NULL) + `copine_discount_note` (text, conditions libres).
- **RLS / triggers intacts.** Les 2 champs sont **volontairement HORS** `lock_profile_update` → éditables librement par la prestataire après coup.
- Coexiste avec `pro_perks` (non touché).

### Web
- `types.ts` + SELECTs (`PRESTATAIRE_SELECT`, `PUBLIC_PRESTATAIRE_SELECT`) + type `PublicPrestataire`.
- `CopineDiscountBadge` — badge fiche publique (charte vert #0F3D2E / or #C9A961).
- `CopineDiscountField` — champ factorisé (case « Je fais un prix aux copines Hilmy 🌸 » + select % + note), self-contained.
- Inscription : `manuel` + `google` (⚠️ `instagram`/`linkedin` sont des stubs « En préparation » → écartés, le composant s'y branchera quand ils deviendront de vrais formulaires).
- Dashboard `fiche` : édition (Draft + init + payload update) + badge en preview lecture seule.

## Test plan
- [ ] Inscription manuel : cocher la case, choisir −10%, ajouter une note → fiche créée avec la réduction
- [ ] Inscription google : idem
- [ ] Fiche publique : badge visible quand `copine_discount_pct != null`, absent sinon
- [ ] Dashboard : modifier la réduction (5→15%), retirer la réduction (décocher) → persiste après save
- [ ] Dashboard lecture seule : badge reflète la valeur enregistrée
- [ ] CHECK DB : un pct hors {5,10,15,20} est rejeté (déjà vérifié en prod : 7 rejeté)

🤖 Generated with [Claude Code](https://claude.com/claude-code)