### PR TITLE
Lightbox photos partagé + suppression de sa reco (RGPD)

### DIFF
--- a/components/v2/AddRecoModal.tsx
+++ b/components/v2/AddRecoModal.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { AnimatePresence, motion } from 'motion/react'
 import { RecoForm, type ExistingReco } from '@/components/v2/RecoForm'
+import { createClient } from '@/lib/supabase/client'
 
 /**
  * Client island posé sur la fiche /recommandation/[slug] (rendu CONNECTÉ
@@ -34,11 +35,82 @@ export function AddRecoModal({
   const router = useRouter()
   const [open, setOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Suppression (droit à l'effacement RGPD) — confirmation BLOQUANTE.
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   const isEdit = existingReco !== null
 
   const close = () => {
     setOpen(false)
     setError(null)
+  }
+
+  /**
+   * Suppression définitive de SA reco. Ordre IMPÉRATIF storage-d'abord :
+   * 1. on collecte tous les chemins storage (table place_user_photos + URLs
+   *    legacy photo_urls), dédupliqués ;
+   * 2. on supprime les FICHIERS d'abord — si ça échoue, on n'efface RIEN en
+   *    base (zéro fichier orphelin) ;
+   * 3. on supprime les lignes place_user_photos AVANT la reco (la FK est
+   *    ON DELETE SET NULL : supprimer la reco d'abord casserait le lien) ;
+   * 4. on supprime la reco (DELETE protégé Postgres-side par la RLS owner-only
+   *    `auth.uid() = user_id` — l'UI ne fait que déclencher).
+   * 5. router.refresh() → la reco disparaît, « N copines » + note recalculés.
+   */
+  const handleDelete = async () => {
+    if (!existingReco) return
+    setDeleting(true)
+    setDeleteError(null)
+    const supabase = createClient()
+
+    // 1. Collecte des chemins storage (table + legacy), dédupliqués.
+    const paths = new Set<string>()
+    const { data: rows } = await supabase
+      .from('place_user_photos')
+      .select('storage_path')
+      .eq('recommendation_id', existingReco.id)
+    for (const r of (rows ?? []) as Array<{ storage_path: string | null }>) {
+      if (r.storage_path) paths.add(r.storage_path)
+    }
+    const marker = '/recommendation-photos/'
+    for (const url of existingReco.photo_urls ?? []) {
+      const idx = url.indexOf(marker)
+      if (idx !== -1) paths.add(decodeURIComponent(url.slice(idx + marker.length)))
+    }
+
+    // 2. STORAGE D'ABORD — abort total si échec (zéro orphelin).
+    if (paths.size > 0) {
+      const { error: rmErr } = await supabase.storage
+        .from('recommendation-photos')
+        .remove(Array.from(paths))
+      if (rmErr) {
+        setDeleting(false)
+        setDeleteError(
+          "Impossible de supprimer les photos — rien n'a été supprimé, réessaie.",
+        )
+        return
+      }
+    }
+
+    // 3. Lignes place_user_photos (RLS owner-only) AVANT la reco.
+    await supabase.from('place_user_photos').delete().eq('recommendation_id', existingReco.id)
+
+    // 4. La reco (RLS DELETE owner-only Postgres-side).
+    const { error: recoErr } = await supabase
+      .from('recommendations')
+      .delete()
+      .eq('id', existingReco.id)
+    if (recoErr) {
+      setDeleting(false)
+      setDeleteError('Suppression impossible. Réessaie.')
+      return
+    }
+
+    // 5. Fermeture + re-render server.
+    setDeleting(false)
+    setConfirmOpen(false)
+    router.refresh()
   }
 
   return (
@@ -53,6 +125,19 @@ export function AddRecoModal({
           →
         </span>
       </button>
+
+      {isEdit && (
+        <button
+          type="button"
+          onClick={() => {
+            setDeleteError(null)
+            setConfirmOpen(true)
+          }}
+          className="inline-flex h-11 w-full items-center justify-center rounded-full border border-red-900/30 text-[11px] font-medium tracking-[0.22em] text-red-900 uppercase transition-all hover:border-red-900 hover:bg-red-900/5"
+        >
+          Supprimer ma reco
+        </button>
+      )}
 
       <AnimatePresence>
         {open && (
@@ -119,6 +204,71 @@ export function AddRecoModal({
                   </button>
                 }
               />
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Confirmation BLOQUANTE : impossible de supprimer en un clic. Annuler
+          est le bouton par défaut (autoFocus) — un Entrée annule, ne supprime
+          pas. La suppression exige un clic explicite sur le bouton danger. */}
+      <AnimatePresence>
+        {confirmOpen && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-[120] flex items-center justify-center bg-vert/50 px-4 backdrop-blur-sm"
+            onClick={() => !deleting && setConfirmOpen(false)}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="delete-reco-title"
+          >
+            <motion.div
+              initial={{ opacity: 0, scale: 0.96, y: 20 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.96, y: 20 }}
+              transition={{ duration: 0.2 }}
+              onClick={(e) => e.stopPropagation()}
+              className="w-full max-w-md rounded-sm border border-or/20 bg-creme p-8 shadow-2xl"
+            >
+              <h2
+                id="delete-reco-title"
+                className="font-serif text-2xl font-light leading-tight text-vert"
+              >
+                Es-tu sûre ?
+              </h2>
+              <p className="mt-3 text-[14px] leading-[1.65] text-texte">
+                Cette action est <strong className="text-red-900">définitive</strong>. Ta reco et
+                ses photos seront supprimées — y compris les fichiers. Impossible de revenir en
+                arrière.
+              </p>
+
+              {deleteError && (
+                <p className="mt-4 rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[12px] text-red-900">
+                  {deleteError}
+                </p>
+              )}
+
+              <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+                <button
+                  type="button"
+                  autoFocus
+                  onClick={() => setConfirmOpen(false)}
+                  disabled={deleting}
+                  className="inline-flex h-11 items-center justify-center rounded-full border border-or/30 px-5 text-[11px] font-medium tracking-[0.22em] text-texte-sec uppercase transition-colors hover:border-or hover:text-vert disabled:opacity-60"
+                >
+                  Annuler
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className="inline-flex h-11 items-center justify-center rounded-full bg-red-900 px-5 text-[11px] font-medium tracking-[0.22em] text-creme uppercase transition-colors hover:bg-red-900/90 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {deleting ? 'Suppression…' : 'Supprimer définitivement'}
+                </button>
+              </div>
             </motion.div>
           </motion.div>
         )}

--- a/components/v2/PhotoGallery.tsx
+++ b/components/v2/PhotoGallery.tsx
@@ -17,6 +17,12 @@ interface Props {
   gridClassName?: string
   /** Aspect ratio de chaque tuile. Défaut : aspect-square. */
   aspectClassName?: string
+  /**
+   * Classes par tuile (sérialisable : calculé côté serveur). Si fourni pour un
+   * index, remplace `aspectClassName` pour cette tuile — permet une mosaïque
+   * (1re photo en grand, col-span) tout en gardant le même lightbox partagé.
+   */
+  itemClassNames?: string[]
   /** Label accessible du lightbox (contexte : nom du lieu/prestataire). */
   ariaLabel?: string
 }
@@ -29,6 +35,7 @@ export function PhotoGallery({
   items,
   gridClassName = 'grid grid-cols-2 gap-3 md:grid-cols-4',
   aspectClassName = 'aspect-square',
+  itemClassNames,
   ariaLabel,
 }: Props) {
   const [openIndex, setOpenIndex] = useState<number | null>(null)
@@ -61,7 +68,7 @@ export function PhotoGallery({
                 key={i}
                 type="button"
                 onClick={() => setOpenIndex(photoIdx)}
-                className={`group relative ${aspectClassName} overflow-hidden rounded-sm focus:outline-none focus:ring-2 focus:ring-or`}
+                className={`group relative ${itemClassNames?.[i] ?? aspectClassName} overflow-hidden rounded-sm focus:outline-none focus:ring-2 focus:ring-or`}
                 aria-label={`Agrandir la photo ${photoIdx + 1} sur ${photoUrls.length}`}
               >
                 {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -82,7 +89,7 @@ export function PhotoGallery({
           return (
             <div
               key={i}
-              className={`${aspectClassName} rounded-sm`}
+              className={`${itemClassNames?.[i] ?? aspectClassName} rounded-sm`}
               style={{
                 background: `linear-gradient(135deg, ${c} 0%, ${
                   items[(i + 1) % items.length] ?? c

--- a/components/v2/RecommandationDetail.tsx
+++ b/components/v2/RecommandationDetail.tsx
@@ -9,6 +9,7 @@ import { FadeInSection } from '@/components/ui/FadeInSection'
 import { LieuCard } from '@/components/v2/LieuCard'
 import { VideoPlayer } from '@/components/v2/VideoPlayer'
 import { AddRecoModal } from '@/components/v2/AddRecoModal'
+import { PhotoGallery } from '@/components/v2/PhotoGallery'
 import type { ExistingReco } from '@/components/v2/RecoForm'
 import { categoriesLieux, type Lieu as MockLieu } from '@/lib/mock-data'
 import { isSelectionHilmy } from '@/lib/permissions-lieux'
@@ -235,23 +236,16 @@ export function RecommandationDetail({
                   grand, le reste en vignettes. Donne du corps visuel à la page. */}
               {galleryPhotos.length > 0 && (
                 <FadeInSection>
-                  <div className="grid grid-cols-2 gap-3 md:gap-4">
-                    {galleryPhotos.map((url, i) => (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        key={i}
-                        src={url}
-                        alt={`${l.nom} — photo ${i + 2}`}
-                        className={`w-full rounded-sm object-cover ${
-                          galleryPhotos.length === 1
-                            ? 'col-span-2 aspect-[16/9]'
-                            : i === 0
-                              ? 'col-span-2 aspect-[16/9]'
-                              : 'aspect-square'
-                        }`}
-                      />
-                    ))}
-                  </div>
+                  <PhotoGallery
+                    items={galleryPhotos}
+                    gridClassName="grid grid-cols-2 gap-3 md:gap-4"
+                    itemClassNames={galleryPhotos.map((_, i) =>
+                      galleryPhotos.length === 1 || i === 0
+                        ? 'col-span-2 aspect-[16/9]'
+                        : 'aspect-square',
+                    )}
+                    ariaLabel={`${l.nom} en images`}
+                  />
                 </FadeInSection>
               )}
 
@@ -357,17 +351,12 @@ export function RecommandationDetail({
                       )}
 
                       {r.photos.length > 0 && (
-                        <div className="mt-5 grid grid-cols-3 gap-2 md:grid-cols-4">
-                          {r.photos.map((url, i) => (
-                            // eslint-disable-next-line @next/next/no-img-element
-                            <img
-                              key={i}
-                              src={url}
-                              alt=""
-                              className="aspect-square w-full rounded-sm object-cover"
-                            />
-                          ))}
-                        </div>
+                        <PhotoGallery
+                          items={r.photos}
+                          gridClassName="mt-5 grid grid-cols-3 gap-2 md:grid-cols-4"
+                          aspectClassName="aspect-square"
+                          ariaLabel={`Photos partagées par ${r.prenom}`}
+                        />
                       )}
                     </li>
                   ))}


### PR DESCRIPTION
## Summary
Deux corrections UX sur la **fiche reco connectée uniquement** (zéro impact public, PR-c non touchée).

- **Lightbox photos** : photos des recos **ET** galerie du lieu désormais cliquables → plein écran via le composant partagé `PhotoLightbox` (clic-dehors / croix / Échap, navigation ‹ ›, compteur, scroll-lock). Un seul composant lightbox partout. `PhotoGallery` gagne un prop sérialisable `itemClassNames` pour préserver la mosaïque du lieu (1re photo en grand) tout en passant par le même lightbox. **Affichage pur, zéro écriture.**
- **Supprimer sa reco (RGPD)** : bouton « Supprimer ma reco » sous « Modifier ma reco », visible seulement quand c'est SA reco. **Confirmation bloquante** (« Es-tu sûre ? Définitif », *Annuler* par défaut/autoFocus — impossible de supprimer en un clic).

### Verrous suppression
- **DELETE owner-only Postgres-side** (RLS `auth.uid() = user_id`) sur `recommendations` **et** `place_user_photos`. L'UI ne fait que déclencher.
- **Cleanup storage-d'abord, zéro orphelin** : collecte des chemins (`place_user_photos.storage_path` + `photo_urls` legacy, dédupliqués) → suppression des **fichiers** → si échec, **rien** n'est effacé en base → sinon lignes `place_user_photos` (avant la reco, FK `ON DELETE SET NULL`) → reco.
- `router.refresh()` → la reco disparaît, « N copines » + note recalculés (vue `place_public_detail`).

## Test plan
- [ ] Connectée, fiche d'un lieu avec galerie + une reco avec photo : cliquer une photo de reco → plein écran ; clic-dehors / croix / Échap ferment ; ‹ › naviguent.
- [ ] Idem sur la galerie du lieu (mosaïque conservée, 1re photo en grand).
- [ ] « Supprimer ma reco » visible uniquement sur SA reco ; modale Annuler par défaut ; un clic seul ne supprime pas.
- [ ] Supprimer une reco avec photo → la reco disparaît, compteur + note recalculés.
- [ ] Vérifier que le **fichier** a disparu du bucket `recommendation-photos` (pas juste la ligne en base).
- [ ] Re-test curl anon : zéro fuite, rien de public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)