### PR TITLE
feat(accueil): bloc « Réductions copines » sur la landing publique

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { HeroV2 } from '@/components/landing/HeroV2'
 import { StartingPoint } from '@/components/landing/StartingPoint'
 import { ThreePromises } from '@/components/landing/ThreePromises'
 import { ElleProfiles } from '@/components/landing/ElleProfiles'
+import { CopineDiscountsSection } from '@/components/landing/CopineDiscountsSection'
 import { Manifesto } from '@/components/landing/Manifesto'
 import { TeamCherche } from '@/components/landing/TeamCherche'
 import { PricingTeaser } from '@/components/landing/PricingTeaser'
@@ -44,6 +45,7 @@ export default function HomePage() {
         <Manifesto />
         <ThreePromises />
         <ElleProfiles />
+        <CopineDiscountsSection />
         <TeamCherche variant="public" />
         <PricingTeaser />
         <FAQ />

--- a/components/landing/CopineDiscountsSection.tsx
+++ b/components/landing/CopineDiscountsSection.tsx
@@ -1,0 +1,98 @@
+import Link from 'next/link'
+import { FadeInSection } from '@/components/ui/FadeInSection'
+import { CopineDiscountBadge } from '@/components/v2/CopineDiscountBadge'
+import {
+  getPrestatairesCopineDiscount,
+  type PublicPrestataire,
+} from '@/lib/supabase/queries/prestataires'
+import { categoryLabel } from '@/lib/constants'
+
+function firstPhotoUrl(p: PublicPrestataire): string | null {
+  for (const arr of [p.galerie, p.photos]) {
+    if (!Array.isArray(arr)) continue
+    for (const x of arr) {
+      if (typeof x === 'string' && x.startsWith('http')) return x
+    }
+  }
+  return null
+}
+
+export async function CopineDiscountsSection() {
+  const { data } = await getPrestatairesCopineDiscount(6)
+  const list = data ?? []
+
+  // Auto-masquage : aucune fiche avec réduction → section absente du DOM.
+  if (list.length === 0) return null
+
+  return (
+    <section className="bg-creme py-28 md:py-36">
+      <div className="mx-auto max-w-container px-6 md:px-20">
+        <FadeInSection>
+          <div className="mb-14 max-w-3xl">
+            <p className="overline mb-3 text-or">Entre copines</p>
+            <h2 className="font-serif text-h2 font-light leading-[1.05] text-vert md:text-display">
+              Réductions copines.
+            </h2>
+            <p className="mt-6 text-[15px] leading-[1.7] text-texte-sec">
+              Montre l&apos;app Hilmy en caisse pour en profiter.
+            </p>
+          </div>
+        </FadeInSection>
+
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {list.map((p, i) => (
+            <CopineDiscountCard key={p.id} p={p} index={i} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function CopineDiscountCard({
+  p,
+  index,
+}: {
+  p: PublicPrestataire
+  index: number
+}) {
+  const photoUrl = firstPhotoUrl(p)
+  return (
+    <FadeInSection delay={index * 0.05} className="h-full">
+      <Link
+        href={`/prestataires/${p.slug}`}
+        className="group flex h-full flex-col overflow-hidden rounded-sm bg-blanc transition-all duration-500 hover:-translate-y-1 hover:shadow-[0_30px_60px_-30px_rgba(15,61,46,0.25)]"
+      >
+        <div className="relative h-52 w-full overflow-hidden bg-vert/5">
+          {photoUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={photoUrl}
+              alt={p.nom}
+              className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
+            />
+          )}
+        </div>
+        <div className="flex flex-1 flex-col gap-4 p-5">
+          <div>
+            <p className="overline text-or">{categoryLabel(p.categorie)}</p>
+            <h3 className="mt-1 font-serif text-[20px] font-light text-vert">
+              {p.nom}
+            </h3>
+            {p.ville && (
+              <p className="text-[13px] text-texte-sec">{p.ville}</p>
+            )}
+          </div>
+          {p.copine_discount_pct != null && (
+            <div className="mt-auto">
+              <CopineDiscountBadge
+                pct={p.copine_discount_pct}
+                note={p.copine_discount_note}
+              />
+            </div>
+          )}
+        </div>
+      </Link>
+    </FadeInSection>
+  )
+}

--- a/lib/supabase/queries/prestataires.ts
+++ b/lib/supabase/queries/prestataires.ts
@@ -224,6 +224,40 @@ export async function getPublicPrestataire(
   }
 }
 
+/**
+ * Liste publique des prestataires ayant renseigné une réduction copines
+ * (`copine_discount_pct` non null). Projection PUBLIQUE (même garanties que
+ * getPublicPrestataire : pas de whatsapp/email/phone, is_founder strippé,
+ * palier effectif). Alimente le bloc « Réductions copines » de l'accueil
+ * anonyme — la section se masque d'elle-même si la liste est vide.
+ */
+export async function getPrestatairesCopineDiscount(
+  limit = 6,
+): Promise<QueryResult<PublicPrestataire[]>> {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('profiles')
+      .select(PUBLIC_PRESTATAIRE_SELECT)
+      .not('copine_discount_pct', 'is', null)
+      // Modèle B : visibilité gérée par la RLS (fiche visible dès paiement)
+      .order('approved_at', { ascending: false, nullsFirst: false })
+      .limit(limit)
+
+    if (error) return { data: null, error: error.message }
+    const rows = (data ?? []) as unknown as (PublicPrestataire & {
+      is_founder?: boolean
+    })[]
+    const mapped = rows.map(({ is_founder, palier, ...rest }) => ({
+      ...rest,
+      palier: getEffectivePalier({ palier, is_founder }),
+    })) as PublicPrestataire[]
+    return { data: mapped, error: null }
+  } catch (err) {
+    return { data: null, error: errorMessage(err) }
+  }
+}
+
 /** Récupère une prestataire par son slug. Renvoie null si introuvable. */
 export async function getPrestataireBySlug(
   slug: string


### PR DESCRIPTION
## Contexte
Première brique de la refonte « accueil bonnes adresses entre copines » (Lot A2). Un bloc met en avant les prestataires qui offrent une réduction à la communauté.

## Changement
- **Section « Réductions copines »** ajoutée sur la landing publique (`/`), après `ElleProfiles`.
- Liste les prestataires avec `copine_discount_pct` non null (mig 62), badge **−X%** en héros + lien vers la fiche.
- **Auto-masquage** : si 0 fiche avec réduction, la section ne se rend pas du tout (pas de bloc vide). État prod actuel = 0/28 → invisible tant que des réductions ne sont pas renseignées.
- **Projection publique anonyme-safe** : `getPrestatairesCopineDiscount()` n'expose ni whatsapp/email/phone, et strippe `is_founder`. Découverte publique, contact toujours gated derrière login.
- Carte dédiée légère (le badge est l'élément central) → l'annuaire reste inchangé.

## Test (effectué en local contre la DB prod)
- [x] 0 fiche → section absente du DOM.
- [x] Réduction posée sur `hilmy-demo-cercle-pro` → section visible, badge −15%, lien fiche OK.
- [x] Aucun champ contact (wa.me/mailto/tel/whatsapp) dans le HTML de la section.
- [x] Reset à NULL → section disparaît. Fiche démo remise à NULL.
- [x] Typecheck propre sur les fichiers touchés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)