### PR TITLE
feat(reco): ajout/édition de reco depuis la fiche (PR-a, membres only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ parcours-utilisatrice.html
 hilmy-deploy.sh
 hilmy-fix.sh
 
+
+# Backups DB horodatés (données perso — JAMAIS committer)
+_hilmy_db_backups/
+supabase/.temp/

--- a/app/dashboard/utilisatrice/recommandations/nouvelle/page.tsx
+++ b/app/dashboard/utilisatrice/recommandations/nouvelle/page.tsx
@@ -1,23 +1,18 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'motion/react'
-import { toast } from 'sonner'
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader'
 import { GoldLine } from '@/components/ui/GoldLine'
 import {
   PlaceAutocomplete,
   type AutocompletePlace,
 } from '@/components/google/PlaceAutocomplete'
+import { RecoForm } from '@/components/v2/RecoForm'
 import { createClient } from '@/lib/supabase/client'
-import {
-  DIET_CATEGORIES,
-  DIET_TAGS_MAP,
-  PLACE_CATEGORIES_MAP,
-  REC_TAGS_MAP,
-} from '@/lib/constants'
+import { PLACE_CATEGORIES_MAP } from '@/lib/constants'
 
 type PlaceDetails = AutocompletePlace & {
   phone: string | null
@@ -27,8 +22,6 @@ type PlaceDetails = AutocompletePlace & {
 }
 
 const PLACE_CATS = Object.entries(PLACE_CATEGORIES_MAP) as [string, string][]
-const TAGS = Object.entries(REC_TAGS_MAP) as [string, string][]
-const DIETS = Object.entries(DIET_TAGS_MAP) as [string, string][]
 
 function slugify(s: string) {
   return s
@@ -60,22 +53,13 @@ function guessPlaceCategory(googleType: string | null): string {
 export default function RecommandationNouvellePage() {
   const router = useRouter()
   const supabase = createClient()
-  const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   const [userId, setUserId] = useState<string | null>(null)
   const [checking, setChecking] = useState(true)
-  const [submitting, setSubmitting] = useState(false)
-  const [uploading, setUploading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const [place, setPlace] = useState<PlaceDetails | null>(null)
   const [hilmyCategory, setHilmyCategory] = useState<string>('')
-  const [comment, setComment] = useState('')
-  const [rating, setRating] = useState<number>(0)
-  const [tags, setTags] = useState<string[]>([])
-  const [dietTags, setDietTags] = useState<string[]>([])
-  const [photos, setPhotos] = useState<string[]>([])
-  const [priceIndicator, setPriceIndicator] = useState('')
 
   useEffect(() => {
     const run = async () => {
@@ -110,50 +94,12 @@ export default function RecommandationNouvellePage() {
     }
   }
 
-  const toggleTag = (t: string) =>
-    setTags((cur) => (cur.includes(t) ? cur.filter((x) => x !== t) : [...cur, t]))
-
-  const toggleDiet = (t: string) =>
-    setDietTags((cur) => (cur.includes(t) ? cur.filter((x) => x !== t) : [...cur, t]))
-
-  const handlePhoto = async (file: File) => {
-    if (!userId) return
-    if (file.size > 5 * 1024 * 1024) {
-      setError('Chaque photo doit faire moins de 5 Mo.')
-      return
-    }
-    setUploading(true)
-    setError(null)
-    const ext = file.name.split('.').pop()?.toLowerCase() ?? 'jpg'
-    const path = `${userId}/${Date.now()}.${ext}`
-    const { error: upErr } = await supabase.storage
-      .from('recommendation-photos')
-      .upload(path, file, { cacheControl: '3600' })
-    if (upErr) {
-      setError(upErr.message)
-      setUploading(false)
-      return
-    }
-    const {
-      data: { publicUrl },
-    } = supabase.storage.from('recommendation-photos').getPublicUrl(path)
-    setPhotos((p) => [...p, publicUrl])
-    setUploading(false)
-  }
-
-  const submit = async () => {
-    if (!userId || !place) return
-    if (comment.trim().length < 50) {
-      setError('Ton commentaire doit faire au moins 50 caractères.')
-      return
-    }
-    setSubmitting(true)
-    setError(null)
-
-    // Upsert place
-    // URL stable servie par le proxy /api/places/photo — sans clé Google
-    // (cf. lib/google/places.ts placePhotoProxyUrl). Persistée telle quelle,
-    // lue directement par le web et l'app mobile. www canonique = pas de hop.
+  // Résout l'id du lieu pour RecoForm : upsert places depuis les détails Google.
+  // URL stable servie par le proxy /api/places/photo — sans clé Google
+  // (cf. lib/google/places.ts placePhotoProxyUrl). Persistée telle quelle,
+  // lue directement par le web et l'app mobile. www canonique = pas de hop.
+  const resolvePlaceId = async (): Promise<string | null> => {
+    if (!place) return null
     const photoProxyUrl = place.google_place_id
       ? `https://www.hilmy.io/api/places/photo?place_id=${encodeURIComponent(
           place.google_place_id,
@@ -200,54 +146,25 @@ export default function RecommandationNouvellePage() {
 
       if (insErr) {
         setError(`Impossible d'ajouter le lieu : ${insErr.message}`)
-        setSubmitting(false)
-        return
+        return null
       }
       placeId = inserted.id
     }
 
     if (!placeId) {
       setError('Lieu introuvable — réessaie.')
-      setSubmitting(false)
-      return
+      return null
     }
-
-    const mergedTags = DIET_CATEGORIES.has(hilmyCategory)
-      ? [...tags, ...dietTags]
-      : tags
-    const { error: recoErr } = await supabase.from('recommendations').insert({
-      user_id: userId,
-      type: 'place',
-      place_id: placeId,
-      comment: comment.trim(),
-      rating: rating || null,
-      tags: mergedTags.length ? mergedTags : null,
-      price_indicator: priceIndicator || null,
-      photo_urls: photos.length ? photos : null,
-      status: 'published',
-    })
-
-    setSubmitting(false)
-    if (recoErr) {
-      setError(recoErr.message)
-      return
-    }
-    // Toast voix Sara — gamification mig 16 award +10 pts via trigger
-    // SECURITY DEFINER, on est optimiste côté client (best-effort).
-    toast.success('+10 pts · Tu fais grandir Hilmy', { duration: 4000 })
-    router.push('/dashboard/utilisatrice/recommandations')
+    return placeId
   }
 
-  if (checking) {
+  if (checking || !userId) {
     return (
       <section className="flex min-h-[60vh] items-center justify-center">
         <div className="h-10 w-10 animate-spin rounded-full border-2 border-or border-t-transparent" />
       </section>
     )
   }
-
-  const canSubmit =
-    place && comment.trim().length >= 50 && comment.trim().length <= 800 && hilmyCategory
 
   return (
     <>
@@ -332,205 +249,23 @@ export default function RecommandationNouvellePage() {
           </AnimatePresence>
         </div>
 
-        {/* Step 2 : reco */}
-        {place && (
-          <motion.div
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="mt-10 rounded-sm border border-or/20 bg-blanc p-8 md:p-10"
-          >
-            <div className="mb-6 flex items-center gap-4">
-              <GoldLine width={40} />
-              <span className="overline text-or">02 · Ta recommandation</span>
-            </div>
-
-            <div className="space-y-6">
-              <div>
-                <span className="overline text-or">Ta note</span>
-                <div className="mt-2 flex gap-1">
-                  {[1, 2, 3, 4, 5].map((n) => (
-                    <button
-                      key={n}
-                      type="button"
-                      onClick={() => setRating((r) => (r === n ? 0 : n))}
-                      className={`text-3xl transition-colors ${
-                        n <= rating ? 'text-or' : 'text-or/20 hover:text-or/50'
-                      }`}
-                      aria-label={`${n} étoiles`}
-                    >
-                      ★
-                    </button>
-                  ))}
-                  <span className="ml-3 self-end text-[11px] italic text-texte-sec">
-                    {rating > 0 ? `${rating} / 5` : 'Facultatif'}
-                  </span>
-                </div>
-              </div>
-
-              <label className="block">
-                <span className="overline text-or">Ton commentaire</span>
-                <textarea
-                  rows={6}
-                  value={comment}
-                  onChange={(e) => setComment(e.target.value)}
-                  minLength={50}
-                  maxLength={800}
-                  placeholder="Pourquoi on y va, quand, avec qui, ce qu'on commande. Sois toi-même — c'est ça qu'on veut lire."
-                  className="mt-2 w-full resize-none rounded-sm border border-or/20 bg-creme-soft px-4 py-3 font-serif text-[15px] italic leading-[1.6] text-vert focus:border-or focus:outline-none"
-                />
-                <span className="mt-1 block text-right text-[11px] text-texte-sec">
-                  {comment.length} / min 50 · max 800
-                </span>
-              </label>
-
-              <div>
-                <span className="overline text-or">Contexte (optionnel)</span>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  {TAGS.map(([slug, label]) => {
-                    const on = tags.includes(slug)
-                    return (
-                      <button
-                        key={slug}
-                        type="button"
-                        onClick={() => toggleTag(slug)}
-                        className={`rounded-full border px-4 py-2 text-[11px] font-medium tracking-[0.18em] uppercase transition-all ${
-                          on
-                            ? 'border-vert bg-vert text-creme'
-                            : 'border-or/30 bg-blanc text-texte-sec hover:border-or'
-                        }`}
-                      >
-                        {label}
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
-
-              {DIET_CATEGORIES.has(hilmyCategory) && (
-                <div>
-                  <span className="overline text-or">Régime alimentaire (optionnel)</span>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {DIETS.map(([slug, label]) => {
-                      const on = dietTags.includes(slug)
-                      return (
-                        <button
-                          key={slug}
-                          type="button"
-                          onClick={() => toggleDiet(slug)}
-                          className={`rounded-full border px-4 py-2 text-[11px] font-medium tracking-[0.18em] uppercase transition-all ${
-                            on
-                              ? 'border-or bg-or text-vert'
-                              : 'border-or/30 bg-blanc text-texte-sec hover:border-or'
-                          }`}
-                        >
-                          {label}
-                        </button>
-                      )
-                    })}
-                  </div>
-                </div>
-              )}
-
-              <div>
-                <span className="overline text-or">Indicateur de prix (optionnel)</span>
-                <div className="mt-2 flex gap-2">
-                  {['€', '€€', '€€€'].map((p) => {
-                    const on = priceIndicator === p
-                    return (
-                      <button
-                        key={p}
-                        type="button"
-                        onClick={() => setPriceIndicator(on ? '' : p)}
-                        className={`rounded-full border px-5 py-2 font-serif text-lg transition-all ${
-                          on
-                            ? 'border-or bg-or text-vert'
-                            : 'border-or/30 bg-blanc text-texte-sec hover:border-or'
-                        }`}
-                      >
-                        {p}
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
-
-              <div>
-                <span className="overline text-or">Tes photos (optionnel)</span>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="image/*"
-                  className="hidden"
-                  onChange={(e) => {
-                    const f = e.target.files?.[0]
-                    if (f) handlePhoto(f)
-                    if (e.target) e.target.value = ''
-                  }}
-                />
-                <div className="mt-3 grid grid-cols-3 gap-3 md:grid-cols-6">
-                  {photos.map((url, i) => (
-                    <div
-                      key={url}
-                      className="group relative aspect-square overflow-hidden rounded-sm bg-creme-deep"
-                    >
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img src={url} alt="" className="h-full w-full object-cover" />
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setPhotos((p) => p.filter((u) => u !== url))
-                        }
-                        className="absolute top-1 right-1 rounded-full bg-blanc/90 px-2 py-0.5 text-[10px] text-red-900 opacity-0 transition-opacity group-hover:opacity-100"
-                      >
-                        ×
-                      </button>
-                      {i === 0 && (
-                        <span className="absolute bottom-1 left-1 rounded-full bg-or/90 px-2 py-0.5 text-[8px] tracking-[0.18em] text-vert uppercase">
-                          Couverture
-                        </span>
-                      )}
-                    </div>
-                  ))}
-                  <button
-                    type="button"
-                    onClick={() => fileInputRef.current?.click()}
-                    disabled={uploading || photos.length >= 6}
-                    className="flex aspect-square items-center justify-center rounded-sm border-2 border-dashed border-or/40 bg-creme-soft text-2xl text-or transition-colors hover:border-or hover:bg-blanc disabled:opacity-40"
-                  >
-                    {uploading ? '…' : '+'}
-                  </button>
-                </div>
-                <p className="mt-2 text-[11px] text-texte-sec">
-                  Jusqu&apos;à 6 photos, 5 Mo chacune.
-                </p>
-              </div>
-            </div>
-          </motion.div>
-        )}
-
-        {/* CTA */}
-        <div className="mt-10 flex flex-col items-end gap-3">
-          <button
-            type="button"
-            onClick={submit}
-            disabled={!canSubmit || submitting}
-            className="group inline-flex h-12 items-center gap-2.5 rounded-full bg-vert px-7 text-[12px] font-medium tracking-[0.2em] text-creme uppercase transition-all hover:bg-vert-dark disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {submitting ? 'Publication…' : 'Publier ma recommandation'}
-            <span
-              className="text-or-light transition-transform group-hover:translate-x-1"
-              aria-hidden="true"
+        {/* Step 2 + CTA : formulaire partagé */}
+        <RecoForm
+          userId={userId}
+          hilmyCategory={hilmyCategory}
+          placeReady={place !== null}
+          resolvePlaceId={resolvePlaceId}
+          onError={setError}
+          onSuccess={() => router.push('/dashboard/utilisatrice/recommandations')}
+          footer={
+            <Link
+              href="/dashboard/utilisatrice/recommandations"
+              className="text-[12px] text-texte-sec hover:text-or"
             >
-              →
-            </span>
-          </button>
-          <Link
-            href="/dashboard/utilisatrice/recommandations"
-            className="text-[12px] text-texte-sec hover:text-or"
-          >
-            ← Retour à mes recommandations
-          </Link>
-        </div>
+              ← Retour à mes recommandations
+            </Link>
+          }
+        />
       </section>
     </>
   )

--- a/app/recommandation/[slug]/page.tsx
+++ b/app/recommandation/[slug]/page.tsx
@@ -5,6 +5,7 @@ import {
   type RecoView,
   type VideoEntry,
 } from '@/components/v2/RecommandationDetail'
+import type { ExistingReco } from '@/components/v2/RecoForm'
 import { RecommandationDetailPublic } from '@/components/v2/RecommandationDetailPublic'
 import type { Lieu as MockLieu } from '@/lib/mock-data'
 import {
@@ -230,6 +231,18 @@ export default async function RecommandationPage({
 
   const publicStats = await publicStatsPromise
 
+  // PR-a — SA reco existante sur ce lieu (le cas échéant) → édition vs ajout
+  // depuis la fiche. Filtre identique au verrou RLS (user_id = auth.uid()) ;
+  // .maybeSingle() car au plus une reco place par copine attendue côté produit.
+  const { data: myRecoRow } = await supabase
+    .from('recommendations')
+    .select('id, comment, rating, tags, price_indicator, photo_urls')
+    .eq('user_id', user.id)
+    .eq('place_id', row.id)
+    .eq('type', 'place')
+    .maybeSingle()
+  const myReco: ExistingReco | null = myRecoRow ?? null
+
   return (
     <RecommandationDetail
       l={l}
@@ -240,6 +253,8 @@ export default async function RecommandationPage({
       heroRating={publicStats?.avg_rating ?? null}
       heroNbCopines={publicStats?.nb_copines ?? 0}
       heroPriceMode={publicStats?.price_mode ?? null}
+      currentUserId={user.id}
+      myReco={myReco}
     />
   )
 }

--- a/components/v2/AddRecoModal.tsx
+++ b/components/v2/AddRecoModal.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { AnimatePresence, motion } from 'motion/react'
+import { RecoForm, type ExistingReco } from '@/components/v2/RecoForm'
+
+/**
+ * Client island posé sur la fiche /recommandation/[slug] (rendu CONNECTÉ
+ * uniquement — le composant n'existe pas dans le rendu anonyme, donc invisible
+ * aux non-membres par construction, pas par condition).
+ *
+ * Bouton « Ajouter ma reco » → modale réutilisant RecoForm, lieu déjà connu
+ * (resolvePlaceId renvoie directement placeId, aucun appel Google).
+ * Si `existingReco` est fourni : bouton « Modifier ma reco » + modale préremplie
+ * → UPDATE owner-only (verrou RLS user_id = auth.uid()).
+ *
+ * Au succès : fermeture + router.refresh() pour re-render server → la reco
+ * apparaît dans « Ce qu'on en dit » sans rechargement manuel.
+ */
+export function AddRecoModal({
+  userId,
+  placeId,
+  placeName,
+  hilmyCategory,
+  existingReco = null,
+}: {
+  userId: string
+  placeId: string
+  placeName: string
+  hilmyCategory: string
+  existingReco?: ExistingReco | null
+}) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const isEdit = existingReco !== null
+
+  const close = () => {
+    setOpen(false)
+    setError(null)
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-full bg-vert text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+      >
+        {isEdit ? 'Modifier ma reco' : 'Ajouter ma reco'}
+        <span className="text-or-light" aria-hidden="true">
+          →
+        </span>
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-[100] flex items-start justify-center overflow-y-auto bg-vert/40 p-4 backdrop-blur-sm md:p-8"
+            onClick={close}
+            role="dialog"
+            aria-modal="true"
+            aria-label={isEdit ? 'Modifier ma recommandation' : 'Ajouter ma recommandation'}
+          >
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 16 }}
+              onClick={(e) => e.stopPropagation()}
+              className="my-auto w-full max-w-2xl rounded-sm border border-or/20 bg-creme-soft p-6 shadow-xl md:p-8"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="overline text-or">
+                    {isEdit ? 'Modifier ma reco' : 'Recommander ce lieu'}
+                  </p>
+                  <p className="mt-2 font-serif text-2xl font-light text-vert">
+                    {placeName}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={close}
+                  aria-label="Fermer"
+                  className="shrink-0 rounded-full border border-or/30 px-3 py-1 text-[18px] leading-none text-vert transition-colors hover:border-or hover:bg-blanc"
+                >
+                  ×
+                </button>
+              </div>
+
+              {error && (
+                <div className="mt-5 rounded-sm border border-red-900/20 bg-red-900/5 px-4 py-3 text-[13px] text-red-900">
+                  {error}
+                </div>
+              )}
+
+              <RecoForm
+                userId={userId}
+                hilmyCategory={hilmyCategory}
+                placeReady
+                resolvePlaceId={async () => placeId}
+                existingReco={existingReco}
+                onError={setError}
+                onSuccess={() => {
+                  close()
+                  router.refresh()
+                }}
+                footer={
+                  <button
+                    type="button"
+                    onClick={close}
+                    className="text-[12px] text-texte-sec hover:text-or"
+                  >
+                    Annuler
+                  </button>
+                }
+              />
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  )
+}

--- a/components/v2/RecoForm.tsx
+++ b/components/v2/RecoForm.tsx
@@ -1,0 +1,417 @@
+'use client'
+
+import { useRef, useState, type ReactNode } from 'react'
+import { motion } from 'motion/react'
+import { toast } from 'sonner'
+import { GoldLine } from '@/components/ui/GoldLine'
+import { createClient } from '@/lib/supabase/client'
+import { DIET_CATEGORIES, DIET_TAGS_MAP, REC_TAGS_MAP } from '@/lib/constants'
+
+const TAGS = Object.entries(REC_TAGS_MAP) as [string, string][]
+const DIETS = Object.entries(DIET_TAGS_MAP) as [string, string][]
+
+/** Reco existante à éditer (préremplissage + UPDATE par id). */
+export type ExistingReco = {
+  id: string
+  comment: string | null
+  rating: number | null
+  tags: string[] | null
+  price_indicator: string | null
+  photo_urls: string[] | null
+}
+
+/**
+ * Champs partagés d'une recommandation (note, commentaire, tags, régimes, prix,
+ * photos) + soumission de la ligne `recommendations`. Extrait de la page
+ * /dashboard/utilisatrice/recommandations/nouvelle pour être réutilisé tel quel
+ * dans la modale d'ajout depuis une fiche (composant client island).
+ *
+ * Le lieu est résolu par le parent via `resolvePlaceId` : la page fait son
+ * upsert Google ; la modale renvoie simplement l'id du lieu déjà en base. Une
+ * seule source de vérité pour la validation, l'upload photo et l'insert/update.
+ *
+ * Édition : si `existingReco` est fourni, le formulaire prérempli et la
+ * soumission fait un UPDATE ciblé sur `id`. Le verrou owner-only est garanti
+ * par la RLS UPDATE de `recommendations` (using/with check user_id = auth.uid()),
+ * pas seulement par l'UI.
+ */
+export function RecoForm({
+  userId,
+  hilmyCategory,
+  placeReady,
+  resolvePlaceId,
+  existingReco = null,
+  onError,
+  onSuccess,
+  footer,
+}: {
+  userId: string
+  hilmyCategory: string
+  placeReady: boolean
+  resolvePlaceId: () => Promise<string | null>
+  existingReco?: ExistingReco | null
+  onError: (msg: string | null) => void
+  onSuccess: () => void
+  footer?: ReactNode
+}) {
+  const supabase = createClient()
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  const isEdit = existingReco !== null
+  const initialTags = (existingReco?.tags ?? []).filter((t) => !(t in DIET_TAGS_MAP))
+  const initialDiets = (existingReco?.tags ?? []).filter((t) => t in DIET_TAGS_MAP)
+
+  const [submitting, setSubmitting] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const [comment, setComment] = useState(existingReco?.comment ?? '')
+  const [rating, setRating] = useState<number>(existingReco?.rating ?? 0)
+  const [tags, setTags] = useState<string[]>(initialTags)
+  const [dietTags, setDietTags] = useState<string[]>(initialDiets)
+  const [photos, setPhotos] = useState<string[]>(existingReco?.photo_urls ?? [])
+  const [priceIndicator, setPriceIndicator] = useState(existingReco?.price_indicator ?? '')
+  // Consentement frais demandé à CHAQUE enregistrement (jamais pré-coché, même
+  // en édition) → preuve éclairée renouvelée. Bloquant uniquement si des photos
+  // sont attachées (la certification porte sur les photos).
+  const [consent, setConsent] = useState(false)
+  const needsConsent = photos.length > 0
+
+  const toggleTag = (t: string) =>
+    setTags((cur) => (cur.includes(t) ? cur.filter((x) => x !== t) : [...cur, t]))
+
+  const toggleDiet = (t: string) =>
+    setDietTags((cur) => (cur.includes(t) ? cur.filter((x) => x !== t) : [...cur, t]))
+
+  const handlePhoto = async (file: File) => {
+    if (file.size > 5 * 1024 * 1024) {
+      onError('Chaque photo doit faire moins de 5 Mo.')
+      return
+    }
+    setUploading(true)
+    onError(null)
+    const ext = file.name.split('.').pop()?.toLowerCase() ?? 'jpg'
+    const path = `${userId}/${Date.now()}.${ext}`
+    const { error: upErr } = await supabase.storage
+      .from('recommendation-photos')
+      .upload(path, file, { cacheControl: '3600' })
+    if (upErr) {
+      onError(upErr.message)
+      setUploading(false)
+      return
+    }
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from('recommendation-photos').getPublicUrl(path)
+    setPhotos((p) => [...p, publicUrl])
+    setUploading(false)
+  }
+
+  const submit = async () => {
+    if (comment.trim().length < 50) {
+      onError('Ton commentaire doit faire au moins 50 caractères.')
+      return
+    }
+    if (needsConsent && !consent) {
+      onError('Tu dois cocher la case pour valider ta photo — sans ça, on ne peut pas la publier.')
+      return
+    }
+    setSubmitting(true)
+    onError(null)
+
+    const mergedTags = DIET_CATEGORIES.has(hilmyCategory)
+      ? [...tags, ...dietTags]
+      : tags
+    // Horodaté seulement si des photos sont présentes ET la case cochée.
+    // Pas de photos → null (rien à certifier).
+    const photoConsentAt = needsConsent && consent ? new Date().toISOString() : null
+
+    if (isEdit && existingReco) {
+      // UPDATE ciblé sur SA reco — la RLS (user_id = auth.uid()) verrouille.
+      const { error: updErr } = await supabase
+        .from('recommendations')
+        .update({
+          comment: comment.trim(),
+          rating: rating || null,
+          tags: mergedTags.length ? mergedTags : null,
+          price_indicator: priceIndicator || null,
+          photo_urls: photos.length ? photos : null,
+          photo_consent_at: photoConsentAt,
+        })
+        .eq('id', existingReco.id)
+      setSubmitting(false)
+      if (updErr) {
+        onError(updErr.message)
+        return
+      }
+      toast.success('Reco mise à jour', { duration: 4000 })
+      onSuccess()
+      return
+    }
+
+    const placeId = await resolvePlaceId()
+    if (!placeId) {
+      // resolvePlaceId a déjà signalé l'erreur via onError.
+      setSubmitting(false)
+      return
+    }
+
+    const { error: recoErr } = await supabase.from('recommendations').insert({
+      user_id: userId,
+      type: 'place',
+      place_id: placeId,
+      comment: comment.trim(),
+      rating: rating || null,
+      tags: mergedTags.length ? mergedTags : null,
+      price_indicator: priceIndicator || null,
+      photo_urls: photos.length ? photos : null,
+      photo_consent_at: photoConsentAt,
+      status: 'published',
+    })
+
+    setSubmitting(false)
+    if (recoErr) {
+      onError(recoErr.message)
+      return
+    }
+    // Toast voix Sara — gamification mig 16 award +10 pts via trigger
+    // SECURITY DEFINER, on est optimiste côté client (best-effort).
+    toast.success('+10 pts · Tu fais grandir Hilmy', { duration: 4000 })
+    onSuccess()
+  }
+
+  // NB : le consentement n'est volontairement PAS dans canSubmit. Si une photo
+  // est présente sans la coche, le bouton reste CLIQUABLE → submit() lève un
+  // message explicite (« Tu dois cocher… »), pour qu'elle comprenne POURQUOI,
+  // plutôt qu'un bouton grisé muet.
+  const canSubmit =
+    placeReady &&
+    comment.trim().length >= 50 &&
+    comment.trim().length <= 800 &&
+    !!hilmyCategory
+
+  return (
+    <>
+      {placeReady && (
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mt-10 rounded-sm border border-or/20 bg-blanc p-8 md:p-10"
+        >
+          <div className="mb-6 flex items-center gap-4">
+            <GoldLine width={40} />
+            <span className="overline text-or">02 · Ta recommandation</span>
+          </div>
+
+          <div className="space-y-6">
+            <div>
+              <span className="overline text-or">Ta note</span>
+              <div className="mt-2 flex gap-1">
+                {[1, 2, 3, 4, 5].map((n) => (
+                  <button
+                    key={n}
+                    type="button"
+                    onClick={() => setRating((r) => (r === n ? 0 : n))}
+                    className={`text-3xl transition-colors ${
+                      n <= rating ? 'text-or' : 'text-or/20 hover:text-or/50'
+                    }`}
+                    aria-label={`${n} étoiles`}
+                  >
+                    ★
+                  </button>
+                ))}
+                <span className="ml-3 self-end text-[11px] italic text-texte-sec">
+                  {rating > 0 ? `${rating} / 5` : 'Facultatif'}
+                </span>
+              </div>
+            </div>
+
+            <label className="block">
+              <span className="overline text-or">Ton commentaire</span>
+              <textarea
+                rows={6}
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                minLength={50}
+                maxLength={800}
+                placeholder="Pourquoi on y va, quand, avec qui, ce qu'on commande. Sois toi-même — c'est ça qu'on veut lire."
+                className="mt-2 w-full resize-none rounded-sm border border-or/20 bg-creme-soft px-4 py-3 font-serif text-[15px] italic leading-[1.6] text-vert focus:border-or focus:outline-none"
+              />
+              <span className="mt-1 block text-right text-[11px] text-texte-sec">
+                {comment.length} / min 50 · max 800
+              </span>
+            </label>
+
+            <div>
+              <span className="overline text-or">Contexte (optionnel)</span>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {TAGS.map(([slug, label]) => {
+                  const on = tags.includes(slug)
+                  return (
+                    <button
+                      key={slug}
+                      type="button"
+                      onClick={() => toggleTag(slug)}
+                      className={`rounded-full border px-4 py-2 text-[11px] font-medium tracking-[0.18em] uppercase transition-all ${
+                        on
+                          ? 'border-vert bg-vert text-creme'
+                          : 'border-or/30 bg-blanc text-texte-sec hover:border-or'
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+
+            {DIET_CATEGORIES.has(hilmyCategory) && (
+              <div>
+                <span className="overline text-or">Régime alimentaire (optionnel)</span>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {DIETS.map(([slug, label]) => {
+                    const on = dietTags.includes(slug)
+                    return (
+                      <button
+                        key={slug}
+                        type="button"
+                        onClick={() => toggleDiet(slug)}
+                        className={`rounded-full border px-4 py-2 text-[11px] font-medium tracking-[0.18em] uppercase transition-all ${
+                          on
+                            ? 'border-or bg-or text-vert'
+                            : 'border-or/30 bg-blanc text-texte-sec hover:border-or'
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            <div>
+              <span className="overline text-or">Indicateur de prix (optionnel)</span>
+              <div className="mt-2 flex gap-2">
+                {['€', '€€', '€€€'].map((p) => {
+                  const on = priceIndicator === p
+                  return (
+                    <button
+                      key={p}
+                      type="button"
+                      onClick={() => setPriceIndicator(on ? '' : p)}
+                      className={`rounded-full border px-5 py-2 font-serif text-lg transition-all ${
+                        on
+                          ? 'border-or bg-or text-vert'
+                          : 'border-or/30 bg-blanc text-texte-sec hover:border-or'
+                      }`}
+                    >
+                      {p}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+
+            <div>
+              <span className="overline text-or">Tes photos (optionnel)</span>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(e) => {
+                  const f = e.target.files?.[0]
+                  if (f) handlePhoto(f)
+                  if (e.target) e.target.value = ''
+                }}
+              />
+              <div className="mt-3 grid grid-cols-3 gap-3 md:grid-cols-6">
+                {photos.map((url, i) => (
+                  <div
+                    key={url}
+                    className="group relative aspect-square overflow-hidden rounded-sm bg-creme-deep"
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img src={url} alt="" className="h-full w-full object-cover" />
+                    <button
+                      type="button"
+                      onClick={() => setPhotos((p) => p.filter((u) => u !== url))}
+                      className="absolute top-1 right-1 rounded-full bg-blanc/90 px-2 py-0.5 text-[10px] text-red-900 opacity-0 transition-opacity group-hover:opacity-100"
+                    >
+                      ×
+                    </button>
+                    {i === 0 && (
+                      <span className="absolute bottom-1 left-1 rounded-full bg-or/90 px-2 py-0.5 text-[8px] tracking-[0.18em] text-vert uppercase">
+                        Couverture
+                      </span>
+                    )}
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={uploading || photos.length >= 6}
+                  className="flex aspect-square items-center justify-center rounded-sm border-2 border-dashed border-or/40 bg-creme-soft text-2xl text-or transition-colors hover:border-or hover:bg-blanc disabled:opacity-40"
+                >
+                  {uploading ? '…' : '+'}
+                </button>
+              </div>
+              <p className="mt-2 text-[11px] text-texte-sec">
+                Jusqu&apos;à 6 photos, 5 Mo chacune.
+              </p>
+            </div>
+
+            {needsConsent && (
+              <div className="rounded-sm border border-or/25 bg-creme-soft p-4">
+                <label className="flex cursor-pointer items-start gap-3">
+                  <input
+                    type="checkbox"
+                    checked={consent}
+                    onChange={(e) => setConsent(e.target.checked)}
+                    className="mt-0.5 h-4 w-4 shrink-0 accent-vert"
+                  />
+                  <span className="text-[13px] leading-[1.55] text-vert">
+                    Je certifie avoir le droit de publier ces photos et qu&apos;aucune
+                    personne identifiable n&apos;y figure sans son accord.
+                  </span>
+                </label>
+                <p className="mt-2 pl-7 text-[12px] font-medium leading-[1.5] text-vert">
+                  Coche cette case pour que ta photo soit publiée. Sans la coche,
+                  elle n&apos;est pas validée — on ne la met pas en ligne.
+                </p>
+                <p className="mt-2 pl-7 text-[11px] leading-[1.5] text-texte-sec">
+                  Tu restes responsable des images que tu partages. Une photo
+                  pourra être retirée sur signalement. Pas de visage de tiers ni
+                  d&apos;enfant sans le consentement des personnes concernées.
+                </p>
+              </div>
+            )}
+          </div>
+        </motion.div>
+      )}
+
+      <div className="mt-10 flex flex-col items-end gap-3">
+        <button
+          type="button"
+          onClick={submit}
+          disabled={!canSubmit || submitting}
+          className="group inline-flex h-12 items-center gap-2.5 rounded-full bg-vert px-7 text-[12px] font-medium tracking-[0.2em] text-creme uppercase transition-all hover:bg-vert-dark disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitting
+            ? isEdit
+              ? 'Enregistrement…'
+              : 'Publication…'
+            : isEdit
+              ? 'Enregistrer les modifications'
+              : 'Publier ma recommandation'}
+          <span
+            className="text-or-light transition-transform group-hover:translate-x-1"
+            aria-hidden="true"
+          >
+            →
+          </span>
+        </button>
+        {footer}
+      </div>
+    </>
+  )
+}

--- a/components/v2/RecommandationDetail.tsx
+++ b/components/v2/RecommandationDetail.tsx
@@ -8,6 +8,8 @@ import { GoldLine } from '@/components/ui/GoldLine'
 import { FadeInSection } from '@/components/ui/FadeInSection'
 import { LieuCard } from '@/components/v2/LieuCard'
 import { VideoPlayer } from '@/components/v2/VideoPlayer'
+import { AddRecoModal } from '@/components/v2/AddRecoModal'
+import type { ExistingReco } from '@/components/v2/RecoForm'
 import { categoriesLieux, type Lieu as MockLieu } from '@/lib/mock-data'
 import { isSelectionHilmy } from '@/lib/permissions-lieux'
 import { formatRating, copineWord } from '@/lib/reco-format'
@@ -55,6 +57,8 @@ export function RecommandationDetail({
   heroRating,
   heroNbCopines,
   heroPriceMode,
+  currentUserId,
+  myReco,
 }: {
   l: MockLieu
   row: Place
@@ -66,6 +70,10 @@ export function RecommandationDetail({
   heroRating: number | null
   heroNbCopines: number
   heroPriceMode: string | null
+  // Membre connectée (PR-a) : id pour l'ajout, + SA reco existante sur ce lieu
+  // (null si aucune) → bouton « Ajouter » vs « Modifier ma reco ».
+  currentUserId: string
+  myReco: ExistingReco | null
 }) {
   // Photos réelles (http) du lieu. La 1re sert de cover (background hero) ;
   // les suivantes alimentent la galerie « Le lieu en images ». Les entrées
@@ -404,6 +412,13 @@ export function RecommandationDetail({
                   </span>
                 </PlaceContactLink>
                 <div className="mt-3 flex flex-col gap-3">
+                  <AddRecoModal
+                    userId={currentUserId}
+                    placeId={row.id}
+                    placeName={l.nom}
+                    hilmyCategory={l.categorie}
+                    existingReco={myReco}
+                  />
                   <FavoriteButton
                     itemType="lieu"
                     itemId={row.id}

--- a/supabase/migrations/65_recommendations_photo_consent.sql
+++ b/supabase/migrations/65_recommendations_photo_consent.sql
@@ -1,0 +1,24 @@
+-- =====================================================================
+-- HILMY · 65 — Traçabilité du consentement photos sur les recommandations.
+-- ---------------------------------------------------------------------
+-- Contexte (PR-a « ajout reco depuis la fiche ») : dès qu'une copine
+-- attache des photos à sa reco, on lui demande de certifier qu'elle a le
+-- droit de les publier et qu'aucune personne identifiable n'y figure sans
+-- son accord (case bloquante côté UI). On HORODATE ce consentement ici.
+--
+-- Pourquoi dès PR-a alors que les photos ne sont PAS encore publiques
+-- (l'affichage public = PR-c) : on veut une preuve de consentement éclairé
+-- tracée dès la saisie, pas rétroactivement. Enjeu RGPD/nLPD.
+--
+-- Additif et sûr : colonne nullable, aucune valeur par défaut, aucune
+-- réécriture de ligne existante. Les recos déjà en base restent à NULL
+-- (consentement non collecté à l'époque — distinction nette). Aucune RLS
+-- touchée : l'écriture passe par les policies INSERT/UPDATE owner-only
+-- existantes (user_id = auth.uid()).
+-- =====================================================================
+
+alter table public.recommendations
+  add column if not exists photo_consent_at timestamptz;
+
+comment on column public.recommendations.photo_consent_at is
+  'Horodatage du consentement photos (certif. droit de publication + absence de tiers identifiable sans accord). NULL = non collecté. Renseigné par RecoForm uniquement quand des photos sont attachées.';

--- a/supabase/migrations/65_recommendations_photo_consent_rollback.sql
+++ b/supabase/migrations/65_recommendations_photo_consent_rollback.sql
@@ -1,0 +1,8 @@
+-- =====================================================================
+-- HILMY · 65 ROLLBACK — retire la colonne de consentement photos.
+-- Additif inverse : drop pur de la colonne. À ne lancer que si le code
+-- qui écrit photo_consent_at n'est plus déployé (sinon l'écriture casse).
+-- =====================================================================
+
+alter table public.recommendations
+  drop column if exists photo_consent_at;


### PR DESCRIPTION
## Volet 3 de l'audit — PR-a (ajout/édition reco depuis la fiche, membres only)

Permet à une copine **connectée** d'ajouter ou d'éditer SA reco directement depuis `/recommandation/[slug]`, sans passer par `/dashboard/.../nouvelle`.

### Ce que fait cette PR
- **Bouton « Ajouter ma reco » / « Modifier ma reco »** dans la sidebar de la fiche **connectée** (`RecommandationDetail`). Invisible aux anonymes **par construction** (ils reçoivent `RecommandationDetailPublic`, qui ne contient pas le composant).
- **Modale** réutilisant un **formulaire partagé** (`RecoForm`), lieu pré-rempli (aucun appel Google Autocomplete).
- **Édition owner-only** : `UPDATE … .eq('id', …)` verrouillé par la RLS existante « Update own recommendations » (`USING/WITH CHECK auth.uid() = user_id`, mig 10). Détection de SA reco côté serveur avec `.eq('user_id', user.id)`. Double défense.
- **Consentement photos** (mig 65, colonne `photo_consent_at` nullable additive) : case **bloquante** uniquement si photos attachées, jamais pré-cochée (consentement frais à chaque enregistrement), **texte explicatif permanent** + **message d'erreur explicite au clic** + mention légale.

### Zéro régression / zéro fuite
- `RecoForm` extrait **par déplacement** depuis `/recommandations/nouvelle` (−294/+29 sur cette page, code transposé, comportement create identique : seuils 50/800, toast « +10 pts », redirect).
- **Aucune photo ne devient publique** : `place_public_recos` non touchée (exclut toujours `photo_urls`). Robinet public = PR-c.
- Rendu **anonyme** et hero PR1/PR2 inchangés. Build `next build` vert.

### Migration
- `65_recommendations_photo_consent.sql` — `ADD COLUMN photo_consent_at timestamptz` (nullable, additif). **Déjà appliquée en prod** (view-first, backup horodaté préalable), dry-run `BEGIN/ROLLBACK` validé.

### Recette de test (connectée, post-deploy)
1. Ajout depuis une fiche non recommandée → modale → publier → apparaît sans recharger.
2. Photo → case apparaît → publier sans cocher = message d'erreur explicite → cocher → OK.
3. Édition d'une fiche déjà recommandée → « Modifier ma reco » → pré-rempli → enregistrer.
4. `/recommandations/nouvelle` intacte.
5. Anonyme : aucun bouton, aucune photo de reco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)