### PR TITLE
feat(reco): note + prix natifs en hero (public + connecté, identiques)

### DIFF
--- a/app/recommandation/[slug]/page.tsx
+++ b/app/recommandation/[slug]/page.tsx
@@ -133,6 +133,10 @@ export default async function RecommandationPage({
   }
 
   // ── Branche CONNECTÉE (rendu riche existant, inchangé) ──────────────
+  // Stats hero (note + nb copines + prix) lues depuis la MÊME vue anon-safe
+  // que la fiche publique → garantit des valeurs strictement identiques à ce
+  // que voit un visiteur anonyme. Lancé en parallèle (ne dépend que du slug).
+  const publicStatsPromise = getPublicPlaceDetail(slug)
   const { data: row, error } = await getPlaceBySlug(slug)
   if (error || !row) notFound()
   const l: MockLieu = adaptDbPlace(row)
@@ -224,6 +228,8 @@ export default async function RecommandationPage({
       .map(adaptDbPlace)
   }
 
+  const publicStats = await publicStatsPromise
+
   return (
     <RecommandationDetail
       l={l}
@@ -231,6 +237,9 @@ export default async function RecommandationPage({
       recoViews={recoViews}
       videoEntries={videoEntries}
       similaires={similaires}
+      heroRating={publicStats?.avg_rating ?? null}
+      heroNbCopines={publicStats?.nb_copines ?? 0}
+      heroPriceMode={publicStats?.price_mode ?? null}
     />
   )
 }

--- a/components/v2/RecommandationDetail.tsx
+++ b/components/v2/RecommandationDetail.tsx
@@ -10,6 +10,7 @@ import { LieuCard } from '@/components/v2/LieuCard'
 import { VideoPlayer } from '@/components/v2/VideoPlayer'
 import { categoriesLieux, type Lieu as MockLieu } from '@/lib/mock-data'
 import { isSelectionHilmy } from '@/lib/permissions-lieux'
+import { formatRating, copineWord } from '@/lib/reco-format'
 import type { GamificationStatut } from '@/lib/supabase/types'
 import type { Place } from '@/lib/supabase/types'
 
@@ -51,12 +52,20 @@ export function RecommandationDetail({
   recoViews,
   videoEntries,
   similaires,
+  heroRating,
+  heroNbCopines,
+  heroPriceMode,
 }: {
   l: MockLieu
   row: Place
   recoViews: RecoView[]
   videoEntries: VideoEntry[]
   similaires: MockLieu[]
+  // Stats hero NATIVES Hilmy — lues depuis la MÊME source que la fiche
+  // publique (vue place_public_detail) → valeur/format identiques à l'anon.
+  heroRating: number | null
+  heroNbCopines: number
+  heroPriceMode: string | null
 }) {
   // Photos réelles (http) du lieu. La 1re sert de cover (background hero) ;
   // les suivantes alimentent la galerie « Le lieu en images ». Les entrées
@@ -65,6 +74,10 @@ export function RecommandationDetail({
   const coverIsPhoto = placePhotos.length > 0 && l.galerie[0] === placePhotos[0]
   const galleryPhotos = coverIsPhoto ? placePhotos.slice(1) : placePhotos
   const soloReco = recoViews.length === 1
+  // Type lisible (catégorie Google), miroir exact de la fiche publique.
+  const typeLabel = row.google_category
+    ? row.google_category.replace(/_/g, ' ')
+    : null
 
   return (
     <PageShell>
@@ -119,6 +132,29 @@ export function RecommandationDetail({
             <h1 className="mt-5 font-serif text-display font-light leading-[0.95] text-creme">
               {l.nom}
             </h1>
+            {/* Note + prix NATIFS Hilmy (jamais Google) — IDENTIQUE à la fiche
+                publique : même source (place_public_detail), même format. */}
+            <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-creme">
+              {heroRating !== null && (
+                <span className="text-[13px] tracking-[0.18em] uppercase">
+                  <span className="text-or">★</span> {formatRating(heroRating)}
+                  <span className="text-creme/70">
+                    {' · '}
+                    {heroNbCopines} {copineWord(heroNbCopines)}
+                  </span>
+                </span>
+              )}
+              {heroPriceMode && (
+                <span className="font-serif text-[15px] text-or">
+                  {heroPriceMode}
+                </span>
+              )}
+              {typeLabel && (
+                <span className="text-[11px] text-creme/60 capitalize">
+                  {typeLabel}
+                </span>
+              )}
+            </div>
           </div>
         </div>
       </section>

--- a/components/v2/RecommandationDetailPublic.tsx
+++ b/components/v2/RecommandationDetailPublic.tsx
@@ -6,6 +6,7 @@ import { LieuCard } from '@/components/v2/LieuCard'
 import { categoriesLieux, type Lieu as MockLieu } from '@/lib/mock-data'
 import { isSelectionHilmy } from '@/lib/permissions-lieux'
 import { DIET_TAGS_MAP, dietTagLabel, recTagLabel } from '@/lib/constants'
+import { formatRating, copineWord } from '@/lib/reco-format'
 import type {
   PublicPlaceDetail,
   PublicPlaceReco,
@@ -178,10 +179,10 @@ export function RecommandationDetailPublic({
             <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-creme">
               {detail.avg_rating !== null && (
                 <span className="text-[13px] tracking-[0.18em] uppercase">
-                  <span className="text-or">★</span> {detail.avg_rating}
+                  <span className="text-or">★</span> {formatRating(detail.avg_rating)}
                   <span className="text-creme/70">
                     {' · '}
-                    {detail.nb_copines} cop{detail.nb_copines > 1 ? 'ines' : 'ine'}
+                    {detail.nb_copines} {copineWord(detail.nb_copines)}
                   </span>
                 </span>
               )}

--- a/lib/reco-format.ts
+++ b/lib/reco-format.ts
@@ -1,0 +1,17 @@
+/**
+ * Formats PARTAGÉS de la note agrégée + du compte de copines.
+ *
+ * Une seule source de vérité de format → la fiche PUBLIQUE (anon) et la fiche
+ * CONNECTÉE affichent la note/prix de façon strictement identique (même valeur,
+ * même format). Pas de divergence d'affichage entre les deux rendus.
+ */
+
+/** Note moyenne en français, 1 décimale max, sans zéro superflu : 4,6 ; 5. */
+export function formatRating(n: number): string {
+  return n.toLocaleString('fr-FR', { maximumFractionDigits: 1 })
+}
+
+/** « copine » au singulier, « copines » au pluriel. */
+export function copineWord(n: number): string {
+  return n > 1 ? 'copines' : 'copine'
+}


### PR DESCRIPTION
## Résumé
- Le hero de `/recommandation/[slug]` affiche désormais **« ★ moyenne · N copine(s) · prix · type »** sur les **deux** rendus (public anonyme ET connecté), **au même endroit, même format, mêmes valeurs**.
- Avant : la fiche connectée n'avait pas la note/prix agrégés en hero (juste le titre) — elle était plus pauvre que l'anonyme. Corrigé.
- **Display-only** : zéro migration, zéro vue modifiée, zéro nouvelle donnée, zéro service-role.

## Parité garantie
La branche connectée lit les stats hero depuis la **même vue anon-safe** `place_public_detail` que le public (`heroRating = avg_rating`, `heroNbCopines = nb_copines`, `heroPriceMode = price_mode`). Donc valeurs **strictement identiques** à ce que voit un visiteur anonyme — pas de recalcul, pas de divergence d'arrondi.

## Détail
- `lib/reco-format.ts` *(nouveau)* : `formatRating` (fr-FR, « 4,6 » / « 5 » épuré) + `copineWord` (singulier/pluriel) — format partagé identique des deux côtés.
- `RecommandationDetail.tsx` *(connecté)* : ajoute la ligne note+prix+type sous le `<h1>`. **Additif pur** — `MemberName`, gamif, `FavoriteButton` (Sauvegarder), vidéos, galerie, similaires **inchangés**.
- `RecommandationDetailPublic.tsx` : applique `formatRating`/`copineWord` (virgule).
- `page.tsx` *(branche connectée)* : fetch `publicStats` en parallèle, passe les 3 props. Branche anonyme inchangée.

## Zéro régression
- Diff `RecommandationDetail.tsx` = **+36 / -0** (aucune suppression).
- Galerie photos lieu : déjà présente des deux côtés, **non touchée** (logique cover/galerie inchangée depuis PR1).
- `tsc --noEmit` propre.

## Rendus vérifiés (public preview)
- Chikin Bang : « ★ 4,5 · 2 copines · € · Korean Restaurant »
- Cas limites : « ★ 5 · 1 copine · €€ · spa » (rond épuré + singulier OK).

## Test plan
- [ ] Vérif visuelle **connectée** sur prod après deploy (hero note+prix identique à l'anon ; prénoms/gamif/Sauvegarder intacts) — fiche `chikin-bang-korean-street-food-part-dieu-a97a20`.
- [ ] Re-test anon prod (hero rendu + galerie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)