### PR TITLE
feat(reco): ouvre la fiche reco aux visiteurs anonymes (SEO)

### DIFF
--- a/app/recommandation/[slug]/page.tsx
+++ b/app/recommandation/[slug]/page.tsx
@@ -1,14 +1,21 @@
-import { notFound, redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
 import {
   RecommandationDetail,
   type RecoView,
   type VideoEntry,
 } from '@/components/v2/RecommandationDetail'
+import { RecommandationDetailPublic } from '@/components/v2/RecommandationDetailPublic'
 import type { Lieu as MockLieu } from '@/lib/mock-data'
 import {
   getPlaceBySlug,
   getPlacesByCategorie,
 } from '@/lib/supabase/queries/places'
+import {
+  getPublicPlaceDetail,
+  getPublicPlaceRecos,
+  getPublicSimilar,
+} from '@/lib/supabase/queries/places-public'
 import { getRecommendationsByPlace } from '@/lib/supabase/queries/recommendations'
 import { getPlaceVideos } from '@/lib/supabase/queries/videos'
 import { getUserGamificationByUserIds } from '@/lib/supabase/queries/gamification'
@@ -64,6 +71,35 @@ function adaptDbPlace(p: Place): MockLieu {
   }
 }
 
+// SEO — métadonnées rendues côté serveur depuis la vue publique anon-safe.
+// Aucune donnée perso (nom du lieu, ville, description éditoriale).
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  const { slug } = await params
+  const detail = await getPublicPlaceDetail(slug)
+  if (!detail) return { title: 'Recommandation · Hilmy' }
+  const title = `${detail.name}${detail.city ? ` · ${detail.city}` : ''} — recommandé sur Hilmy`
+  const description =
+    detail.description?.slice(0, 155) ??
+    `${detail.name}${detail.city ? ` à ${detail.city}` : ''}, recommandé par la communauté Hilmy.`
+  const url = `/recommandation/${encodeURIComponent(slug)}`
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      type: 'article',
+      ...(detail.main_photo_url ? { images: [detail.main_photo_url] } : {}),
+    },
+  }
+}
+
 export default async function RecommandationPage({
   params,
 }: {
@@ -75,10 +111,28 @@ export default async function RecommandationPage({
   const {
     data: { user },
   } = await supabase.auth.getUser()
+
+  // ── Branche ANONYME ────────────────────────────────────────────────
+  // Pas de session → rendu public allégé, branché UNIQUEMENT sur les vues
+  // anon-safe (place_public_detail / place_public_recos), jamais les tables.
+  // Le composant public ne connaît AUCUNE identité (cf. RecommandationDetailPublic).
   if (!user) {
-    redirect(`/auth/signup?redirect=/recommandation/${encodeURIComponent(slug)}`)
+    const detail = await getPublicPlaceDetail(slug)
+    if (!detail) notFound()
+    const [recos, similaires] = await Promise.all([
+      getPublicPlaceRecos(slug),
+      getPublicSimilar(detail.hilmy_category, slug),
+    ])
+    return (
+      <RecommandationDetailPublic
+        detail={detail}
+        recos={recos}
+        similaires={similaires}
+      />
+    )
   }
 
+  // ── Branche CONNECTÉE (rendu riche existant, inchangé) ──────────────
   const { data: row, error } = await getPlaceBySlug(slug)
   if (error || !row) notFound()
   const l: MockLieu = adaptDbPlace(row)

--- a/components/v2/RecommandationDetailPublic.tsx
+++ b/components/v2/RecommandationDetailPublic.tsx
@@ -1,0 +1,433 @@
+import Link from 'next/link'
+import { PageShell } from '@/components/v2/PageShell'
+import { GoldLine } from '@/components/ui/GoldLine'
+import { FadeInSection } from '@/components/ui/FadeInSection'
+import { LieuCard } from '@/components/v2/LieuCard'
+import { categoriesLieux, type Lieu as MockLieu } from '@/lib/mock-data'
+import { isSelectionHilmy } from '@/lib/permissions-lieux'
+import { DIET_TAGS_MAP, dietTagLabel, recTagLabel } from '@/lib/constants'
+import type {
+  PublicPlaceDetail,
+  PublicPlaceReco,
+} from '@/lib/supabase/queries/places-public'
+
+/**
+ * Rendu PUBLIC (anonyme, indexable SEO) de la fiche reco.
+ *
+ * ⚠️ ÉTANCHÉITÉ — ce composant n'importe NI MemberName, NI gamif, NI aucune
+ * source identitaire, et son type de props (PublicReco) ne contient AUCUN
+ * champ permettant de réidentifier une autrice (pas de prenom/avatar/user_id/
+ * is_copine/statut). Le compilateur interdit donc de fuiter une identité ici.
+ * Le rendu RICHE connecté reste dans RecommandationDetail.tsx, inchangé.
+ *
+ * Server Component (pas de 'use client') → HTML rendu côté serveur =
+ * indexable. Les enfants client (FadeInSection, LieuCard) sont OK en RSC.
+ */
+
+type PublicReco = {
+  reco_id: string
+  date: string
+  rating: number | null
+  comment: string | null
+  tags: string[]
+  diets: string[]
+  priceIndicator: string | null
+}
+
+function catLabel(slug: string | null) {
+  if (!slug) return ''
+  return categoriesLieux.find((c) => c.slug === slug)?.label ?? slug
+}
+
+function relativeDate(iso: string) {
+  const days = Math.round((Date.now() - new Date(iso).getTime()) / 86_400_000)
+  if (days < 1) return "aujourd'hui"
+  if (days < 7) return `il y a ${days} j`
+  if (days < 30) return `il y a ${Math.round(days / 7)} sem.`
+  if (days < 365) return `il y a ${Math.round(days / 30)} mois`
+  const y = Math.round(days / 365)
+  return `il y a ${y} an${y > 1 ? 's' : ''}`
+}
+
+/** Adapte un détail public en MockLieu pour LieuCard (similaires). */
+function detailToMockLieu(d: PublicPlaceDetail): MockLieu {
+  const photosArr = Array.isArray(d.photos) ? d.photos : []
+  const galerie = d.main_photo_url ? [d.main_photo_url, ...photosArr] : photosArr
+  return {
+    slug: d.place_slug,
+    nom: d.name,
+    categorie: d.hilmy_category ?? 'restos-cafes',
+    ville: d.city ?? '',
+    adresse: d.address ?? '',
+    description: d.description ?? '',
+    cover: '#EEE6D8',
+    galerie,
+    recommandePar: [],
+    commentaires: [],
+    palier: d.palier ?? undefined,
+  }
+}
+
+function toPublicReco(r: PublicPlaceReco): PublicReco {
+  const rawTags = r.tags ?? []
+  const diets = rawTags.filter((t) => t in DIET_TAGS_MAP).map(dietTagLabel)
+  const tags = rawTags.filter((t) => !(t in DIET_TAGS_MAP)).map(recTagLabel)
+  return {
+    reco_id: r.reco_id,
+    date: relativeDate(r.created_at),
+    rating: r.rating,
+    comment: r.comment,
+    tags,
+    diets,
+    priceIndicator: r.price_indicator,
+  }
+}
+
+export function RecommandationDetailPublic({
+  detail,
+  recos,
+  similaires,
+}: {
+  detail: PublicPlaceDetail
+  recos: PublicPlaceReco[]
+  similaires: PublicPlaceDetail[]
+}) {
+  const photosArr = Array.isArray(detail.photos) ? detail.photos : []
+  const coverUrl =
+    detail.main_photo_url && detail.main_photo_url.startsWith('http')
+      ? detail.main_photo_url
+      : null
+  // Galerie = photos du lieu hors cover (la cover est déjà dans le hero).
+  const galleryPhotos = photosArr.filter(
+    (u) => typeof u === 'string' && u.startsWith('http') && u !== coverUrl,
+  )
+
+  // On ne garde QUE les recos qui ont du contenu à montrer (commentaire OU
+  // note) → pas de carte vide « moche » (mode dégradé propre, cf. UX3).
+  const recoViews = recos
+    .map(toPublicReco)
+    .filter((r) => (r.comment && r.comment.trim().length > 0) || r.rating)
+  const soloReco = recoViews.length === 1
+
+  const signupHref = `/auth/signup?redirect=/recommandation/${encodeURIComponent(detail.place_slug)}`
+  const mapsHref = detail.google_place_id
+    ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+        `${detail.name} ${detail.address}`,
+      )}&query_place_id=${encodeURIComponent(detail.google_place_id)}`
+    : `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(detail.address)}`
+
+  const typeLabel = detail.google_category
+    ? detail.google_category.replace(/_/g, ' ')
+    : null
+
+  return (
+    <PageShell>
+      {/* Cover */}
+      <section
+        className="relative h-[54vh] min-h-[420px] overflow-hidden pt-20 md:h-[62vh]"
+        style={
+          coverUrl
+            ? {
+                backgroundImage: `linear-gradient(160deg, rgba(15,61,46,0.3) 0%, rgba(245,240,230,0.3) 100%), url(${coverUrl})`,
+                backgroundSize: 'cover',
+                backgroundPosition: 'center',
+              }
+            : { background: 'linear-gradient(160deg, #EEE6D8 0%, #D9C9A8 100%)' }
+        }
+      >
+        <div className="absolute inset-0 bg-grain opacity-[0.08]" />
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-vert/40 to-transparent py-10">
+          <div className="mx-auto max-w-container px-6 md:px-20">
+            <Link
+              href="/recommandations"
+              className="group inline-flex items-center gap-2 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-colors hover:text-or-light"
+            >
+              <span
+                className="text-or transition-transform group-hover:-translate-x-0.5"
+                aria-hidden="true"
+              >
+                ←
+              </span>
+              Retour aux recommandations
+            </Link>
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              {isSelectionHilmy(detail) && (
+                <span
+                  className="inline-flex items-center gap-1.5 rounded-full bg-creme px-3 py-1.5 font-serif text-[11px] font-light italic tracking-[0.2em] text-or shadow-[0_2px_8px_-2px_rgba(15,61,46,0.25)] uppercase backdrop-blur"
+                  aria-label="Lieu Sélection Hilmy"
+                >
+                  <span aria-hidden="true">✨</span>
+                  Sélection Hilmy
+                </span>
+              )}
+              {detail.hilmy_category && (
+                <span className="inline-flex items-center gap-2 rounded-full bg-creme/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
+                  {catLabel(detail.hilmy_category)}
+                </span>
+              )}
+              {detail.city && (
+                <span className="inline-flex items-center gap-2 rounded-full bg-vert/70 px-3 py-1 text-[10px] tracking-[0.22em] text-creme backdrop-blur uppercase">
+                  {detail.city}
+                </span>
+              )}
+            </div>
+            <h1 className="mt-5 font-serif text-display font-light leading-[0.95] text-creme">
+              {detail.name}
+            </h1>
+            {/* Note + prix NATIFS Hilmy (jamais Google) */}
+            <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-creme">
+              {detail.avg_rating !== null && (
+                <span className="text-[13px] tracking-[0.18em] uppercase">
+                  <span className="text-or">★</span> {detail.avg_rating}
+                  <span className="text-creme/70">
+                    {' · '}
+                    {detail.nb_copines} cop{detail.nb_copines > 1 ? 'ines' : 'ine'}
+                  </span>
+                </span>
+              )}
+              {detail.price_mode && (
+                <span className="font-serif text-[15px] text-or">
+                  {detail.price_mode}
+                </span>
+              )}
+              {typeLabel && (
+                <span className="text-[11px] text-creme/60 capitalize">
+                  {typeLabel}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-container px-6 md:px-20">
+          <div className="grid gap-16 md:grid-cols-[1.4fr_1fr] md:gap-20">
+            {/* Main */}
+            <div className="space-y-12">
+              {detail.description && (
+                <FadeInSection>
+                  <header className="flex items-center gap-5">
+                    <GoldLine width={60} />
+                    <span className="overline text-or">Le lieu</span>
+                  </header>
+                  <p className="mt-6 font-serif text-[19px] font-light leading-[1.7] text-vert md:text-[21px]">
+                    {detail.description}
+                  </p>
+                </FadeInSection>
+              )}
+
+              {galleryPhotos.length > 0 && (
+                <FadeInSection>
+                  <div className="grid grid-cols-2 gap-3 md:gap-4">
+                    {galleryPhotos.map((url, i) => (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        key={i}
+                        src={url}
+                        alt={`${detail.name} — photo ${i + 2}`}
+                        className={`w-full rounded-sm object-cover ${
+                          galleryPhotos.length === 1 || i === 0
+                            ? 'col-span-2 aspect-[16/9]'
+                            : 'aspect-square'
+                        }`}
+                      />
+                    ))}
+                  </div>
+                </FadeInSection>
+              )}
+
+              {recoViews.length > 0 && (
+                <>
+                  <FadeInSection>
+                    <header className="flex items-center gap-5">
+                      <GoldLine width={60} />
+                      <span className="overline text-or">
+                        Ce qu&apos;on en dit
+                        {recoViews.length > 1 ? ` · ${recoViews.length} recos` : ''}
+                      </span>
+                    </header>
+                  </FadeInSection>
+
+                  <ul className="space-y-6">
+                    {recoViews.map((r) => (
+                      <li
+                        key={r.reco_id}
+                        className={`rounded-sm border border-or/15 bg-blanc ${
+                          soloReco ? 'p-7 md:p-10' : 'p-6 md:p-8'
+                        }`}
+                      >
+                        {/* En-tête ANONYME : « Une copine » + date, jamais de
+                            prénom/avatar/statut (étanchéité publique). */}
+                        <div className="flex items-center gap-3">
+                          <span
+                            aria-hidden="true"
+                            className="h-10 w-10 rounded-full bg-creme-deep ring-1 ring-or/30"
+                          />
+                          <div>
+                            <p className="text-[14px] font-medium text-vert">
+                              Une copine
+                            </p>
+                            <p className="text-[11px] text-texte-sec">{r.date}</p>
+                          </div>
+                          {r.rating && (
+                            <span
+                              className="ml-auto text-[18px] tracking-[0.1em] text-or"
+                              aria-label={`${r.rating} / 5`}
+                            >
+                              {'★'.repeat(r.rating)}
+                              <span className="text-or/25">
+                                {'★'.repeat(5 - r.rating)}
+                              </span>
+                            </span>
+                          )}
+                        </div>
+
+                        {r.comment && (
+                          <p
+                            className={`mt-5 font-serif italic leading-[1.7] text-texte ${
+                              soloReco
+                                ? 'text-[19px] md:text-[23px]'
+                                : 'text-[16px] md:text-[17px]'
+                            }`}
+                          >
+                            « {r.comment} »
+                          </p>
+                        )}
+
+                        {r.diets.length > 0 && (
+                          <div className="mt-5 flex flex-wrap items-center gap-2">
+                            {r.diets.map((d) => (
+                              <span
+                                key={d}
+                                className="rounded-full border border-vert/30 bg-vert px-3 py-1 text-[10px] font-medium tracking-[0.18em] text-creme uppercase"
+                              >
+                                {d}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+
+                        {(r.tags.length > 0 || r.priceIndicator) && (
+                          <div className="mt-3 flex flex-wrap items-center gap-2">
+                            {r.tags.map((t) => (
+                              <span
+                                key={t}
+                                className="rounded-full border border-or/25 bg-creme-soft px-3 py-1 text-[10px] font-medium tracking-[0.18em] text-vert uppercase"
+                              >
+                                {t}
+                              </span>
+                            ))}
+                            {r.priceIndicator && (
+                              <span className="rounded-full border border-or/40 bg-or/10 px-3 py-1 font-serif text-[14px] text-or">
+                                {r.priceIndicator}
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+
+            {/* Sidebar */}
+            <aside className="md:sticky md:top-28 md:self-start">
+              <div className="rounded-sm border border-or/15 bg-creme-deep p-8">
+                <p className="overline text-or">Où c&apos;est</p>
+                <p className="mt-4 font-serif text-lg font-light text-vert">
+                  {detail.address}
+                </p>
+                <div className="mt-5 h-px w-full bg-or/20" />
+                <div className="mt-5 flex gap-2 text-[11px] text-texte-sec">
+                  <span className="inline-flex items-center gap-1">
+                    <span className="h-1 w-1 rounded-full bg-or" />
+                    Adresse via Google Maps
+                  </span>
+                </div>
+                <a
+                  href={mapsHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-6 inline-flex h-11 w-full items-center justify-center gap-2 rounded-full border border-or/40 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-or hover:bg-blanc"
+                >
+                  Ouvrir dans Maps
+                  <span className="text-or" aria-hidden="true">
+                    →
+                  </span>
+                </a>
+              </div>
+
+              {detail.nb_copines > 0 && (
+                <div className="mt-6 rounded-sm border border-or/15 bg-blanc p-6">
+                  <p className="overline text-or">
+                    Recommandé par {detail.nb_copines} cop
+                    {detail.nb_copines > 1 ? 'ines' : 'ine'}
+                  </p>
+                  <p className="mt-3 text-[12px] leading-[1.6] text-texte-sec">
+                    Des femmes de la communauté Hilmy sont déjà passées par ici.
+                  </p>
+                </div>
+              )}
+
+              {/* CTA inscription (remplace Sauvegarder / Ajouter ma reco,
+                  réservés aux membres). */}
+              <div className="mt-6 rounded-sm border border-or/20 bg-vert p-8 text-creme">
+                <p className="overline text-or">Rejoins le carnet</p>
+                <p className="mt-4 text-[13px] leading-[1.65] text-creme/80">
+                  Crée ton compte pour sauvegarder ce lieu, voir qui le
+                  recommande et ajouter ta propre reco.
+                </p>
+                <Link
+                  href={signupHref}
+                  className="mt-6 inline-flex h-11 w-full items-center justify-center gap-2 rounded-full bg-or text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:bg-or-light"
+                >
+                  Créer mon compte
+                  <span aria-hidden="true">→</span>
+                </Link>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      {similaires.length > 0 && (
+        <section className="bg-blanc py-20 md:py-28">
+          <div className="mx-auto max-w-container px-6 md:px-20">
+            <FadeInSection>
+              <div className="mb-10 flex flex-col justify-between gap-4 md:flex-row md:items-end">
+                <div>
+                  <div className="flex items-center gap-4">
+                    <GoldLine width={48} />
+                    <span className="overline text-or">Dans le même genre</span>
+                  </div>
+                  <h2 className="mt-4 font-serif text-h2 font-light text-vert">
+                    Celles qu&apos;on aime aussi.
+                  </h2>
+                </div>
+                <Link
+                  href="/recommandations"
+                  className="group inline-flex items-center gap-2 text-[13px] font-medium text-vert hover:text-or transition-colors"
+                >
+                  Voir toutes les recos
+                  <span
+                    className="text-or transition-transform group-hover:translate-x-1"
+                    aria-hidden="true"
+                  >
+                    →
+                  </span>
+                </Link>
+              </div>
+            </FadeInSection>
+            <div className="columns-1 gap-6 sm:columns-2 lg:columns-3">
+              {similaires.map((s, i) => (
+                <LieuCard key={s.place_slug} lieu={detailToMockLieu(s)} index={i} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+    </PageShell>
+  )
+}

--- a/lib/supabase/queries/places-public.ts
+++ b/lib/supabase/queries/places-public.ts
@@ -1,0 +1,97 @@
+/**
+ * Queries PUBLIQUES de la fiche reco (PR1 — ouverture anonyme).
+ *
+ * Lisent UNIQUEMENT les vues anon-safe `place_public_detail` et
+ * `place_public_recos` (mig 64), jamais les tables `places` /
+ * `recommendations` / `user_profiles`. Les vues tournent en SECURITY DEFINER
+ * et n'exposent AUCUNE colonne identitaire → impossible de réidentifier une
+ * autrice (cf. verrou n°3 de l'architecture).
+ *
+ * Client serveur ANON (createClient cookie SSR sans session) : le grant anon
+ * sur les vues suffit. AUCUN service-role.
+ */
+
+import { createClient } from "@/lib/supabase/server";
+
+export type PublicPlaceDetail = {
+  place_slug: string;
+  name: string;
+  hilmy_category: string | null;
+  google_category: string | null;
+  city: string;
+  country: string | null;
+  address: string;
+  latitude: number | null;
+  longitude: number | null;
+  description: string | null;
+  main_photo_url: string | null;
+  photos: string[] | null;
+  palier: 'aucun' | 'selection_hilmy' | null;
+  google_place_id: string | null;
+  avg_rating: number | null;
+  nb_avis: number;
+  nb_copines: number;
+  price_mode: string | null;
+};
+
+export type PublicPlaceReco = {
+  reco_id: string;
+  place_slug: string;
+  comment: string | null;
+  rating: number | null;
+  tags: string[] | null;
+  price_indicator: string | null;
+  created_at: string;
+};
+
+const DETAIL_SELECT =
+  "place_slug, name, hilmy_category, google_category, city, country, address, latitude, longitude, description, main_photo_url, photos, palier, google_place_id, avg_rating, nb_avis, nb_copines, price_mode";
+
+const RECO_SELECT =
+  "reco_id, place_slug, comment, rating, tags, price_indicator, created_at";
+
+/** Détail public d'un lieu par slug. null si le lieu n'a aucune reco publiée. */
+export async function getPublicPlaceDetail(
+  slug: string
+): Promise<PublicPlaceDetail | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("place_public_detail")
+    .select(DETAIL_SELECT)
+    .eq("place_slug", slug)
+    .maybeSingle();
+  if (error || !data) return null;
+  return data as unknown as PublicPlaceDetail;
+}
+
+/** Commentaires publics anonymisés d'un lieu (plus récents en premier). */
+export async function getPublicPlaceRecos(
+  slug: string
+): Promise<PublicPlaceReco[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("place_public_recos")
+    .select(RECO_SELECT)
+    .eq("place_slug", slug)
+    .order("created_at", { ascending: false });
+  if (error || !data) return [];
+  return data as unknown as PublicPlaceReco[];
+}
+
+/** Lieux similaires (même catégorie), pour le maillage interne SEO. */
+export async function getPublicSimilar(
+  hilmyCategory: string | null,
+  excludeSlug: string,
+  limit = 3
+): Promise<PublicPlaceDetail[]> {
+  if (!hilmyCategory) return [];
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("place_public_detail")
+    .select(DETAIL_SELECT)
+    .eq("hilmy_category", hilmyCategory)
+    .neq("place_slug", excludeSlug)
+    .limit(limit);
+  if (error || !data) return [];
+  return data as unknown as PublicPlaceDetail[];
+}

--- a/supabase/migrations/64_place_public_views.sql
+++ b/supabase/migrations/64_place_public_views.sql
@@ -1,0 +1,95 @@
+-- =====================================================================
+-- HILMY · 64 — Fiche reco PUBLIQUE : deux vues anon-safe pour ouvrir la
+--               page /recommandation/[slug] aux visiteurs anonymes (SEO).
+--
+-- POURQUOI DEUX VUES SECURITY DEFINER (security_invoker=false)
+-- RLS de places + recommendations exige auth.uid() IS NOT NULL → anon lit
+-- 0 ligne (vérifié prod). Ces vues tournent avec les droits du propriétaire
+-- (bypass RLS) et n'exposent QUE des colonnes Hilmy-natives non-perso.
+--
+-- ⚠️ VUES EXPOSÉES À ANON — toute colonne du SELECT devient publique.
+-- Interdits ABSOLUS (réidentifient une autrice) : user_id, prenom, avatar,
+-- is_copine, copine_since, gamif, created_by_user_id. L'avatar de l'app est
+-- DÉRIVÉ du user_id → ne jamais sortir user_id. nb_copines compte des
+-- user_id DISTINCTS sans jamais les exposer.
+--
+-- Périmètre PR1 : on ouvre le contenu Hilmy DÉJÀ en base. Pas de Google live
+-- (horaires/tél = PR membre), pas de photos copines (photo_urls = PR
+-- modération). La cover Google (main_photo_url) est conservée telle quelle.
+--
+-- Idempotent (CREATE OR REPLACE). Rollback : 64_place_public_views_rollback.sql.
+-- =====================================================================
+
+-- ─── Vue A : détail public d'un lieu (1 ligne / lieu ayant ≥1 reco publiée)
+-- Agrège la note + le prix NATIFS Hilmy (depuis recommendations), jamais
+-- Google. N'expose AUCUN uuid de lieu : la clé publique est le slug.
+create or replace view public.place_public_detail
+with (security_invoker = false) as
+select
+  p.slug                                            as place_slug,
+  p.name                                            as name,
+  p.hilmy_category                                  as hilmy_category,
+  p.google_category                                 as google_category,
+  p.city                                            as city,
+  p.country                                         as country,
+  p.address                                         as address,
+  p.latitude                                        as latitude,
+  p.longitude                                       as longitude,
+  p.description                                     as description,
+  p.main_photo_url                                  as main_photo_url,
+  p.photos                                          as photos,
+  p.palier                                          as palier,
+  p.google_place_id                                 as google_place_id,
+  round(avg(r.rating) filter (where r.rating is not null), 1) as avg_rating,
+  count(r.rating) filter (where r.rating is not null)        as nb_avis,
+  count(distinct r.user_id)                                   as nb_copines,
+  mode() within group (order by r.price_indicator)
+    filter (where r.price_indicator is not null)             as price_mode
+from public.places p
+join public.recommendations r
+  on r.place_id = p.id
+ and r.status = 'published'
+ and r.type   = 'place'
+where p.slug is not null
+group by
+  p.slug, p.name, p.hilmy_category, p.google_category, p.city, p.country,
+  p.address, p.latitude, p.longitude, p.description, p.main_photo_url,
+  p.photos, p.palier, p.google_place_id;
+
+-- ─── Vue B : commentaires publics ANONYMISÉS (1 ligne / reco publiée)
+-- AUCUNE colonne identitaire. reco_id = clé React uniquement (la table base
+-- reste inaccessible à anon). On joint par slug pour ne sortir aucun uuid de
+-- lieu non plus.
+create or replace view public.place_public_recos
+with (security_invoker = false) as
+select
+  r.id              as reco_id,
+  p.slug            as place_slug,
+  r.comment         as comment,
+  r.rating          as rating,
+  r.tags            as tags,
+  r.price_indicator as price_indicator,
+  r.created_at      as created_at
+from public.recommendations r
+join public.places p on p.id = r.place_id
+where r.status = 'published'
+  and r.type   = 'place'
+  and p.slug is not null;
+
+-- ─── Grants : strictement SELECT à anon, authenticated, service_role ──────
+-- Supabase accorde TOUS les droits par défaut aux rôles sur les nouveaux
+-- objets du schéma public → on révoque puis on n'accorde QUE select.
+revoke all on public.place_public_detail from public, anon, authenticated;
+revoke all on public.place_public_recos  from public, anon, authenticated;
+grant select on public.place_public_detail to anon, authenticated, service_role;
+grant select on public.place_public_recos  to anon, authenticated, service_role;
+
+-- ─── Comments de garde (visibles dans pg_views.viewdef) ──────────────────
+comment on view public.place_public_detail is
+  '⚠️ Vue SECURITY DEFINER (security_invoker=false) — exposée à anon (fiche publique /recommandation/[slug], SEO). 1 ligne par lieu ayant ≥1 reco publiée. Note + prix NATIFS Hilmy (avg rating, nb_avis, nb_copines=count distinct user_id NON exposé, price_mode). Clé publique = slug, AUCUN uuid de lieu. Ne JAMAIS ajouter user_id, prenom, avatar, is_copine, copine_since, gamif, created_by_user_id.';
+comment on view public.place_public_recos is
+  '⚠️ Vue SECURITY DEFINER (security_invoker=false) — exposée à anon (commentaires publics ANONYMISÉS de la fiche). 1 ligne par reco publiée (status=published, type=place). Colonnes : reco_id (clé React), place_slug (jointure), comment (texte tel quel, PR1 sans modération), rating, tags, price_indicator, created_at. Ne JAMAIS ajouter user_id ni photo_urls (PR photos/modération).';
+
+-- =====================================================================
+-- ROLLBACK : voir supabase/migrations/64_place_public_views_rollback.sql
+-- =====================================================================

--- a/supabase/migrations/64_place_public_views_rollback.sql
+++ b/supabase/migrations/64_place_public_views_rollback.sql
@@ -1,0 +1,7 @@
+-- =====================================================================
+-- HILMY · 64 ROLLBACK — supprime les vues publiques de la fiche reco.
+-- Additif et sans donnée : drop pur, aucun impact sur places/recommendations.
+-- =====================================================================
+
+drop view if exists public.place_public_detail;
+drop view if exists public.place_public_recos;


### PR DESCRIPTION
## Résumé
- Les visiteurs **non connectés** voient un rendu public allégé et **indexable** de `/recommandation/[slug]` (au lieu d'être redirigés vers signup).
- Note + prix **natifs Hilmy** (issus de `recommendations`, jamais Google), commentaires **anonymisés** (« Une copine »), CTA inscription.
- Le rendu **riche connecté** (`RecommandationDetail`, prénoms/gamif/sauvegarder) est **inchangé** — branche anonyme en early-return.

## Détail
- **mig 64** : deux vues anon-safe `place_public_detail` + `place_public_recos` (`security_invoker=false`), `grant select` à anon. **Aucune** colonne identitaire exposée (pas de `user_id`/`prenom`/`avatar`/`is_copine`/gamif/`photo_urls`). Rollback fourni.
- `lib/supabase/queries/places-public.ts` : queries anon (SSR `createClient`, **zéro service-role**).
- `RecommandationDetailPublic.tsx` : Server Component, mode dégradé propre (sans description / sans galerie / note seule).
- `page.tsx` : branche anonyme + `generateMetadata` SEO ; branche connectée byte-identique.

## Étanchéité prouvée (anon, curl sans cookie)
- 11 marqueurs identitaires = **0**. Les 2 UUID rendus = `reco_id` (clés React), pas de `user_id`.
- SSR : nom + description + commentaires + `<title>` présents côté serveur.

## Liens testés (tous vivants)
- 3 similaires → 200, `/recommandations` → 200, `/auth/signup?redirect=...` correct par fiche.
- « Ouvrir dans Maps » : URL Google officielle `maps/search/?api=1&query=...&query_place_id=...`.

## Cas limites
- Sans description → bloc « Le lieu » absent. Reco note-only → pas de bloc citation vide. « 1 copine » au singulier.

## Test plan
- [ ] Vérif visuelle **connectée** sur prod (rendu riche intact) — fiche `chikin-bang-korean-street-food-part-dieu-a97a20`.
- [ ] Re-test curl anon en **prod** après déploiement (zéro fuite + SSR).

## Migration
La mig 64 est **déjà appliquée sur la DB prod** (vues additives/inertes, non référencées par le site live tant que ce code n'est pas déployé). Rollback : `supabase/migrations/64_place_public_views_rollback.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)