### PR TITLE
feat(landing): bloc « Les copines recommandent » (vitrine anon-safe)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { StartingPoint } from '@/components/landing/StartingPoint'
 import { ThreePromises } from '@/components/landing/ThreePromises'
 import { ElleProfiles } from '@/components/landing/ElleProfiles'
 import { CopineDiscountsSection } from '@/components/landing/CopineDiscountsSection'
+import { RecosSection } from '@/components/landing/RecosSection'
 import { EvenementsSection } from '@/components/landing/EvenementsSection'
 import { Manifesto } from '@/components/landing/Manifesto'
 import { TeamCherche } from '@/components/landing/TeamCherche'
@@ -47,6 +48,7 @@ export default function HomePage() {
         <ThreePromises />
         <ElleProfiles />
         <CopineDiscountsSection />
+        <RecosSection />
         <EvenementsSection />
         <TeamCherche variant="public" />
         <PricingTeaser />

--- a/components/landing/RecosSection.tsx
+++ b/components/landing/RecosSection.tsx
@@ -1,0 +1,86 @@
+import Link from 'next/link'
+import { FadeInSection } from '@/components/ui/FadeInSection'
+import { placeCategoryLabel } from '@/lib/constants'
+import { getRecosVitrine, type VitrineReco } from '@/lib/supabase/queries/recommendations'
+
+function Stars({ rating }: { rating: number | null }) {
+  if (!rating) return null
+  const full = Math.max(0, Math.min(5, Math.round(rating)))
+  return (
+    <span className="text-[13px] tracking-[0.15em] text-or" aria-label={`${full} sur 5`}>
+      {'★'.repeat(full)}
+      <span className="text-or/25">{'★'.repeat(5 - full)}</span>
+    </span>
+  )
+}
+
+export async function RecosSection() {
+  const { data } = await getRecosVitrine(6)
+  const list = data ?? []
+
+  // Auto-masquage : aucune reco de copine → section absente du DOM.
+  if (list.length === 0) return null
+
+  return (
+    <section className="bg-creme py-28 md:py-36">
+      <div className="mx-auto max-w-container px-6 md:px-20">
+        <FadeInSection>
+          <div className="mb-14 flex flex-wrap items-end justify-between gap-6">
+            <div className="max-w-3xl">
+              <p className="overline mb-3 text-or">Bouche à oreille</p>
+              <h2 className="font-serif text-h2 font-light leading-[1.05] text-vert md:text-display">
+                Les copines recommandent.
+              </h2>
+              <p className="mt-6 text-[15px] leading-[1.7] text-texte-sec">
+                Les adresses qu&apos;on s&apos;échange vraiment. Testées, approuvées,
+                partagées entre nous.
+              </p>
+            </div>
+            <Link
+              href="/dashboard/utilisatrice/recommandations/nouvelle"
+              className="inline-flex h-12 items-center gap-2.5 rounded-full bg-or px-6 text-[11px] font-medium uppercase tracking-[0.22em] text-vert transition-all hover:bg-or-light"
+            >
+              Recommande ton adresse
+              <span aria-hidden="true">→</span>
+            </Link>
+          </div>
+        </FadeInSection>
+
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {list.map((r, i) => (
+            <RecoCard key={r.place_slug} r={r} index={i} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function RecoCard({ r, index }: { r: VitrineReco; index: number }) {
+  return (
+    <FadeInSection delay={index * 0.05} className="h-full">
+      <Link
+        href={`/recommandation/${r.place_slug}`}
+        className="group flex h-full flex-col overflow-hidden rounded-sm bg-blanc p-6 transition-all duration-500 hover:-translate-y-1 hover:shadow-[0_30px_60px_-30px_rgba(15,61,46,0.25)]"
+      >
+        <div className="mb-4 flex items-center justify-between gap-3">
+          {r.place_hilmy_category && (
+            <span className="overline text-or">
+              {placeCategoryLabel(r.place_hilmy_category)}
+            </span>
+          )}
+          <Stars rating={r.rating} />
+        </div>
+        <h3 className="font-serif text-[20px] font-light leading-snug text-vert">
+          {r.place_name}
+        </h3>
+        {r.place_city && (
+          <p className="mt-1.5 text-[13px] text-texte-sec">{r.place_city}</p>
+        )}
+        <p className="mt-auto pt-5 text-[12px] italic text-texte-sec/80">
+          Une copine recommande
+        </p>
+      </Link>
+    </FadeInSection>
+  )
+}

--- a/docs/backlog-lot-b.md
+++ b/docs/backlog-lot-b.md
@@ -28,3 +28,20 @@ Shippé en Option A **sans attribution** : la carte affiche date + titre + ville
   - un **consentement explicite** sur ce qui est rendu public.
 - Technique : `events.user_id` → join `user_profiles` (pas de FK directe, PostgREST n'auto-embed pas → fetch 2 temps ou vue dédiée), + chemin de lecture **anon-safe** du pseudo (vue ou RLS anon).
 - Aujourd'hui `/evenements-v2` hardcode `organisatrice: 'HILMY'` — même bascule à prévoir là.
+
+## Texte verbatim des recos sur la vitrine publique
+
+**Origine :** sous-lot A2-b (bloc « Les copines recommandent » sur la landing publique).
+Shippé en Option A **sans texte** : la carte affiche lieu + ville + catégorie + note, pas
+le `comment` rédigé par la copine. La vue `recos_vitrine_public` (mig 63) n'expose
+volontairement **ni `comment`, ni `user_id`, ni `photo_urls`**.
+
+**À faire en Lot B :**
+- Surfacer l'**extrait du texte** de la reco sur la carte vitrine (landing + détail lieu).
+- Prérequis bloquants avant tout rendu public du texte :
+  - **modération** du contenu — le `comment` peut contenir des mots à ne jamais rendre
+    dans l'UI publique (ex. « halal » → règle CLAUDE.md : aucune référence Muslim/halal/Islam) ;
+  - un **pseudo public** choisi par l'autrice (même brique que l'attribution events) ;
+  - un **consentement explicite** sur la mise en avant publique de son témoignage.
+- Technique : étendre la vue (ou une vue sœur) avec un `comment` **modéré/tronqué** +
+  pseudo anon-safe ; ne jamais joindre le `comment` brut au HTML anonyme.

--- a/lib/supabase/queries/recommendations.ts
+++ b/lib/supabase/queries/recommendations.ts
@@ -86,6 +86,70 @@ export async function getRecommendationsByPlace(
   }
 }
 
+/**
+ * Champs PUBLICS d'une reco de lieu — servis depuis la vue SECURITY
+ * DEFINER `recos_vitrine_public` (mig 63), seul chemin de lecture anonyme
+ * (la table recommendations est en RLS auth-only). Zéro donnée perso :
+ * pas de user_id, pas de comment, pas de photo_urls. Voir le comment SQL
+ * de la vue.
+ */
+export type VitrineReco = {
+  place_slug: string;
+  place_name: string;
+  place_city: string | null;
+  place_hilmy_category: string | null;
+  rating: number | null;
+};
+
+type VitrineRecoRow = VitrineReco & {
+  is_user_reco: boolean;
+  created_at: string;
+};
+
+/**
+ * Les N lieux distincts les plus récemment recommandés par de VRAIES
+ * copines (`is_user_reco=true` → seeds éditoriaux exclus : pas de fausse
+ * preuve sociale). Dédoublonné par lieu (un lieu = une carte, la reco la
+ * plus récente l'emporte). Projection anonyme-safe. Alimente le bloc
+ * « Les copines recommandent » de l'accueil anonyme — la section se
+ * masque d'elle-même si la liste est vide.
+ */
+export async function getRecosVitrine(
+  limit = 6
+): Promise<QueryResult<VitrineReco[]>> {
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from("recos_vitrine_public")
+      .select(
+        "place_slug, place_name, place_city, place_hilmy_category, rating, is_user_reco, created_at"
+      )
+      .eq("is_user_reco", true)
+      .order("created_at", { ascending: false })
+      .limit(60);
+
+    if (error) return { data: null, error: error.message };
+
+    const seen = new Set<string>();
+    const deduped: VitrineReco[] = [];
+    for (const row of (data ?? []) as unknown as VitrineRecoRow[]) {
+      if (seen.has(row.place_slug)) continue;
+      seen.add(row.place_slug);
+      deduped.push({
+        place_slug: row.place_slug,
+        place_name: row.place_name,
+        place_city: row.place_city,
+        place_hilmy_category: row.place_hilmy_category,
+        rating: row.rating,
+      });
+      if (deduped.length >= limit) break;
+    }
+    return { data: deduped, error: null };
+  } catch (err) {
+    return { data: null, error: errorMessage(err) };
+  }
+}
+
 function errorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
   return String(err);

--- a/supabase/migrations/63_recos_vitrine_public.sql
+++ b/supabase/migrations/63_recos_vitrine_public.sql
@@ -1,0 +1,51 @@
+-- =====================================================================
+-- HILMY · 63 — recos_vitrine_public : couche publique anon-safe des
+--                                     recommandations de lieux
+--
+-- POURQUOI UNE VUE SECURITY DEFINER
+-- RLS de recommendations exige auth.uid() IS NOT NULL → anon lit 0 ligne
+-- (vérifié prod : recommendations=0, places=0 en clé anon). Impossible de
+-- lire la table côté public. Cette vue tourne avec les droits du
+-- propriétaire (bypass RLS) et n'expose QUE des colonnes non-perso.
+--
+-- ⚠️ VUE EXPOSÉE À ANON — toute colonne du SELECT devient publique.
+-- Interdits : user_id, comment, photo_urls, email, address, admin_notes,
+-- et le nom de batch BRUT (source_import). On expose à la place un
+-- booléen dérivé is_user_reco.
+--
+-- Idempotent (CREATE OR REPLACE). Rollback : 63_recos_vitrine_public_rollback.sql.
+-- =====================================================================
+
+create or replace view public.recos_vitrine_public
+with (security_invoker = false) as
+select
+  p.slug           as place_slug,
+  p.name           as place_name,
+  p.city           as place_city,
+  p.hilmy_category as place_hilmy_category,
+  r.rating         as rating,
+  r.created_at     as created_at,
+  (r.source_import = 'user') as is_user_reco
+from public.recommendations r
+join public.places p on p.id = r.place_id
+where r.status = 'published'
+  and r.type   = 'place'
+  and r.rating is not null;
+
+-- ─── Grants : strictement SELECT à anon, authenticated, service_role ──
+-- ⚠️ On révoque aussi explicitement de anon/authenticated : Supabase leur
+-- accorde TOUS les droits par défaut (ALTER DEFAULT PRIVILEGES) sur les
+-- nouveaux objets du schéma public. `revoke … from public` ne suffit pas
+-- (droits accordés directement aux rôles, pas via public). La vue est de
+-- toute façon non-modifiable (JOIN + colonne calculée), mais on durcit
+-- pour garantir : anon ne peut QUE lire cette vue, rien d'écrire.
+revoke all on public.recos_vitrine_public from public, anon, authenticated;
+grant select on public.recos_vitrine_public to anon, authenticated, service_role;
+
+-- ─── Comment (visible dans pg_views.viewdef) ─────────────────────────
+comment on view public.recos_vitrine_public is
+  '⚠️ Vue SECURITY DEFINER (security_invoker=false) — exposée à anon (SSR landing « Les copines recommandent » + couche publique réutilisable). Recos de lieux publiées jointes à places. Colonnes 100% non-perso : place_slug/name/city/hilmy_category, rating, created_at, is_user_reco (booléen dérivé). Filtres : status=published, type=place, rating non-null. is_user_reco=true ⇒ « Une copine recommande » ; false ⇒ seed éditorial « Sélection Hilmy ». Ne JAMAIS ajouter user_id, comment, photo_urls, address, admin_notes, ni source_import brut (nom de batch interne).';
+
+-- =====================================================================
+-- ROLLBACK : voir supabase/migrations/63_recos_vitrine_public_rollback.sql
+-- =====================================================================

--- a/supabase/migrations/63_recos_vitrine_public_rollback.sql
+++ b/supabase/migrations/63_recos_vitrine_public_rollback.sql
@@ -1,0 +1,3 @@
+-- ROLLBACK · 63 — recos_vitrine_public
+-- Non-destructif : supprime uniquement la vue publique (aucune donnée).
+drop view if exists public.recos_vitrine_public;


### PR DESCRIPTION
## Résumé
- Bloc **« Les copines recommandent »** sur la landing publique anonyme.
- Données servies par une vue **SECURITY DEFINER** `recos_vitrine_public` (mig 63) — seul chemin de lecture anonyme (la table `recommendations` est en RLS auth-only → anon lit 0).
- Carte : lieu + ville + catégorie + note + « Une copine recommande ». CTA « Recommande ton adresse ». Auto-masquage si vide.

## Sécurité (vérifié en prod, clé anon)
- Vue exposée à anon en **SELECT seulement** (revoke durci vs défaut Supabase qui accorde tout à anon).
- Colonnes 100% non-perso : `place_slug/name/city/hilmy_category`, `rating`, `created_at`, `is_user_reco`. **Pas** de `user_id`, `comment`, `photo_urls`.
- Tables de base `recommendations` / `places` : toujours **0 ligne** pour anon.
- Landing n'affiche QUE `is_user_reco=true` → les 30 seeds éditoriaux ne sont jamais signés « Une copine recommande » (pas de fausse preuve sociale).
- Dédoublonnage par lieu : 6 lieux distincts (4 lieux à 2+ recos fusionnés en 1 carte).

## Migration 63
Vue non-destructive (création seule). Rollback = `drop view`. Déjà appliquée en prod.

## Backlog Lot B
Texte verbatim des recos (modération + pseudo public + consentement) ajouté à `docs/backlog-lot-b.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)