### PR TITLE
feat(accueil): bloc « Événements de la commu » sur la landing publique

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { StartingPoint } from '@/components/landing/StartingPoint'
 import { ThreePromises } from '@/components/landing/ThreePromises'
 import { ElleProfiles } from '@/components/landing/ElleProfiles'
 import { CopineDiscountsSection } from '@/components/landing/CopineDiscountsSection'
+import { EvenementsSection } from '@/components/landing/EvenementsSection'
 import { Manifesto } from '@/components/landing/Manifesto'
 import { TeamCherche } from '@/components/landing/TeamCherche'
 import { PricingTeaser } from '@/components/landing/PricingTeaser'
@@ -46,6 +47,7 @@ export default function HomePage() {
         <ThreePromises />
         <ElleProfiles />
         <CopineDiscountsSection />
+        <EvenementsSection />
         <TeamCherche variant="public" />
         <PricingTeaser />
         <FAQ />

--- a/components/landing/EvenementsSection.tsx
+++ b/components/landing/EvenementsSection.tsx
@@ -1,0 +1,97 @@
+import Link from 'next/link'
+import { FadeInSection } from '@/components/ui/FadeInSection'
+import { getProchainEvents, type PublicEvent } from '@/lib/supabase/queries/events'
+
+const MOIS_COURTS = [
+  'janv',
+  'févr',
+  'mars',
+  'avril',
+  'mai',
+  'juin',
+  'juil',
+  'août',
+  'sept',
+  'oct',
+  'nov',
+  'déc',
+]
+
+function formatDateFr(iso: string): string {
+  const d = new Date(iso)
+  const jour = String(d.getDate()).padStart(2, '0')
+  const mois = MOIS_COURTS[d.getMonth()]
+  const h = String(d.getHours()).padStart(2, '0')
+  const m = String(d.getMinutes()).padStart(2, '0')
+  return `${jour} ${mois} ${d.getFullYear()} · ${h}h${m}`
+}
+
+export async function EvenementsSection() {
+  const { data } = await getProchainEvents(3)
+  const list = data ?? []
+
+  // Auto-masquage : aucun événement à venir → section absente du DOM.
+  if (list.length === 0) return null
+
+  return (
+    <section className="bg-creme py-28 md:py-36">
+      <div className="mx-auto max-w-container px-6 md:px-20">
+        <FadeInSection>
+          <div className="mb-14 flex flex-wrap items-end justify-between gap-6">
+            <div className="max-w-3xl">
+              <p className="overline mb-3 text-or">Entre copines</p>
+              <h2 className="font-serif text-h2 font-light leading-[1.05] text-vert md:text-display">
+                Événements de la commu.
+              </h2>
+              <p className="mt-6 text-[15px] leading-[1.7] text-texte-sec">
+                Brunchs, ateliers, balades. Les prochains moments qu&apos;on vit
+                ensemble.
+              </p>
+            </div>
+            <Link
+              href="/dashboard/utilisatrice/evenements/nouveau"
+              className="inline-flex h-12 items-center gap-2.5 rounded-full bg-or px-6 text-[11px] font-medium uppercase tracking-[0.22em] text-vert transition-all hover:bg-or-light"
+            >
+              Ajouter le tien
+              <span aria-hidden="true">→</span>
+            </Link>
+          </div>
+        </FadeInSection>
+
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {list.map((e, i) => (
+            <EvenementCard key={e.id} e={e} index={i} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function EvenementCard({ e, index }: { e: PublicEvent; index: number }) {
+  const href = `/evenement-v2/${e.slug ?? e.id}`
+  return (
+    <FadeInSection delay={index * 0.05} className="h-full">
+      <Link
+        href={href}
+        className="group flex h-full flex-col overflow-hidden rounded-sm bg-blanc transition-all duration-500 hover:-translate-y-1 hover:shadow-[0_30px_60px_-30px_rgba(15,61,46,0.25)]"
+      >
+        {/* Flyer volontairement omis : son URL de stockage contient le
+            user_id de la créatrice (cf. PUBLIC_EVENT_SELECT). Bloc visuel
+            sobre en attendant le re-key storage du Lot B. */}
+        <div className="flex h-40 w-full items-center justify-center bg-vert/[0.06]">
+          <span className="font-serif text-[44px] font-light leading-none text-or/60">
+            {String(new Date(e.start_date).getDate()).padStart(2, '0')}
+          </span>
+        </div>
+        <div className="flex flex-1 flex-col gap-3 p-5">
+          <p className="overline text-or">{formatDateFr(e.start_date)}</p>
+          <h3 className="font-serif text-[20px] font-light leading-snug text-vert">
+            {e.title}
+          </h3>
+          {e.city && <p className="mt-auto text-[13px] text-texte-sec">{e.city}</p>}
+        </div>
+      </Link>
+    </FadeInSection>
+  )
+}

--- a/docs/backlog-lot-b.md
+++ b/docs/backlog-lot-b.md
@@ -1,0 +1,30 @@
+# Backlog — Lot B (profils + social)
+
+## Flyers d'événements : re-key le storage (chemin sans user_id)
+
+**Origine :** sous-lot A2-d. Découvert au test : le flyer d'un event est rangé sous
+`event-flyers/<user_id>/<ts>.png` → afficher `flyer_url` fait **fuiter le user_id de
+la créatrice** dans le HTML public anonyme.
+
+**Décision A2-d :** flyer **omis** de la carte landing (bloc visuel sobre à la place).
+
+**À faire en Lot B :**
+- Re-key le storage des flyers vers un chemin **sans user_id** (ex. `event-flyers/<event_id>/…`
+  ou un identifiant opaque), + migration / ré-upload des flyers existants.
+- Corriger **la même fuite sur `/evenements-v2`** (la page rend déjà `flyer_url` avec le
+  chemin user_id).
+- Puis **réintroduire le flyer** sur la carte landing (réajouter `flyer_url` à
+  `PUBLIC_EVENT_SELECT` + l'`<img>`).
+
+## Attribution « Ajouté par [prénom] » sur les événements publics
+
+**Origine :** sous-lot A2-d (bloc « Événements de la commu » sur la landing publique).
+Shippé en Option A **sans attribution** : la carte affiche date + titre + ville, pas la créatrice.
+
+**À faire en Lot B :**
+- Surfacer « Ajouté par [prénom] » sur les events publics (landing + `/evenement-v2/[slug]`).
+- Prérequis bloquant : **ne jamais mettre le prénom de quelqu'un dans le HTML public anonyme sans consentement**. Il faut d'abord :
+  - un profil avec **pseudo public** choisi par l'utilisatrice ;
+  - un **consentement explicite** sur ce qui est rendu public.
+- Technique : `events.user_id` → join `user_profiles` (pas de FK directe, PostgREST n'auto-embed pas → fetch 2 temps ou vue dédiée), + chemin de lecture **anon-safe** du pseudo (vue ou RLS anon).
+- Aujourd'hui `/evenements-v2` hardcode `organisatrice: 'HILMY'` — même bascule à prévoir là.

--- a/lib/supabase/queries/events.ts
+++ b/lib/supabase/queries/events.ts
@@ -56,6 +56,62 @@ export async function getAllEvents(): Promise<QueryResult<HilmyEvent[]>> {
   }
 }
 
+/**
+ * Champs PUBLICS d'un événement — exposés sans login dans le HTML anonyme
+ * de la landing. SÉCURITÉ : on n'expose PAS `user_id` (créatrice),
+ * `external_signup_url`, ni aucune méta interne.
+ *
+ * ⚠️ `flyer_url` est volontairement EXCLU : le chemin de stockage des
+ * flyers contient le `user_id` de la créatrice
+ * (`event-flyers/<user_id>/<ts>.png`) — l'afficher ferait fuiter cet
+ * identifiant dans le HTML anonyme. À réintroduire en Lot B une fois le
+ * storage re-keyé (chemins sans user_id). L'attribution
+ * « Ajouté par [prénom] » est elle aussi repoussée au Lot B
+ * (profils + pseudo public + consentement).
+ */
+const PUBLIC_EVENT_SELECT = `
+  id,
+  title,
+  slug,
+  start_date,
+  city
+`;
+
+export type PublicEvent = {
+  id: string;
+  title: string;
+  slug: string | null;
+  start_date: string;
+  city: string | null;
+};
+
+/**
+ * Les N prochains événements publiés (à venir), triés par date croissante.
+ * Projection PUBLIQUE anonyme-safe (pas de user_id ni de donnée perso).
+ * Alimente le bloc « Événements de la commu » de l'accueil anonyme — la
+ * section se masque d'elle-même si la liste est vide.
+ */
+export async function getProchainEvents(
+  limit = 3
+): Promise<QueryResult<PublicEvent[]>> {
+  try {
+    const supabase = await createClient();
+    const now = new Date().toISOString();
+    const { data, error } = await supabase
+      .from("events")
+      .select(PUBLIC_EVENT_SELECT)
+      .eq("status", "published")
+      .gte("start_date", now)
+      .order("start_date", { ascending: true })
+      .limit(limit);
+
+    if (error) return { data: null, error: error.message };
+    return { data: (data ?? []) as unknown as PublicEvent[], error: null };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
 /** Liste uniquement les événements à venir. */
 export async function getUpcomingEvents(): Promise<QueryResult<HilmyEvent[]>> {
   try {


### PR DESCRIPTION
## Summary
- Nouveau bloc **« Événements de la commu »** sur la landing publique (`/`), après « Réductions copines ».
- Section **auto-masquante** : `return null` si 0 événement à venir (même pattern que A2-c).
- `getProchainEvents(3)` — projection **publique anonyme-safe** (`id, title, slug, start_date, city`), `status='published'` + `start_date >= now`, tri date croissante.
- Carte : bloc date + date FR + titre + ville. CTA **« Ajouter le tien »** → `/dashboard/utilisatrice/evenements/nouveau` (login + `?next=`).

## Sécurité / privacy
- `flyer_url` **volontairement exclu** : son chemin de stockage contient le `user_id` de la créatrice (`event-flyers/<user_id>/…`) → l'afficher fuiterait cet identifiant dans le HTML anonyme. Vérifié au test : **zéro user_id / email / chemin flyer** dans la section.
- Attribution « Ajouté par [prénom] » repoussée au **Lot B** (pseudo public + consentement). Voir `docs/backlog-lot-b.md`.

## Rendu
- Landing déjà en **SSR dynamique** (`cookies()` via `createClient`) → un event créé apparaît sans délai. Pas de `revalidate` ajouté.

## Test plan
- [x] Section présente en local contre DB prod avec l'event à venir (« Atelier BentoCake », Genève) + CTA + lien `/evenement-v2/...`
- [x] Scan fuite : aucun `user_id`/email/chemin flyer dans la section
- [x] Typecheck OK sur les fichiers touchés
- [ ] Vérif prod hilmy.io après déploiement Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)