### PR TITLE
fix(fiche): bouton Appeler retombe sur le WhatsApp E.164 si phone_public vide

### DIFF
--- a/app/prestataires/[slug]/page.tsx
+++ b/app/prestataires/[slug]/page.tsx
@@ -367,12 +367,12 @@ export default async function PrestatairePage({
                         WhatsApp · {priv.whatsapp}
                       </a>
                     )}
-                    {priv.phone_public && (
+                    {(priv.phone_public || priv.whatsapp) && (
                       <a
-                        href={`tel:${priv.phone_public}`}
+                        href={`tel:${priv.phone_public || priv.whatsapp}`}
                         className="block rounded-full border border-or/40 px-5 py-3 text-center text-[14px] text-vert transition-colors hover:bg-creme-soft"
                       >
-                        📞 {priv.phone_public}
+                        📞 {priv.phone_public || priv.whatsapp}
                       </a>
                     )}
                     {priv.email && (


### PR DESCRIPTION
## Contexte
Sur la fiche prestataire, le bouton **Appeler** (`tel:`) ne s'affichait que si la colonne `phone_public` était renseignée. Or la plupart des prestataires ne saisissent que leur **WhatsApp** (obligatoire, stocké en E.164) → le bouton Appeler n'apparaissait quasi jamais.

## Changement
- Le bouton Appeler s'affiche dès qu'un numéro existe : `phone_public` en priorité, **fallback sur le numéro WhatsApp E.164** sinon.
- 1 condition modifiée dans `app/prestataires/[slug]/page.tsx` (bloc contact).
- **Aucun changement de gating** : le bloc contact reste masqué tant que le visiteur n'est pas connecté.

## Test
- [ ] Fiche avec `phone_public` rempli → bouton Appeler = `phone_public` (inchangé).
- [ ] Fiche sans `phone_public` mais avec WhatsApp → bouton Appeler = numéro WhatsApp.
- [ ] Fiche sans aucun numéro → message "pas encore renseigné de canal de contact".
- [ ] Visiteur non connecté → bloc contact toujours gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)