### PR TITLE
feat(filtres): filtre pays/ville dynamique (annuaire + recommandations)

### DIFF
--- a/app/annuaire/AnnuaireClient.tsx
+++ b/app/annuaire/AnnuaireClient.tsx
@@ -9,7 +9,8 @@ import { FiltersBar } from '@/components/v2/FiltersBar'
 import { PrestataireCard } from '@/components/v2/PrestataireCard'
 import { LiveEmptyState } from '@/components/v2/LiveStates'
 import {
-  villesSuggestions,
+  buildGeoFilters,
+  paysBucket,
   categoriesPrestataires,
   type Prestataire as MockPrestataire,
 } from '@/lib/mock-data'
@@ -34,6 +35,7 @@ export function AnnuaireClient({
 }: Props) {
   const [query, setQuery] = useState(initialQuery)
   const [categorie, setCategorie] = useState(initialCategorie)
+  const [pays, setPays] = useState('all')
   const [ville, setVille] = useState('all')
   const [note, setNote] = useState('all')
 
@@ -43,6 +45,7 @@ export function AnnuaireClient({
     const q = normalise(query.trim())
     return dataSource.filter((p) => {
       if (categorie !== 'all' && p.categorie !== categorie) return false
+      if (pays !== 'all' && paysBucket(p) !== pays) return false
       if (ville !== 'all' && p.ville !== ville) return false
       if (note === '45' && p.note < 4.5) return false
       if (note === '48' && p.note < 4.8) return false
@@ -53,16 +56,25 @@ export function AnnuaireClient({
         return false
       return true
     })
-  }, [dataSource, query, categorie, ville, note])
+  }, [dataSource, query, categorie, pays, ville, note])
 
-  const villesPresentes = Array.from(new Set(dataSource.map((p) => p.ville)))
-  const villesOptions = villesPresentes
-    .sort((a, b) => villesSuggestions.indexOf(a) - villesSuggestions.indexOf(b))
-    .map((v) => ({ value: v, label: v }))
+  // Options Pays/Ville calculées en DISTINCT sur les données réelles (dynamique).
+  const { paysOptions, villesByPays, allVilles } = useMemo(
+    () => buildGeoFilters(dataSource),
+    [dataSource],
+  )
+  const villesForPays = pays === 'all' ? allVilles : (villesByPays.get(pays) ?? [])
+
+  // Changer de pays remet la ville à « toutes ».
+  const onPaysChange = (v: string) => {
+    setPays(v)
+    setVille('all')
+  }
 
   const reset = () => {
     setQuery('')
     setCategorie('all')
+    setPays('all')
     setVille('all')
     setNote('all')
   }
@@ -160,11 +172,22 @@ export function AnnuaireClient({
             ],
           },
           {
+            id: 'pays',
+            label: 'Pays',
+            value: pays,
+            onChange: onPaysChange,
+            options: [{ value: 'all', label: 'Tous' }, ...paysOptions],
+          },
+          {
             id: 'ville',
             label: 'Ville',
             value: ville,
             onChange: setVille,
-            options: [{ value: 'all', label: 'Toutes' }, ...villesOptions],
+            variant: 'dropdown',
+            options: [
+              { value: 'all', label: 'Toutes les villes' },
+              ...villesForPays.map((v) => ({ value: v, label: v })),
+            ],
           },
           {
             id: 'note',

--- a/app/annuaire/page.tsx
+++ b/app/annuaire/page.tsx
@@ -80,6 +80,7 @@ function adaptPrestataireFromDb(p: DbPrestataire): MockPrestataire {
     metier,
     categorie: p.categorie,
     ville: p.ville,
+    pays: p.pays ?? null,
     note: p.note_moyenne ?? 0,
     avis: p.nb_avis ?? 0,
     prix: (p.prix_gamme as '€' | '€€' | '€€€') ?? '€€',

--- a/app/onboarding/prestataire/manuel/page.tsx
+++ b/app/onboarding/prestataire/manuel/page.tsx
@@ -208,6 +208,7 @@ export default function ManuelOnboardingPage() {
       nom: nom.trim(),
       slug,
       categorie,
+      pays: pays.trim() || null,
       ville: formatVilleDisplay(ville.trim()) ?? ville.trim(),
       whatsapp: toE164(waDial, waNumber),
       phone_public: phonePublic.trim() || null,

--- a/app/recommandations/page.tsx
+++ b/app/recommandations/page.tsx
@@ -15,7 +15,8 @@ import {
 } from '@/components/v2/LiveStates'
 import {
   categoriesLieux,
-  villesSuggestions,
+  buildGeoFilters,
+  paysBucket,
   type Lieu as MockLieu,
 } from '@/lib/mock-data'
 import { createClient } from '@/lib/supabase/client'
@@ -35,6 +36,7 @@ function adaptPlaceFromDb(p: Place): MockLieu {
     nom: p.name,
     categorie: p.hilmy_category ?? 'restos-cafes',
     ville: p.city ?? '',
+    pays: p.country ?? null,
     adresse: p.address ?? '',
     description: p.description ?? '',
     cover,
@@ -79,6 +81,7 @@ function RecommandationsContent() {
   const [categorie, setCategorie] = useState(
     () => searchParams.get('categorie') ?? 'all',
   )
+  const [pays, setPays] = useState('all')
   const [ville, setVille] = useState('all')
 
   const [loading, setLoading] = useState(true)
@@ -151,21 +154,32 @@ function RecommandationsContent() {
     const q = normalise(query.trim())
     return dataSource.filter((l) => {
       if (categorie !== 'all' && l.categorie !== categorie) return false
+      if (pays !== 'all' && paysBucket(l) !== pays) return false
       if (ville !== 'all' && l.ville !== ville) return false
       if (q && !normalise(`${l.nom} ${l.ville} ${l.description}`).includes(q))
         return false
       return true
     })
-  }, [dataSource, query, categorie, ville])
+  }, [dataSource, query, categorie, pays, ville])
 
-  const villesPresentes = Array.from(new Set(dataSource.map((l) => l.ville)))
-  const villesOptions = villesPresentes
-    .sort((a, b) => villesSuggestions.indexOf(a) - villesSuggestions.indexOf(b))
-    .map((v) => ({ value: v, label: v }))
+  // Options Pays/Ville calculées en DISTINCT sur les données réelles (dynamique).
+  const { paysOptions, villesByPays, allVilles } = useMemo(
+    () => buildGeoFilters(dataSource),
+    [dataSource],
+  )
+  const villesForPays = pays === 'all' ? allVilles : (villesByPays.get(pays) ?? [])
+
+  // Changer de pays remet la ville à « toutes » (la ville d'avant peut ne plus
+  // appartenir au nouveau pays).
+  const onPaysChange = (v: string) => {
+    setPays(v)
+    setVille('all')
+  }
 
   const reset = () => {
     setQuery('')
     setCategorie('all')
+    setPays('all')
     setVille('all')
   }
 
@@ -286,11 +300,22 @@ function RecommandationsContent() {
             ],
           },
           {
+            id: 'pays',
+            label: 'Pays',
+            value: pays,
+            onChange: onPaysChange,
+            options: [{ value: 'all', label: 'Tous' }, ...paysOptions],
+          },
+          {
             id: 'ville',
             label: 'Ville',
             value: ville,
             onChange: setVille,
-            options: [{ value: 'all', label: 'Toutes' }, ...villesOptions],
+            variant: 'dropdown',
+            options: [
+              { value: 'all', label: 'Toutes les villes' },
+              ...villesForPays.map((v) => ({ value: v, label: v })),
+            ],
           },
         ]}
       />

--- a/components/v2/FiltersBar.tsx
+++ b/components/v2/FiltersBar.tsx
@@ -1,18 +1,31 @@
 'use client'
 
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+
 interface Option {
   value: string
   label: string
 }
 
+interface FilterGroupConfig {
+  id: string
+  label: string
+  options: Option[]
+  value: string
+  onChange: (v: string) => void
+  /**
+   * 'chips' (défaut) : boutons pills horizontaux. Convient aux dimensions à
+   * faible cardinalité (Catégorie, Pays).
+   *
+   * 'dropdown' : bouton déclencheur + popover avec champ de filtre texte et
+   * liste scrollable. Convient aux longues listes (Ville) — ne déborde jamais
+   * la page (max-height + scroll interne).
+   */
+  variant?: 'chips' | 'dropdown'
+}
+
 interface FiltersBarProps {
-  groups: {
-    id: string
-    label: string
-    options: Option[]
-    value: string
-    onChange: (v: string) => void
-  }[]
+  groups: FilterGroupConfig[]
   resultCount?: number
   onReset?: () => void
   resetLabel?: string
@@ -31,9 +44,13 @@ export function FiltersBar({
       <div className="mx-auto max-w-container px-4 py-4 sm:px-6 sm:py-5 md:px-20">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between md:gap-6">
           <div className="flex flex-col gap-4 md:flex-row md:flex-wrap md:items-center md:gap-x-6 md:gap-y-4">
-            {groups.map((g) => (
-              <FilterGroup key={g.id} {...g} />
-            ))}
+            {groups.map((g) =>
+              g.variant === 'dropdown' ? (
+                <FilterDropdown key={g.id} {...g} />
+              ) : (
+                <FilterChips key={g.id} {...g} />
+              ),
+            )}
           </div>
           <div className="flex items-center gap-5 text-[11px]">
             {typeof resultCount === 'number' && (
@@ -57,20 +74,7 @@ export function FiltersBar({
   )
 }
 
-function FilterGroup({
-  label,
-  options,
-  value,
-  onChange,
-}: Option extends never
-  ? never
-  : {
-      id: string
-      label: string
-      options: Option[]
-      value: string
-      onChange: (v: string) => void
-    }) {
+function FilterChips({ label, options, value, onChange }: FilterGroupConfig) {
   return (
     <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
       <span className="overline text-or">{label}</span>
@@ -96,6 +100,143 @@ function FilterGroup({
             </button>
           )
         })}
+      </div>
+    </div>
+  )
+}
+
+/** Normalise pour un filtre insensible casse + accents. */
+const normalise = (s: string) =>
+  s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+
+function FilterDropdown({ label, options, value, onChange }: FilterGroupConfig) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listId = useId()
+
+  const selected = options.find((o) => o.value === value)
+  const selectedLabel = selected?.label ?? options[0]?.label ?? ''
+  const isActive = value !== 'all'
+
+  const filtered = useMemo(() => {
+    const q = normalise(query.trim())
+    if (!q) return options
+    return options.filter((o) => normalise(o.label).includes(q))
+  }, [options, query])
+
+  // Fermeture au clic extérieur + Échap.
+  useEffect(() => {
+    if (!open) return
+    const onPointer = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onPointer)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onPointer)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  // Focus le champ de filtre à l'ouverture, reset la recherche à la fermeture.
+  useEffect(() => {
+    if (open) {
+      const t = setTimeout(() => inputRef.current?.focus(), 0)
+      return () => clearTimeout(t)
+    }
+    setQuery('')
+  }, [open])
+
+  return (
+    <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+      <span className="overline text-or">{label}</span>
+      <div className="relative" ref={containerRef}>
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          className={`flex min-h-[40px] items-center gap-2 rounded-full px-4 py-2 text-[12px] font-medium transition-all md:min-h-0 md:px-3.5 md:py-1.5 ${
+            isActive
+              ? 'bg-vert text-creme'
+              : 'bg-blanc text-texte-sec hover:bg-creme-deep hover:text-vert'
+          }`}
+        >
+          <span className="max-w-[160px] truncate">{selectedLabel}</span>
+          <span
+            aria-hidden="true"
+            className={`text-[9px] transition-transform ${open ? 'rotate-180' : ''}`}
+          >
+            ▼
+          </span>
+        </button>
+
+        {open && (
+          <div
+            className="absolute left-0 z-40 mt-2 w-[clamp(220px,80vw,280px)] overflow-hidden rounded-xl border border-or/25 bg-blanc shadow-[0_24px_60px_-30px_rgba(15,61,46,0.5)]"
+            role="dialog"
+            aria-label={`Filtrer par ${label.toLowerCase()}`}
+          >
+            <div className="border-b border-or/15 p-2">
+              <input
+                ref={inputRef}
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={`Filtrer ${label.toLowerCase()}…`}
+                aria-label={`Filtrer la liste ${label.toLowerCase()}`}
+                aria-controls={listId}
+                className="w-full rounded-lg bg-creme-soft px-3 py-2 text-[13px] text-vert outline-none placeholder:text-texte-sec/50 focus:ring-1 focus:ring-or/40"
+              />
+            </div>
+            <ul
+              id={listId}
+              role="listbox"
+              className="max-h-[260px] overflow-y-auto overscroll-contain py-1"
+            >
+              {filtered.length === 0 ? (
+                <li className="px-3 py-3 text-center text-[12px] text-texte-sec">
+                  Aucune ville
+                </li>
+              ) : (
+                filtered.map((opt) => {
+                  const active = value === opt.value
+                  return (
+                    <li key={opt.value} role="option" aria-selected={active}>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onChange(opt.value)
+                          setOpen(false)
+                        }}
+                        className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-[13px] transition-colors ${
+                          active
+                            ? 'bg-creme-deep font-medium text-vert'
+                            : 'text-texte-sec hover:bg-creme-soft hover:text-vert'
+                        }`}
+                      >
+                        <span className="truncate">{opt.label}</span>
+                        {active && (
+                          <span aria-hidden="true" className="text-or">
+                            ✓
+                          </span>
+                        )}
+                      </button>
+                    </li>
+                  )
+                })
+              )}
+            </ul>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -50,6 +50,67 @@ export const villesSuggestions: string[] = [
   "Monte-Carlo",
 ];
 
+// ─── Filtres géo dynamiques (Pays / Ville) ────────────────────────
+// Les options Pays + Ville sont calculées en DISTINCT sur les données
+// RÉELLES (lieux/prestataires), jamais sur une liste figée. Un nouveau
+// pays/ville en base apparaît donc tout seul dans les filtres.
+// `villesSuggestions` ci-dessus ne sert plus que d'ordre d'affichage soft.
+export const PAYS_NON_PRECISE = "__none__";
+export const PAYS_NON_PRECISE_LABEL = "Pays non précisé";
+
+type GeoItem = { ville?: string | null; pays?: string | null };
+
+/** Bucket pays d'un item : pays non vide, sinon sentinelle "non précisé". */
+export function paysBucket(item: GeoItem): string {
+  const p = (item.pays ?? "").trim();
+  return p || PAYS_NON_PRECISE;
+}
+
+/**
+ * Construit les options de filtres géo depuis les données réelles.
+ * Retourne :
+ *  - `paysOptions` : pays distincts présents (ordre alpha FR, "non précisé" en
+ *    dernier) — à passer en chips.
+ *  - `villesByPays` : Map pays → villes distinctes triées (ordre alpha FR), pour
+ *    alimenter le dropdown selon le pays sélectionné.
+ *  - `allVilles` : toutes les villes distinctes (pays = "all").
+ */
+export function buildGeoFilters(items: GeoItem[]): {
+  paysOptions: { value: string; label: string }[];
+  villesByPays: Map<string, string[]>;
+  allVilles: string[];
+} {
+  const sets = new Map<string, Set<string>>();
+  const all = new Set<string>();
+  for (const it of items) {
+    const pays = paysBucket(it);
+    const ville = (it.ville ?? "").trim();
+    if (!sets.has(pays)) sets.set(pays, new Set());
+    if (ville) {
+      sets.get(pays)!.add(ville);
+      all.add(ville);
+    }
+  }
+  const paysList = Array.from(sets.keys()).sort((a, b) => {
+    if (a === PAYS_NON_PRECISE) return 1;
+    if (b === PAYS_NON_PRECISE) return -1;
+    return a.localeCompare(b, "fr");
+  });
+  const paysOptions = paysList.map((p) => ({
+    value: p,
+    label: p === PAYS_NON_PRECISE ? PAYS_NON_PRECISE_LABEL : p,
+  }));
+  const villesByPays = new Map<string, string[]>();
+  for (const [pays, set] of sets) {
+    villesByPays.set(
+      pays,
+      Array.from(set).sort((a, b) => a.localeCompare(b, "fr")),
+    );
+  }
+  const allVilles = Array.from(all).sort((a, b) => a.localeCompare(b, "fr"));
+  return { paysOptions, villesByPays, allVilles };
+}
+
 // ─── Catégories alignées sur le schéma DB (profiles.categorie) ─────
 // 11 catégories prestataires — CHECK constraint en base
 // (01_alter_profiles.sql + 21_categorie_conseilleres.sql).
@@ -94,6 +155,9 @@ export type Prestataire = {
   metier: string;
   categorie: string;
   ville: Ville;
+  /** Pays — source DB `profiles.pays`. Peut être vide pour les fiches legacy
+   *  (backfill PR2) → bucket "Pays non précisé" dans les filtres. */
+  pays?: string | null;
   note: number;
   avis: number;
   prix: "€" | "€€" | "€€€";
@@ -364,6 +428,9 @@ export type Lieu = {
   nom: string;
   categorie: string;
   ville: Ville;
+  /** Pays — source DB `places.country` (capturé auto via Google Places à la
+   *  création). Optionnel côté type pour compat ; en pratique 100% rempli. */
+  pays?: string | null;
   adresse: string;
   description: string;
   cover: string;

--- a/lib/supabase/queries/prestataires.ts
+++ b/lib/supabase/queries/prestataires.ts
@@ -24,9 +24,9 @@ import type {
 import { getEffectivePalier } from "@/lib/permissions";
 
 // ⚠️ On ne sélectionne que les colonnes qui existent vraiment dans la DB.
-// Les champs pays/region/code_postal/zone_intervention du type TS Prestataire
-// sont absents de la table `profiles` actuelle — ils resteront undefined
-// côté consumer (ALTER à ajouter via une future migration si besoin).
+// `pays` existe en base (alimente le filtre Pays dynamique de l'annuaire). Les
+// champs region/code_postal/zone_intervention du type TS Prestataire sont en
+// revanche absents de `profiles` — ils resteront undefined côté consumer.
 const PRESTATAIRE_SELECT = `
   id,
   user_id,
@@ -36,6 +36,7 @@ const PRESTATAIRE_SELECT = `
   slug,
   categorie,
   ville,
+  pays,
   description,
   tagline,
   whatsapp,


### PR DESCRIPTION
## Summary
- **Refonte du filtre Lieu** pour scaler à plusieurs pays. Catégorie reste en chips ; **Pays** devient une ligne de chips dédiée ; **Ville** passe en **dropdown** (champ de filtre texte accent-insensible + liste scrollable, `max-h` + scroll interne) qui ne déborde jamais la page (validé desktop 1280px et mobile 375px).
- **Filtres 100% dynamiques** : pays et villes dérivés en DISTINCT des données réelles (`buildGeoFilters`), zéro liste figée. Une nouvelle adresse fait apparaître son pays/ville automatiquement, sans toucher au code.
- **Bucket « Pays non précisé »** pour les fiches sans pays renseigné (libellé propre, jamais `null`/vide).
- **Capture du pays à la création** (onboarding manuel prestataire) : ajout de `pays` dans l'insert `profiles`, qui était omis — c'est la cause des fiches legacy sans pays.
- Expose `pays` dans `PRESTATAIRE_SELECT` (alimente le filtre annuaire).

## Périmètre
7 fichiers, +300/−41. Le gros = nouveau composant `FilterDropdown` dans `FiltersBar.tsx` + helper `buildGeoFilters` dans `mock-data.ts`. La ligne ajoutée dans `manuel/page.tsx` est chirurgicale (1 ligne dans l'objet insert, ne touche ni validation, ni `status`, ni RLS). Aucun service-role, aucun fichier parasite.

## Test plan
- [x] `/annuaire` (SSR, 22 prestataires réelles) : catégorie → pays chips → ville dropdown ; 13 villes dynamiques triées alpha ; filtre interne accent-insensible (`gen` → Genève, Genis) ; dropdown 280px, **aucun débordement** desktop ni mobile ; chip « Pays non précisé » propre ; filtre catégorie fonctionnel (22→4).
- [x] `/recommandations` : page se résout proprement (empty state sous RLS anon — `places` non lisible sans session) ; filtre UI identique (même `FiltersBar`, mêmes helpers).
- [ ] Vérif post-merge en prod (données réelles + nouvelle fiche → pays auto).

## Suite (PR2, séparée)
Backfill du `pays` des ~26 fiches prestataires legacy via géocodage Google de leur ville.