### PR TITLE
feat(photos): table place_user_photos + modération a posteriori (PR-b)

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -21,7 +21,7 @@ export default async function AdminLayout({
   //   'published' OR owner)
   // → service_role pour avoir les vrais chiffres. Safe parce que
   // l'accès à ce layout est déjà gaté par le notFound() ci-dessus.
-  const [prestaCount, eventCount, recoCount, reportCount, jeChercheSignalementsCount, pendingPerksCount] = await Promise.all([
+  const [prestaCount, eventCount, recoCount, photoCount, reportCount, jeChercheSignalementsCount, pendingPerksCount] = await Promise.all([
     admin
       .from('profiles')
       .select('id', { count: 'exact', head: true })
@@ -32,6 +32,11 @@ export default async function AdminLayout({
       .eq('status', 'flagged'),
     admin
       .from('recommendations')
+      .select('id', { count: 'exact', head: true })
+      .eq('status', 'flagged'),
+    // PR-b : photos de lieux signalées en attente de modération.
+    admin
+      .from('place_user_photos')
       .select('id', { count: 'exact', head: true })
       .eq('status', 'flagged'),
     admin
@@ -64,6 +69,11 @@ export default async function AdminLayout({
       href: '/admin/recommandations-a-moderer',
       label: 'Recommandations',
       badge: recoCount.count ?? 0,
+    },
+    {
+      href: '/admin/photos-a-moderer',
+      label: 'Photos de lieux',
+      badge: photoCount.count ?? 0,
     },
     {
       href: '/admin/signalements',

--- a/app/admin/photos-a-moderer/page.tsx
+++ b/app/admin/photos-a-moderer/page.tsx
@@ -1,0 +1,127 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+import { PhotoRow } from './photoRowClient'
+
+type Status = 'published' | 'flagged' | 'removed'
+
+type PhotoRecord = {
+  id: string
+  user_id: string
+  status: string
+  storage_path: string
+  moderation_motif: string | null
+  created_at: string
+  place: { name: string; slug: string | null } | { name: string; slug: string | null }[] | null
+}
+
+export default async function PhotosAModererPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: Status }>
+}) {
+  const { status = 'flagged' } = await searchParams
+  // Protection auth assurée par app/admin/layout.tsx. service_role pour
+  // bypass la RLS SELECT (connecté-only en PR-b ; ici on voit tous statuts).
+  const supabase = createAdminClient()
+
+  // NB : pas d'embed user_profiles ici. place_user_photos.user_id pointe sur
+  // auth.users (pas de FK vers user_profiles) → PostgREST ne sait pas résoudre
+  // l'embed. On récupère les prénoms dans une requête séparée (même pattern que
+  // la fiche /recommandation/[slug]).
+  const { data, error } = await supabase
+    .from('place_user_photos')
+    .select(
+      `id, user_id, status, storage_path, moderation_motif, created_at, place:places ( name, slug )`,
+    )
+    .eq('status', status)
+    .order('created_at', { ascending: false })
+    .limit(100)
+
+  const rows = (data ?? []) as PhotoRecord[]
+
+  // Prénoms des autrices, en batch.
+  const userIds = Array.from(new Set(rows.map((r) => r.user_id)))
+  const prenomById = new Map<string, string>()
+  if (userIds.length > 0) {
+    const { data: profs } = await supabase
+      .from('user_profiles')
+      .select('user_id, prenom')
+      .in('user_id', userIds)
+    for (const p of (profs ?? []) as Array<{ user_id: string; prenom: string }>) {
+      prenomById.set(p.user_id, p.prenom)
+    }
+  }
+
+  // URL publique calculée côté serveur depuis le storage_path (path SANS user_id).
+  const photos = rows.map((r) => ({
+    id: r.id,
+    status: r.status,
+    moderation_motif: r.moderation_motif,
+    created_at: r.created_at,
+    place: Array.isArray(r.place) ? (r.place[0] ?? null) : r.place,
+    prenom: prenomById.get(r.user_id) ?? 'Une copine',
+    url: supabase.storage.from('recommendation-photos').getPublicUrl(r.storage_path).data
+      .publicUrl,
+  }))
+
+  return (
+    <section className="px-6 py-10 md:px-12 md:py-14">
+      <header className="border-b border-or/15 pb-6">
+        <p className="overline text-or">Modération · photos de lieux</p>
+        <h1 className="mt-3 font-serif text-3xl font-light text-vert md:text-4xl">
+          {status === 'flagged' && 'Photos signalées.'}
+          {status === 'published' && 'Toutes les photos.'}
+          {status === 'removed' && 'Photos retirées.'}
+        </h1>
+      </header>
+
+      <nav className="mt-6 flex flex-wrap gap-2">
+        {(
+          [
+            { key: 'flagged', label: 'Signalées' },
+            { key: 'published', label: 'Publiées' },
+            { key: 'removed', label: 'Retirées' },
+          ] as const
+        ).map((t) => {
+          const active = status === t.key
+          return (
+            <a
+              key={t.key}
+              href={`?status=${t.key}`}
+              className={`inline-flex items-center rounded-full px-4 py-2 text-[11px] font-medium tracking-[0.22em] uppercase transition-colors ${
+                active
+                  ? 'bg-vert text-creme'
+                  : 'bg-blanc text-texte-sec hover:bg-creme-deep hover:text-vert'
+              }`}
+            >
+              {t.label}
+            </a>
+          )
+        })}
+      </nav>
+
+      {error && (
+        <p className="mt-6 rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[13px] text-red-900">
+          {error.message}
+        </p>
+      )}
+
+      <div className="mt-8">
+        {photos.length === 0 ? (
+          <div className="rounded-sm border border-or/15 bg-blanc p-10 text-center">
+            <p className="font-serif text-xl italic text-vert">
+              {status === 'flagged'
+                ? 'Rien à modérer — la communauté est sage.'
+                : 'Aucune photo dans cette file.'}
+            </p>
+          </div>
+        ) : (
+          <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {photos.map((p) => (
+              <PhotoRow key={p.id} photo={p} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/app/admin/photos-a-moderer/photoRowClient.tsx
+++ b/app/admin/photos-a-moderer/photoRowClient.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { MotifModal } from '@/components/v2/MotifModal'
+
+type Photo = {
+  id: string
+  status: string
+  moderation_motif: string | null
+  created_at: string
+  url: string
+  prenom: string
+  place: { name: string; slug: string | null } | null
+}
+
+export function PhotoRow({ photo }: { photo: Photo }) {
+  const router = useRouter()
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [removeOpen, setRemoveOpen] = useState(false)
+  const [removeError, setRemoveError] = useState<string | null>(null)
+
+  const placeName = photo.place?.name ?? 'Lieu inconnu'
+  const placeLink = photo.place?.slug ? `/recommandation/${photo.place.slug}` : null
+
+  const setStatus = async (next: 'flagged' | 'published') => {
+    setBusy(next)
+    setError(null)
+    const res = await fetch(`/api/admin/place-photos/${photo.id}/status`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: next }),
+    })
+    const body = await res.json().catch(() => ({}))
+    setBusy(null)
+    if (!res.ok) {
+      setError(body.error ?? 'Erreur inconnue')
+      return
+    }
+    router.refresh()
+  }
+
+  const confirmRemove = async (motif: string) => {
+    setBusy('removed')
+    setRemoveError(null)
+    const res = await fetch(`/api/admin/place-photos/${photo.id}/remove`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ motif }),
+    })
+    const body = await res.json().catch(() => ({}))
+    setBusy(null)
+    if (!res.ok) {
+      setRemoveError(body.error ?? 'Erreur inconnue')
+      return
+    }
+    setRemoveOpen(false)
+    router.refresh()
+  }
+
+  return (
+    <li className="overflow-hidden rounded-sm border border-or/20 bg-blanc">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={photo.url}
+        alt={`Photo de ${placeName}`}
+        className="aspect-[4/3] w-full object-cover"
+      />
+      <div className="p-4">
+        <div className="flex flex-wrap items-baseline gap-2">
+          <p className="font-serif text-lg font-light text-vert">{placeName}</p>
+          <span className="text-[11px] text-texte-sec">
+            par {photo.prenom} ·{' '}
+            {new Date(photo.created_at).toLocaleDateString('fr-FR', {
+              day: 'numeric',
+              month: 'short',
+            })}
+          </span>
+        </div>
+
+        {photo.moderation_motif && photo.status === 'removed' && (
+          <div className="mt-3 rounded-sm border border-red-900/20 bg-red-900/5 p-3">
+            <p className="overline text-red-900">Motif de retrait</p>
+            <p className="mt-1 text-[12px] italic text-texte">« {photo.moderation_motif} »</p>
+          </div>
+        )}
+
+        <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-or/10 pt-4">
+          {placeLink && (
+            <a
+              href={placeLink}
+              target="_blank"
+              rel="noopener"
+              className="text-[11px] tracking-[0.22em] text-or uppercase hover:text-or-deep"
+            >
+              Voir la fiche →
+            </a>
+          )}
+          {photo.status === 'published' && (
+            <button
+              type="button"
+              onClick={() => setStatus('flagged')}
+              disabled={busy !== null}
+              className="inline-flex h-8 items-center rounded-full border border-or/30 px-4 text-[10px] font-medium tracking-[0.22em] text-texte-sec uppercase hover:border-or hover:text-or-deep disabled:opacity-60"
+            >
+              {busy === 'flagged' ? '…' : 'Signaler'}
+            </button>
+          )}
+          {photo.status === 'flagged' && (
+            <button
+              type="button"
+              onClick={() => setStatus('published')}
+              disabled={busy !== null}
+              className="inline-flex h-8 items-center rounded-full bg-vert px-4 text-[10px] font-medium tracking-[0.22em] text-creme uppercase hover:bg-vert-dark disabled:opacity-60"
+            >
+              {busy === 'published' ? '…' : 'Rétablir'}
+            </button>
+          )}
+          {photo.status !== 'removed' && (
+            <button
+              type="button"
+              onClick={() => {
+                setRemoveError(null)
+                setRemoveOpen(true)
+              }}
+              disabled={busy !== null}
+              className="inline-flex h-8 items-center rounded-full bg-red-900 px-4 text-[10px] font-medium tracking-[0.22em] text-creme uppercase hover:bg-red-900/90 disabled:opacity-60"
+            >
+              Retirer
+            </button>
+          )}
+          <span className="ml-auto text-[10px] tracking-[0.22em] text-texte-sec uppercase">
+            {photo.status}
+          </span>
+        </div>
+
+        {error && <p className="mt-2 text-[12px] text-red-900">{error}</p>}
+      </div>
+
+      <MotifModal
+        open={removeOpen}
+        titre="Retirer cette photo ?"
+        description={
+          <>
+            <p>
+              Soft delete : la photo disparaîtra des fiches (PR-c) et ne sera plus comptée.{' '}
+              <strong className="text-vert">
+                Le motif est obligatoire (10 caractères min.)
+              </strong>
+              .
+            </p>
+            <p className="mt-2 italic text-texte-sec">
+              Le motif est visible dans l&apos;admin mais n&apos;est pas envoyé à l&apos;autrice.
+            </p>
+          </>
+        }
+        confirmLabel="Retirer la photo"
+        placeholder="Visage de tiers, contenu inapproprié, doublon..."
+        loading={busy === 'removed'}
+        error={removeError}
+        onConfirm={confirmRemove}
+        onCancel={() => setRemoveOpen(false)}
+      />
+    </li>
+  )
+}

--- a/app/api/admin/place-photos/[id]/remove/route.ts
+++ b/app/api/admin/place-photos/[id]/remove/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin/guard";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * POST /api/admin/place-photos/[id]/remove
+ * Retrait admin d'une photo de lieu avec motif obligatoire (min 10 chars).
+ * Soft delete : status='removed' + moderation_motif=<motif> (admin-only).
+ * On ne supprime PAS le fichier storage (réversible ; PR-c ne lira que les
+ * lignes status='published').
+ *
+ * Body : { motif: string }
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const guard = await requireAdmin();
+  if (guard.error) return guard.error;
+
+  const { id } = await params;
+  const body = await request.json().catch(() => ({}));
+  const motif = typeof body?.motif === "string" ? body.motif.trim() : "";
+
+  if (motif.length < 10) {
+    return NextResponse.json(
+      { error: "Le motif de retrait est obligatoire (10 caractères minimum)." },
+      { status: 400 },
+    );
+  }
+
+  const admin = createAdminClient();
+  const { error } = await admin
+    .from("place_user_photos")
+    .update({
+      status: "removed",
+      moderation_motif: motif,
+      moderated_at: new Date().toISOString(),
+    })
+    .eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/admin/place-photos/[id]/status/route.ts
+++ b/app/api/admin/place-photos/[id]/status/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin/guard";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+const ALLOWED = new Set(["published", "flagged", "removed"] as const);
+
+/**
+ * POST /api/admin/place-photos/[id]/status
+ * Modération a posteriori des photos de lieux (PR-b). Bascule le statut
+ * (Signaler / Rétablir). service_role → bypass RLS, gaté par requireAdmin().
+ *
+ * Body : { status: 'published' | 'flagged' | 'removed' }
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const guard = await requireAdmin();
+  if (guard.error) return guard.error;
+
+  const { id } = await params;
+  const body = await request.json().catch(() => ({}));
+  const next = body?.status;
+
+  if (!ALLOWED.has(next)) {
+    return NextResponse.json(
+      { error: `status doit être un de : ${Array.from(ALLOWED).join(", ")}` },
+      { status: 400 },
+    );
+  }
+
+  const admin = createAdminClient();
+  const { error } = await admin
+    .from("place_user_photos")
+    .update({ status: next, moderated_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/components/v2/RecoForm.tsx
+++ b/components/v2/RecoForm.tsx
@@ -68,6 +68,13 @@ export function RecoForm({
   const [tags, setTags] = useState<string[]>(initialTags)
   const [dietTags, setDietTags] = useState<string[]>(initialDiets)
   const [photos, setPhotos] = useState<string[]>(existingReco?.photo_urls ?? [])
+  // PR-b : photos uploadées DANS CETTE session (path storage + url publique).
+  // Alimente place_user_photos (structure propre, source de vérité future).
+  // On conserve `photos` (urls) pour la double écriture photo_urls → le rendu
+  // connecté actuel reste inchangé. DETTE : photo_urls devra être retiré plus
+  // tard ; la lecture publique (PR-c) ne lira QUE place_user_photos, jamais
+  // l'array legacy.
+  const [newPhotos, setNewPhotos] = useState<{ path: string; url: string }[]>([])
   const [priceIndicator, setPriceIndicator] = useState(existingReco?.price_indicator ?? '')
   // Consentement frais demandé à CHAQUE enregistrement (jamais pré-coché, même
   // en édition) → preuve éclairée renouvelée. Bloquant uniquement si des photos
@@ -89,7 +96,11 @@ export function RecoForm({
     setUploading(true)
     onError(null)
     const ext = file.name.split('.').pop()?.toLowerCase() ?? 'jpg'
-    const path = `${userId}/${Date.now()}.${ext}`
+    // PR-b : path SANS user_id (anti-fuite d'identité dans l'URL publique).
+    // uuid plat ; la propriété du fichier est portée par la colonne `owner`
+    // (posée par Supabase à l'upload) → verrou écriture/suppression owner-only
+    // côté storage. Le place_id vit dans la colonne place_user_photos.place_id.
+    const path = `${crypto.randomUUID()}.${ext}`
     const { error: upErr } = await supabase.storage
       .from('recommendation-photos')
       .upload(path, file, { cacheControl: '3600' })
@@ -102,7 +113,27 @@ export function RecoForm({
       data: { publicUrl },
     } = supabase.storage.from('recommendation-photos').getPublicUrl(path)
     setPhotos((p) => [...p, publicUrl])
+    setNewPhotos((n) => [...n, { path, url: publicUrl }])
     setUploading(false)
+  }
+
+  // PR-b : enregistre dans place_user_photos les photos uploadées CETTE session.
+  // Double écriture (en plus de photo_urls) → structure propre côté table, rendu
+  // connecté inchangé. Best-effort : si l'insert échoue, la reco + photo_urls
+  // sont déjà sauvegardées (on ne casse pas l'enregistrement principal). La RLS
+  // INSERT (user_id = auth.uid()) verrouille à la base.
+  const savePlacePhotos = async (placeId: string, recommendationId: string) => {
+    if (newPhotos.length === 0) return
+    const { error } = await supabase.from('place_user_photos').insert(
+      newPhotos.map((ph) => ({
+        place_id: placeId,
+        user_id: userId,
+        recommendation_id: recommendationId,
+        storage_path: ph.path,
+        status: 'published',
+      })),
+    )
+    if (error) console.error('place_user_photos insert', error.message)
   }
 
   const submit = async () => {
@@ -137,11 +168,18 @@ export function RecoForm({
           photo_consent_at: photoConsentAt,
         })
         .eq('id', existingReco.id)
-      setSubmitting(false)
       if (updErr) {
+        setSubmitting(false)
         onError(updErr.message)
         return
       }
+      // Nouvelles photos ajoutées pendant l'édition → place_user_photos.
+      // resolvePlaceId() côté modale renvoie simplement le placeId (sans effet).
+      if (newPhotos.length > 0) {
+        const placeId = await resolvePlaceId()
+        if (placeId) await savePlacePhotos(placeId, existingReco.id)
+      }
+      setSubmitting(false)
       toast.success('Reco mise à jour', { duration: 4000 })
       onSuccess()
       return
@@ -154,24 +192,31 @@ export function RecoForm({
       return
     }
 
-    const { error: recoErr } = await supabase.from('recommendations').insert({
-      user_id: userId,
-      type: 'place',
-      place_id: placeId,
-      comment: comment.trim(),
-      rating: rating || null,
-      tags: mergedTags.length ? mergedTags : null,
-      price_indicator: priceIndicator || null,
-      photo_urls: photos.length ? photos : null,
-      photo_consent_at: photoConsentAt,
-      status: 'published',
-    })
+    const { data: inserted, error: recoErr } = await supabase
+      .from('recommendations')
+      .insert({
+        user_id: userId,
+        type: 'place',
+        place_id: placeId,
+        comment: comment.trim(),
+        rating: rating || null,
+        tags: mergedTags.length ? mergedTags : null,
+        price_indicator: priceIndicator || null,
+        photo_urls: photos.length ? photos : null,
+        photo_consent_at: photoConsentAt,
+        status: 'published',
+      })
+      .select('id')
+      .single()
 
-    setSubmitting(false)
     if (recoErr) {
+      setSubmitting(false)
       onError(recoErr.message)
       return
     }
+    // Double écriture place_user_photos (structure propre, rendu inchangé).
+    if (inserted?.id) await savePlacePhotos(placeId, inserted.id)
+    setSubmitting(false)
     // Toast voix Sara — gamification mig 16 award +10 pts via trigger
     // SECURITY DEFINER, on est optimiste côté client (best-effort).
     toast.success('+10 pts · Tu fais grandir Hilmy', { duration: 4000 })

--- a/supabase/migrations/66_place_user_photos.sql
+++ b/supabase/migrations/66_place_user_photos.sql
@@ -1,0 +1,120 @@
+-- =====================================================================
+-- HILMY · PR-b · 66 — Table dédiée photos de lieux + modération a posteriori
+--
+-- Objectif PR-b : poser la STRUCTURE propre des photos membres.
+--   • Table place_user_photos (1 ligne / photo), modération a posteriori
+--     (default 'published' → la photo est active dès l'upload).
+--   • storage_path SANS user_id (anti-fuite d'identité dans l'URL).
+--   • Verrou écriture par OWNER côté storage (la colonne owner posée par
+--     Supabase à l'upload), car le nouveau path (uuid plat) ne porte plus
+--     l'identité dans le chemin.
+--
+-- ROBINET FERMÉ : RIEN de public ici. Lecture connecté-only (anon = zéro).
+-- place_public_recos reste INTOUCHÉE. L'affichage public, c'est PR-c.
+--
+-- Dette technique notée : photo_urls (array sur recommendations) reste en
+-- DOUBLE ÉCRITURE pendant PR-b (rendu connecté inchangé). À RETIRER plus tard
+-- (PR-c ou PR-b.2). Règle d'or : PR-c ne lira QUE place_user_photos, JAMAIS
+-- l'array legacy photo_urls. Les photos legacy (ancien path {user_id}/…) sont
+-- LAISSÉES en place, jamais exposées en public.
+-- =====================================================================
+
+-- ─── 1) Table ────────────────────────────────────────────────────────
+create table if not exists public.place_user_photos (
+  id                uuid primary key default gen_random_uuid(),
+  place_id          uuid not null references public.places(id) on delete cascade,
+  user_id           uuid not null references auth.users(id) on delete cascade,
+  recommendation_id uuid references public.recommendations(id) on delete set null,
+  storage_path      text not null,
+  status            text not null default 'published'
+                      check (status in ('published', 'flagged', 'removed')),
+  moderation_motif  text,
+  created_at        timestamptz not null default now(),
+  moderated_at      timestamptz
+);
+
+comment on table public.place_user_photos is
+  'PR-b : photos de lieux uploadées par les membres. Modération a posteriori (default published → active dès l''upload). storage_path SANS user_id (anti-fuite). Lecture connecté-only en PR-b ; le public viendra en PR-c via une vue anon-safe. Règle d''or : la lecture publique ne lira QUE cette table, jamais l''array legacy recommendations.photo_urls.';
+
+create index if not exists idx_place_user_photos_place_status
+  on public.place_user_photos (place_id, status);
+create index if not exists idx_place_user_photos_user
+  on public.place_user_photos (user_id);
+create index if not exists idx_place_user_photos_status
+  on public.place_user_photos (status);
+
+-- ─── 2) RLS sur la table — verrou owner-only (Postgres-enforced) ──────
+alter table public.place_user_photos enable row level security;
+
+-- SELECT : connecté seulement. Anon n'a PAS la policy (to authenticated) →
+-- robinet fermé. Une membre voit les photos publiées + les siennes (tous statuts).
+drop policy if exists "place_user_photos_read_connected" on public.place_user_photos;
+create policy "place_user_photos_read_connected"
+  on public.place_user_photos for select
+  to authenticated
+  using (
+    (auth.uid() is not null and status = 'published')
+    or (auth.uid() = user_id)
+  );
+
+-- INSERT : owner-only — on ne crée qu'à son propre nom.
+drop policy if exists "place_user_photos_insert_own" on public.place_user_photos;
+create policy "place_user_photos_insert_own"
+  on public.place_user_photos for insert
+  to authenticated
+  with check (user_id = auth.uid());
+
+-- UPDATE : owner-only — verrou identique à l'édition des recos.
+drop policy if exists "place_user_photos_update_own" on public.place_user_photos;
+create policy "place_user_photos_update_own"
+  on public.place_user_photos for update
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- DELETE : owner-only.
+drop policy if exists "place_user_photos_delete_own" on public.place_user_photos;
+create policy "place_user_photos_delete_own"
+  on public.place_user_photos for delete
+  to authenticated
+  using (auth.uid() = user_id);
+
+-- NB modération admin : via service_role (createAdminClient) qui BYPASSE la RLS.
+-- Pas de policy dédiée — c'est le canal admin existant, serveur-only.
+
+-- ─── 3) Storage — recommendation-photos : verrou par OWNER (additif) ──
+-- Le nouveau path (uuid plat, sans user_id) ne porte plus l'identité, donc
+-- storage_owner_from_path() ne peut plus servir de verrou ici. On bascule
+-- recommendation-photos sur la colonne `owner` (posée par Supabase à l'upload).
+--
+-- IMPORTANT : on n' AJOUTE que des policies dédiées, on NE TOUCHE PAS aux
+-- policies génériques (hilmy_buckets_*) ni aux legacy. En RLS, les policies
+-- permissives se combinent en OR ; pour un path plat, storage_owner_from_path()
+-- renvoie null (pas de slash) → les génériques n'accordent RIEN sur les nouveaux
+-- fichiers. Toute la permission vient des policies ci-dessous. Les autres buckets
+-- (prestataire-photos, event-flyers, user-avatars, profile-videos, place-videos)
+-- restent strictement inchangés → zéro régression.
+
+-- INSERT : un membre crée un NOUVEAU fichier (uuid random → pas de collision ;
+-- upsert:false → impossible d'écraser un existant). Pas de owner check à
+-- l'insert (owner est posé par Supabase APRÈS), inutile et fragile ici.
+drop policy if exists "reco_photos_insert_auth" on storage.objects;
+create policy "reco_photos_insert_auth"
+  on storage.objects for insert
+  to authenticated
+  with check (bucket_id = 'recommendation-photos');
+
+-- UPDATE/DELETE : owner-only → une membre ne touche QUE ses fichiers, jamais
+-- ceux d'une autre. C'est ça qui protège les fichiers entre membres.
+drop policy if exists "reco_photos_owner_update" on storage.objects;
+create policy "reco_photos_owner_update"
+  on storage.objects for update
+  to authenticated
+  using (bucket_id = 'recommendation-photos' and owner = auth.uid())
+  with check (bucket_id = 'recommendation-photos' and owner = auth.uid());
+
+drop policy if exists "reco_photos_owner_delete" on storage.objects;
+create policy "reco_photos_owner_delete"
+  on storage.objects for delete
+  to authenticated
+  using (bucket_id = 'recommendation-photos' and owner = auth.uid());

--- a/supabase/migrations/66_place_user_photos_rollback.sql
+++ b/supabase/migrations/66_place_user_photos_rollback.sql
@@ -1,0 +1,14 @@
+-- =====================================================================
+-- HILMY · PR-b · 66 ROLLBACK — place_user_photos + storage policies
+-- La mig 66 n'a fait qu' AJOUTER 3 policies dédiées + la table (elle n'a PAS
+-- touché aux policies génériques). Le rollback retire donc seulement ces 3
+-- policies et drop la table.
+-- =====================================================================
+
+-- ─── Storage : retirer les policies dédiées recommendation-photos ────
+drop policy if exists "reco_photos_insert_auth" on storage.objects;
+drop policy if exists "reco_photos_owner_update" on storage.objects;
+drop policy if exists "reco_photos_owner_delete" on storage.objects;
+
+-- ─── Table ───────────────────────────────────────────────────────────
+drop table if exists public.place_user_photos;


### PR DESCRIPTION
## Résumé
PR-b du chantier photos. Pose la **structure propre** des photos de lieux et la **modération a posteriori** — sans rien rendre public (l'affichage public = PR-c, le robinet RGPD).

- **Migration 66** (déjà appliquée en prod, view-first) : table `place_user_photos` (default `published` = a posteriori), RLS owner-only (`user_id = auth.uid()`, Postgres-enforced), lecture **connecté-only** (anon = zéro). Verrou storage par colonne `owner` pour `recommendation-photos` → nouveau path `uuid` plat **sans user_id** (fin de la fuite d'identité dans l'URL). Additif : génériques + autres buckets inchangés.
- **RecoForm** : upload au nouveau path + **double écriture** dans `place_user_photos` (on garde `photo_urls` pour le rendu connecté actuel — **dette** notée à retirer ; PR-c ne lira QUE `place_user_photos`).
- **Admin** : `/admin/photos-a-moderer` (Signalées/Publiées/Retirées) + routes `status` / `remove` (soft delete + motif ≥10) + badge nav.

## Périmètre (robinet fermé)
- `place_public_recos` **intouchée**, aucune vue anon ne lit la table.
- Legacy `photo_urls` **laissé en place**, jamais exposé.

## Test plan
- [ ] Vercel vert
- [ ] curl anon prod : 0 photo, 0 fuite user_id
- [ ] (manuel, connecté) upload depuis fiche → ligne `place_user_photos` créée, path = `uuid.ext`
- [ ] (manuel, admin) Signaler / Rétablir / Retirer fonctionnent

🤖 Generated with [Claude Code](https://claude.com/claude-code)