### PR TITLE
feat(landing): barre de recherche + chips d'aiguillage dans le hero

### DIFF
--- a/app/annuaire/AnnuaireClient.tsx
+++ b/app/annuaire/AnnuaireClient.tsx
@@ -16,24 +16,44 @@ import {
 
 type Props = {
   prestataires: MockPrestataire[]
+  initialQuery?: string
+  initialCategorie?: string
 }
 
-export function AnnuaireClient({ prestataires }: Props) {
-  const [categorie, setCategorie] = useState('all')
+/** Normalise pour une recherche insensible à la casse ET aux accents. */
+const normalise = (s: string) =>
+  s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+
+export function AnnuaireClient({
+  prestataires,
+  initialQuery = '',
+  initialCategorie = 'all',
+}: Props) {
+  const [query, setQuery] = useState(initialQuery)
+  const [categorie, setCategorie] = useState(initialCategorie)
   const [ville, setVille] = useState('all')
   const [note, setNote] = useState('all')
 
   const dataSource = prestataires
 
   const filtered = useMemo(() => {
+    const q = normalise(query.trim())
     return dataSource.filter((p) => {
       if (categorie !== 'all' && p.categorie !== categorie) return false
       if (ville !== 'all' && p.ville !== ville) return false
       if (note === '45' && p.note < 4.5) return false
       if (note === '48' && p.note < 4.8) return false
+      if (
+        q &&
+        !normalise(`${p.nom} ${p.metier} ${p.tagline} ${p.ville}`).includes(q)
+      )
+        return false
       return true
     })
-  }, [dataSource, categorie, ville, note])
+  }, [dataSource, query, categorie, ville, note])
 
   const villesPresentes = Array.from(new Set(dataSource.map((p) => p.ville)))
   const villesOptions = villesPresentes
@@ -41,6 +61,7 @@ export function AnnuaireClient({ prestataires }: Props) {
     .map((v) => ({ value: v, label: v }))
 
   const reset = () => {
+    setQuery('')
     setCategorie('all')
     setVille('all')
     setNote('all')
@@ -94,6 +115,32 @@ export function AnnuaireClient({ prestataires }: Props) {
           </>
         }
       />
+
+      <div className="mx-auto max-w-container px-4 pt-8 sm:px-6 md:px-20">
+        <div className="flex items-center gap-2 rounded-full border border-or/30 bg-blanc px-5 py-1.5 shadow-[0_10px_30px_-20px_rgba(15,61,46,0.4)]">
+          <span aria-hidden="true" className="text-texte-sec/50">
+            ⌕
+          </span>
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Cherche par nom, métier, ville…"
+            aria-label="Rechercher un prestataire"
+            className="min-w-0 flex-1 bg-transparent py-2 text-[15px] text-vert outline-none placeholder:text-texte-sec/50"
+          />
+          {query && (
+            <button
+              type="button"
+              onClick={() => setQuery('')}
+              aria-label="Effacer la recherche"
+              className="shrink-0 px-2 text-texte-sec/60 transition-colors hover:text-vert"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+      </div>
 
       <FiltersBar
         resultCount={filtered.length}

--- a/app/annuaire/page.tsx
+++ b/app/annuaire/page.tsx
@@ -96,7 +96,15 @@ function adaptPrestataireFromDb(p: DbPrestataire): MockPrestataire {
 // SSR : on fetch côté serveur via getAllPrestataires() qui strippe is_founder
 // et retourne le palier effectif. Aucune donnée brute is_founder ne transite
 // dans le bundle ni dans la JSON envoyée au client.
-export default async function AnnuairePage() {
+export default async function AnnuairePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string; categorie?: string }>
+}) {
+  const sp = await searchParams
+  const initialQuery = sp.q ?? ''
+  const initialCategorie = sp.categorie ?? 'all'
+
   const { data, error } = await getAllPrestataires()
 
   if (error) {
@@ -124,5 +132,11 @@ export default async function AnnuairePage() {
   }))
   const sorted = sortByPalierThenServerOrder(adapted)
 
-  return <AnnuaireClient prestataires={sorted} />
+  return (
+    <AnnuaireClient
+      prestataires={sorted}
+      initialQuery={initialQuery}
+      initialCategorie={initialCategorie}
+    />
+  )
 }

--- a/app/recommandations/page.tsx
+++ b/app/recommandations/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { Suspense, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import { PageShell } from '@/components/v2/PageShell'
 import { PageHero } from '@/components/v2/PageHero'
@@ -44,8 +45,40 @@ function adaptPlaceFromDb(p: Place): MockLieu {
   }
 }
 
+/** Normalise pour une recherche insensible à la casse ET aux accents. */
+const normalise = (s: string) =>
+  s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+
+// useSearchParams() exige une frontière <Suspense> (Next). Le contenu réel
+// vit dans RecommandationsContent ; l'export default ne fait que l'envelopper.
 export default function RecommandationsPage() {
-  const [categorie, setCategorie] = useState('all')
+  return (
+    <Suspense
+      fallback={
+        <PageShell>
+          <PageHero
+            number="02"
+            kicker="Les recommandations"
+            titre={<>Les adresses qui passent de main en main.</>}
+          />
+          <SkeletonListGrid count={6} />
+        </PageShell>
+      }
+    >
+      <RecommandationsContent />
+    </Suspense>
+  )
+}
+
+function RecommandationsContent() {
+  const searchParams = useSearchParams()
+  const [query, setQuery] = useState(() => searchParams.get('q') ?? '')
+  const [categorie, setCategorie] = useState(
+    () => searchParams.get('categorie') ?? 'all',
+  )
   const [ville, setVille] = useState('all')
 
   const [loading, setLoading] = useState(true)
@@ -115,12 +148,15 @@ export default function RecommandationsPage() {
   const dataSource = liveLieux
 
   const filtered = useMemo(() => {
+    const q = normalise(query.trim())
     return dataSource.filter((l) => {
       if (categorie !== 'all' && l.categorie !== categorie) return false
       if (ville !== 'all' && l.ville !== ville) return false
+      if (q && !normalise(`${l.nom} ${l.ville} ${l.description}`).includes(q))
+        return false
       return true
     })
-  }, [dataSource, categorie, ville])
+  }, [dataSource, query, categorie, ville])
 
   const villesPresentes = Array.from(new Set(dataSource.map((l) => l.ville)))
   const villesOptions = villesPresentes
@@ -128,6 +164,7 @@ export default function RecommandationsPage() {
     .map((v) => ({ value: v, label: v }))
 
   const reset = () => {
+    setQuery('')
     setCategorie('all')
     setVille('all')
   }
@@ -204,6 +241,32 @@ export default function RecommandationsPage() {
           </span>
         </Link>
       </PageHero>
+
+      <div className="mx-auto max-w-container px-4 pt-8 sm:px-6 md:px-20">
+        <div className="flex items-center gap-2 rounded-full border border-or/30 bg-blanc px-5 py-1.5 shadow-[0_10px_30px_-20px_rgba(15,61,46,0.4)]">
+          <span aria-hidden="true" className="text-texte-sec/50">
+            ⌕
+          </span>
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Cherche par nom, ville…"
+            aria-label="Rechercher un lieu"
+            className="min-w-0 flex-1 bg-transparent py-2 text-[15px] text-vert outline-none placeholder:text-texte-sec/50"
+          />
+          {query && (
+            <button
+              type="button"
+              onClick={() => setQuery('')}
+              aria-label="Effacer la recherche"
+              className="shrink-0 px-2 text-texte-sec/60 transition-colors hover:text-vert"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+      </div>
 
       <FiltersBar
         resultCount={filtered.length}

--- a/components/landing/HeroSearch.tsx
+++ b/components/landing/HeroSearch.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+/**
+ * Barre de recherche du hero — aiguilleur de destination (Lot A · A2-a).
+ * Les chips SÉLECTIONNENT une destination ; la navigation se fait au submit
+ * (Enter ou loupe), en passant terme + catégorie dans l'URL. Exception :
+ * la chip Événements navigue IMMÉDIATEMENT (la page events ne lit pas ?q=,
+ * cf. backlog A2-a-bis), donc pas de submit qui jetterait le terme.
+ */
+type Chip = {
+  id: string
+  label: string
+  dest: string
+  categorie?: string
+  placeholder: string
+  /** Navigation immédiate au clic (pas de sélection ni de submit). */
+  immediate?: boolean
+}
+
+const CHIPS: Chip[] = [
+  {
+    id: 'prestataires',
+    label: 'Prestataires',
+    dest: '/annuaire',
+    placeholder: 'Cherche une coiffeuse, une thérapeute…',
+  },
+  {
+    id: 'restos',
+    label: 'Restos & Cafés',
+    dest: '/recommandations',
+    categorie: 'restos-cafes',
+    placeholder: 'Cherche un resto, un café…',
+  },
+  {
+    id: 'boutiques',
+    label: 'Boutiques',
+    dest: '/recommandations',
+    categorie: 'boutiques',
+    placeholder: 'Cherche une boutique…',
+  },
+  {
+    id: 'bien-etre',
+    label: 'Bien-être',
+    dest: '/recommandations',
+    categorie: 'bien-etre',
+    placeholder: 'Cherche un spa, un soin…',
+  },
+  {
+    id: 'evenements',
+    label: 'Événements',
+    dest: '/evenements-v2',
+    placeholder: 'Parcourir les événements…',
+    immediate: true,
+  },
+]
+
+export function HeroSearch() {
+  const router = useRouter()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [selected, setSelected] = useState('prestataires')
+  const [query, setQuery] = useState('')
+
+  const active = CHIPS.find((c) => c.id === selected) ?? CHIPS[0]
+
+  function handleChip(chip: Chip) {
+    if (chip.immediate) {
+      router.push(chip.dest)
+      return
+    }
+    setSelected(chip.id)
+    inputRef.current?.focus()
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const params = new URLSearchParams()
+    if (active.categorie) params.set('categorie', active.categorie)
+    const q = query.trim()
+    if (q) params.set('q', q)
+    const qs = params.toString()
+    router.push(qs ? `${active.dest}?${qs}` : active.dest)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="w-full max-w-xl">
+      {/* Chips d'aiguillage */}
+      <div className="mb-3 flex flex-wrap items-center justify-center gap-2">
+        {CHIPS.map((chip) => {
+          const isActive = !chip.immediate && chip.id === selected
+          return (
+            <button
+              key={chip.id}
+              type="button"
+              onClick={() => handleChip(chip)}
+              aria-pressed={isActive}
+              className={
+                isActive
+                  ? 'rounded-full border border-or bg-or px-4 py-1.5 text-[12px] font-medium tracking-[0.04em] text-vert transition-colors'
+                  : 'rounded-full border border-creme/30 bg-white/5 px-4 py-1.5 text-[12px] tracking-[0.04em] text-creme/80 transition-colors hover:border-or/60 hover:text-creme'
+              }
+            >
+              {chip.label}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Champ + bouton */}
+      <div className="flex items-center gap-2 rounded-full bg-creme/95 py-1.5 pl-5 pr-1.5 shadow-[0_20px_50px_-20px_rgba(0,0,0,0.6)] ring-1 ring-or/20">
+        <input
+          ref={inputRef}
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={active.placeholder}
+          aria-label="Rechercher une adresse"
+          enterKeyHint="search"
+          className="min-w-0 flex-1 bg-transparent py-2 text-[15px] text-vert outline-none placeholder:text-texte-sec/50"
+        />
+        <button
+          type="submit"
+          aria-label="Rechercher"
+          className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-or text-vert transition-colors hover:bg-or-light"
+        >
+          <span aria-hidden="true" className="text-lg">
+            →
+          </span>
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/components/landing/HeroV2.tsx
+++ b/components/landing/HeroV2.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { motion, useReducedMotion } from 'motion/react'
 import { GoldLine } from '@/components/ui/GoldLine'
+import { HeroSearch } from '@/components/landing/HeroSearch'
 
 /* ─────────────────────────────────────────────────────────
    SYSTÈME DE SWITCH — change HERO_VARIANT pour tester
@@ -107,9 +108,10 @@ export function HeroV2({ variant }: { variant?: VariantKey } = {}) {
         },
   }
 
-  // Délai après fin du stagger H1 pour sous-titre + CTA
+  // Délai après fin du stagger H1 pour sous-titre + recherche + CTA
   const subDelay = 0.6 * speed
-  const ctaDelay = 1.2 * speed
+  const searchDelay = 0.9 * speed
+  const ctaDelay = 1.3 * speed
   // Shimmer démarre juste après que tous les mots soient apparus
   const shimmerDelay = 0.1 + words.length * 0.08 * speed + 0.1
 
@@ -244,6 +246,21 @@ export function HeroV2({ variant }: { variant?: VariantKey } = {}) {
         >
           {sub}
         </motion.p>
+
+        {/* Recherche — barre + chips d'aiguillage */}
+        <motion.div
+          initial={shouldReduceMotion ? undefined : { opacity: 0, y: 15 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.3 }}
+          transition={{
+            duration: 0.5 * speed,
+            delay: searchDelay,
+            ease: 'easeOut',
+          }}
+          className="flex w-full justify-center"
+        >
+          <HeroSearch />
+        </motion.div>
 
         {/* CTAs — scale léger à la fin */}
         <motion.div

--- a/docs/backlog-lot-b.md
+++ b/docs/backlog-lot-b.md
@@ -45,3 +45,18 @@ volontairement **ni `comment`, ni `user_id`, ni `photo_urls`**.
   - un **consentement explicite** sur la mise en avant publique de son témoignage.
 - Technique : étendre la vue (ou une vue sœur) avec un `comment` **modéré/tronqué** +
   pseudo anon-safe ; ne jamais joindre le `comment` brut au HTML anonyme.
+
+## A2-a-bis — Support `?q=` (et `?categorie=`) sur les événements
+
+**Origine :** sous-lot A2-a (barre de recherche du hero, aiguilleur de destination).
+La barre route vers `/annuaire?q=` (prestataires) et `/recommandations?categorie=…&q=`
+(lieux). Pour les **événements**, la chip « Événements » fait une **navigation immédiate**
+vers `/evenements-v2` **sans transmettre le terme** : la page events ne lit aujourd'hui
+que `?seasonal=<slug>` (pas de `?q=` ni `?categorie=`).
+
+**À faire (petit patch) :**
+- Faire lire à `/evenements-v2` un param `?q=` (filtre texte client sur titre + ville +
+  description) et éventuellement `?categorie=<event_type>`, sur le même modèle que les
+  patchs annuaire/recommandations.
+- Puis basculer la chip « Événements » du hero en mode **sélection + submit** (comme les
+  autres chips) pour transmettre le terme tapé, au lieu de la navigation immédiate.


### PR DESCRIPTION
## Summary
- Ajoute `HeroSearch` dans le hero de la landing : une barre de recherche + des chips qui **sélectionnent une destination** (aiguilleurs), pas un moteur unifié.
  - **Prestataires** (défaut) → `/annuaire`
  - **Restos & Cafés / Boutiques / Bien-être** → `/recommandations?categorie=…`
  - **Événements** → navigation **immédiate** vers `/evenements-v2` (la page events ne lit pas encore `?q=`, cf. backlog A2-a-bis)
  - Le clic de chip donne le **focus** à l'input et **adapte le placeholder**.
  - La navigation se fait **au submit** (Enter ou loupe) en passant `?q=` + `?categorie=`.
- Câble les pages de destination pour **pré-remplir leurs filtres** depuis l'URL :
  - `/annuaire` lit `searchParams` (server component, `?q=` + `?categorie=`)
  - `/recommandations` lit `useSearchParams` (client, sous `<Suspense>`)
  - Les deux gagnent un **champ de recherche visible, pré-rempli et éditable**, avec un filtre texte **insensible à la casse ET aux accents** (« henne » trouve « henné »).
- Backlog : nouvelle entrée **A2-a-bis** (support `?q=` sur les événements).

## Test plan
- [ ] Taper « matcha » sans chip → atterrit sur `/annuaire?q=matcha`, input pré-rempli, liste filtrée
- [ ] Chip **Restos & Cafés** + « matcha » → `/recommandations?categorie=restos-cafes&q=matcha`
- [ ] Chip **Boutiques** sans terme → `/recommandations?categorie=boutiques`
- [ ] Chip **Événements** → `/evenements-v2` (immédiat)
- [ ] Rendu hero desktop + mobile (chips, search, 2 CTAs) — validé en preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)