### PR TITLE
feat(nav): liens Accueil + Je cherche, fiche reco non-cliquable

### DIFF
--- a/app/recommandation/[slug]/page.tsx
+++ b/app/recommandation/[slug]/page.tsx
@@ -473,14 +473,15 @@ export default async function RecommandationPage({
                     Recommandé par {recoViews.length} cop
                     {recoViews.length > 1 ? 'ines' : 'ine'}
                   </p>
-                  <div className="mt-4 flex flex-wrap items-center gap-2">
+                  {/* Texte simple, pas de pastille : en attendant les profils
+                      publics (Lot B), ce bloc ne doit PAS paraître cliquable.
+                      Aucun lien, aucun pointer — cursor-default explicite. */}
+                  <div className="mt-4 flex cursor-default flex-col gap-3">
                     {recoViews.map((r) => (
-                      <div
-                        key={r.id}
-                        className="flex items-center gap-2 rounded-full border border-or/20 bg-creme-soft px-3 py-1.5"
-                      >
+                      <div key={r.id} className="flex items-center gap-2">
                         <span
-                          className="h-6 w-6 rounded-full ring-1 ring-or/30"
+                          aria-hidden="true"
+                          className="h-6 w-6 shrink-0 rounded-full ring-1 ring-or/30"
                           style={{ background: r.avatar }}
                         />
                         <span className="text-[12px] font-medium text-vert">

--- a/components/landing/Navigation.tsx
+++ b/components/landing/Navigation.tsx
@@ -70,9 +70,16 @@ export function Navigation({
 
         <div className="hidden items-center gap-10 md:flex">
           {[
+            // Lien Accueil explicite en tête : le logo seul ne suffit pas
+            // comme repère de retour. Même cible que le logo (espace connecté
+            // vs landing publique).
+            { href: user ? '/accueil' : '/', label: 'Accueil' },
             { href: '/annuaire', label: "L'annuaire" },
             { href: '/recommandations', label: 'Recommandations' },
             { href: '/evenements-v2', label: 'Événements' },
+            // Module « Je cherche » (feed des copines). La liste est
+            // anon-accessible (SSR public), donc pas de redirect login ici.
+            { href: '/je-cherche', label: 'Je cherche' },
             { href: '/tarifs', label: 'Tarifs' },
             // Lien Pass Copine — visible si user connectée non-prestataire
             // (les prestataires ont leur propre flow d'abo dans /tarifs).


### PR DESCRIPTION
## Contexte
Quick wins issus du retour utilisatrice réelle (Jiji) sur la prod. Lot groupé n°1 (3 des 5 points).

## Changements
- **UX 5 — Lien « Accueil » explicite** en tête de nav. Le logo seul ne suffisait pas comme repère de retour. Même cible que le logo (`/accueil` connectée, `/` anonyme).
- **UX 4 — Entrée « Je cherche »** dans la nav, entre Événements et Tarifs → `/je-cherche`. La liste (feed des copines) est SSR **anon-accessible**, donc aucun redirect login nécessaire.
- **BUG 2 — « Recommandé par » non-cliquable.** Sur `/recommandation/[slug]`, les copines étaient rendues en **pastilles arrondies** (bordure dorée + fond crème) → fausse affordance cliquable, alors qu'aucun `<Link>`/`onClick` n'existe. Aplati en texte simple (avatar + prénom) avec `cursor-default`, en attendant les profils publics (Lot B).

## Tests
- [x] Typecheck : aucune nouvelle erreur sur les fichiers touchés (erreurs TS pré-existantes hors scope).
- [x] Rendu nav desktop vérifié : `Accueil · L'annuaire · Recommandations · Événements · Je cherche · Tarifs · À propos`.
- [ ] Vérif prod après déploiement Vercel : nav + clics Accueil/Je cherche, bloc reco visuellement non-cliquable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)