### PR TITLE
feat(photos): affichage public des photos communauté (PR-c)

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -21,7 +21,7 @@ export default async function AdminLayout({
   //   'published' OR owner)
   // → service_role pour avoir les vrais chiffres. Safe parce que
   // l'accès à ce layout est déjà gaté par le notFound() ci-dessus.
-  const [prestaCount, eventCount, recoCount, photoCount, reportCount, jeChercheSignalementsCount, pendingPerksCount] = await Promise.all([
+  const [prestaCount, eventCount, recoCount, photoCount, communityPhotoReportCount, reportCount, jeChercheSignalementsCount, pendingPerksCount] = await Promise.all([
     admin
       .from('profiles')
       .select('id', { count: 'exact', head: true })
@@ -39,6 +39,12 @@ export default async function AdminLayout({
       .from('place_user_photos')
       .select('id', { count: 'exact', head: true })
       .eq('status', 'flagged'),
+    // PR-c : signalements communauté de photos (content_reports) en attente.
+    admin
+      .from('content_reports')
+      .select('id', { count: 'exact', head: true })
+      .eq('target_type', 'place_photo')
+      .eq('status', 'pending'),
     admin
       .from('recommendation_reports')
       .select('id', { count: 'exact', head: true })
@@ -74,6 +80,11 @@ export default async function AdminLayout({
       href: '/admin/photos-a-moderer',
       label: 'Photos de lieux',
       badge: photoCount.count ?? 0,
+    },
+    {
+      href: '/admin/photos-a-moderer?status=community',
+      label: 'Photos signalées',
+      badge: communityPhotoReportCount.count ?? 0,
     },
     {
       href: '/admin/signalements',

--- a/app/admin/photos-a-moderer/communityReportRowClient.tsx
+++ b/app/admin/photos-a-moderer/communityReportRowClient.tsx
@@ -1,0 +1,185 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { MotifModal } from '@/components/v2/MotifModal'
+
+/**
+ * Ligne de la file « Signalées par la communauté » (PR-c).
+ *
+ * Source : content_reports (target_type='place_photo', status='pending'). Un
+ * signalement ne masque RIEN — la photo reste publiée tant que l'admin n'agit
+ * pas. Deux issues pour vider la file :
+ *  - « Retirer la photo » → /api/admin/place-photos/[photo_id]/remove (soft
+ *    delete + motif), PUIS marque le signalement reviewed (sort de la file).
+ *  - « Marquer traité » → /api/admin/content-reports/[report_id]/status
+ *    (reviewed) sans toucher la photo (signalement jugé infondé / déjà géré).
+ */
+type CommunityReport = {
+  report_id: string
+  photo_id: string
+  reason: string | null
+  reported_at: string
+  url: string | null
+  photo_status: string | null
+  prenom: string
+  place: { name: string; slug: string | null } | null
+}
+
+export function CommunityReportRow({ report }: { report: CommunityReport }) {
+  const router = useRouter()
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [removeOpen, setRemoveOpen] = useState(false)
+  const [removeError, setRemoveError] = useState<string | null>(null)
+
+  const placeName = report.place?.name ?? 'Lieu inconnu'
+  const placeLink = report.place?.slug ? `/recommandation/${report.place.slug}` : null
+
+  const markReviewed = async () => {
+    setBusy('reviewed')
+    setError(null)
+    const res = await fetch(`/api/admin/content-reports/${report.report_id}/status`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'reviewed' }),
+    })
+    const body = await res.json().catch(() => ({}))
+    setBusy(null)
+    if (!res.ok) {
+      setError(body.error ?? 'Erreur inconnue')
+      return
+    }
+    router.refresh()
+  }
+
+  const confirmRemove = async (motif: string) => {
+    setBusy('removed')
+    setRemoveError(null)
+    // 1. Retrait de la photo (soft delete + motif).
+    const res = await fetch(`/api/admin/place-photos/${report.photo_id}/remove`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ motif }),
+    })
+    const body = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      setBusy(null)
+      setRemoveError(body.error ?? 'Erreur inconnue')
+      return
+    }
+    // 2. Le signalement sort de la file (reviewed). Échec ici = non bloquant :
+    //    la photo est déjà retirée, l'admin pourra re-traiter le signalement.
+    await fetch(`/api/admin/content-reports/${report.report_id}/status`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'reviewed' }),
+    })
+    setBusy(null)
+    setRemoveOpen(false)
+    router.refresh()
+  }
+
+  return (
+    <li className="overflow-hidden rounded-sm border border-or/20 bg-blanc">
+      {report.url ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={report.url}
+          alt={`Photo signalée de ${placeName}`}
+          className="aspect-[4/3] w-full object-cover"
+        />
+      ) : (
+        <div className="flex aspect-[4/3] w-full items-center justify-center bg-creme-deep">
+          <p className="text-[12px] italic text-texte-sec">Photo introuvable</p>
+        </div>
+      )}
+      <div className="p-4">
+        <div className="flex flex-wrap items-baseline gap-2">
+          <p className="font-serif text-lg font-light text-vert">{placeName}</p>
+          <span className="text-[11px] text-texte-sec">
+            par {report.prenom} · signalée le{' '}
+            {new Date(report.reported_at).toLocaleDateString('fr-FR', {
+              day: 'numeric',
+              month: 'short',
+            })}
+          </span>
+        </div>
+
+        <div className="mt-3 rounded-sm border border-or/20 bg-creme-soft p-3">
+          <p className="overline text-or">Motif du signalement</p>
+          <p className="mt-1 text-[12px] italic text-texte">
+            {report.reason ? `« ${report.reason} »` : 'Aucun motif précisé.'}
+          </p>
+        </div>
+
+        {report.photo_status && report.photo_status !== 'published' && (
+          <p className="mt-2 text-[11px] tracking-[0.18em] text-texte-sec uppercase">
+            Photo déjà {report.photo_status}
+          </p>
+        )}
+
+        <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-or/10 pt-4">
+          {placeLink && (
+            <a
+              href={placeLink}
+              target="_blank"
+              rel="noopener"
+              className="text-[11px] tracking-[0.22em] text-or uppercase hover:text-or-deep"
+            >
+              Voir la fiche →
+            </a>
+          )}
+          <button
+            type="button"
+            onClick={markReviewed}
+            disabled={busy !== null}
+            className="inline-flex h-8 items-center rounded-full border border-or/30 px-4 text-[10px] font-medium tracking-[0.22em] text-texte-sec uppercase hover:border-or hover:text-or-deep disabled:opacity-60"
+          >
+            {busy === 'reviewed' ? '…' : 'Marquer traité'}
+          </button>
+          {report.photo_status === 'published' && (
+            <button
+              type="button"
+              onClick={() => {
+                setRemoveError(null)
+                setRemoveOpen(true)
+              }}
+              disabled={busy !== null}
+              className="inline-flex h-8 items-center rounded-full bg-red-900 px-4 text-[10px] font-medium tracking-[0.22em] text-creme uppercase hover:bg-red-900/90 disabled:opacity-60"
+            >
+              Retirer la photo
+            </button>
+          )}
+        </div>
+
+        {error && <p className="mt-2 text-[12px] text-red-900">{error}</p>}
+      </div>
+
+      <MotifModal
+        open={removeOpen}
+        titre="Retirer cette photo ?"
+        description={
+          <>
+            <p>
+              Soft delete : la photo disparaîtra des fiches (PR-c) et ne sera plus comptée.{' '}
+              <strong className="text-vert">
+                Le motif est obligatoire (10 caractères min.)
+              </strong>
+              . Le signalement sera marqué traité.
+            </p>
+            <p className="mt-2 italic text-texte-sec">
+              Le motif est visible dans l&apos;admin mais n&apos;est pas envoyé à l&apos;autrice.
+            </p>
+          </>
+        }
+        confirmLabel="Retirer la photo"
+        placeholder="Visage de tiers, contenu inapproprié, doublon..."
+        loading={busy === 'removed'}
+        error={removeError}
+        onConfirm={confirmRemove}
+        onCancel={() => setRemoveOpen(false)}
+      />
+    </li>
+  )
+}

--- a/app/admin/photos-a-moderer/page.tsx
+++ b/app/admin/photos-a-moderer/page.tsx
@@ -1,7 +1,8 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { PhotoRow } from './photoRowClient'
+import { CommunityReportRow } from './communityReportRowClient'
 
-type Status = 'published' | 'flagged' | 'removed'
+type Status = 'published' | 'flagged' | 'removed' | 'community'
 
 type PhotoRecord = {
   id: string
@@ -22,19 +23,22 @@ export default async function PhotosAModererPage({
   // Protection auth assurée par app/admin/layout.tsx. service_role pour
   // bypass la RLS SELECT (connecté-only en PR-b ; ici on voit tous statuts).
   const supabase = createAdminClient()
+  const isCommunity = status === 'community'
 
   // NB : pas d'embed user_profiles ici. place_user_photos.user_id pointe sur
   // auth.users (pas de FK vers user_profiles) → PostgREST ne sait pas résoudre
   // l'embed. On récupère les prénoms dans une requête séparée (même pattern que
   // la fiche /recommandation/[slug]).
-  const { data, error } = await supabase
-    .from('place_user_photos')
-    .select(
-      `id, user_id, status, storage_path, moderation_motif, created_at, place:places ( name, slug )`,
-    )
-    .eq('status', status)
-    .order('created_at', { ascending: false })
-    .limit(100)
+  const { data, error } = isCommunity
+    ? { data: null, error: null }
+    : await supabase
+        .from('place_user_photos')
+        .select(
+          `id, user_id, status, storage_path, moderation_motif, created_at, place:places ( name, slug )`,
+        )
+        .eq('status', status)
+        .order('created_at', { ascending: false })
+        .limit(100)
 
   const rows = (data ?? []) as PhotoRecord[]
 
@@ -63,6 +67,90 @@ export default async function PhotosAModererPage({
       .publicUrl,
   }))
 
+  // ── File communauté (PR-c) : signalements content_reports en attente ──────
+  // target_type='place_photo', status='pending'. La photo RESTE publiée ; on
+  // résout chaque target_id → place_user_photos (url, statut, place, autrice).
+  let communityReports: Array<{
+    report_id: string
+    photo_id: string
+    reason: string | null
+    reported_at: string
+    url: string | null
+    photo_status: string | null
+    prenom: string
+    place: { name: string; slug: string | null } | null
+  }> = []
+  let communityError: string | null = null
+  if (isCommunity) {
+    const { data: reps, error: repErr } = await supabase
+      .from('content_reports')
+      .select('id, target_id, reason, created_at')
+      .eq('target_type', 'place_photo')
+      .eq('status', 'pending')
+      .order('created_at', { ascending: false })
+      .limit(100)
+    communityError = repErr?.message ?? null
+    const reportRows = (reps ?? []) as Array<{
+      id: string
+      target_id: string
+      reason: string | null
+      created_at: string
+    }>
+    const photoIds = Array.from(new Set(reportRows.map((r) => r.target_id)))
+    const photoById = new Map<
+      string,
+      {
+        user_id: string
+        status: string
+        storage_path: string
+        place: { name: string; slug: string | null } | null
+      }
+    >()
+    if (photoIds.length > 0) {
+      const { data: pics } = await supabase
+        .from('place_user_photos')
+        .select('id, user_id, status, storage_path, place:places ( name, slug )')
+        .in('id', photoIds)
+      for (const p of (pics ?? []) as PhotoRecord[]) {
+        photoById.set(p.id, {
+          user_id: p.user_id,
+          status: p.status,
+          storage_path: p.storage_path,
+          place: Array.isArray(p.place) ? (p.place[0] ?? null) : p.place,
+        })
+      }
+      // Prénoms des autrices des photos signalées.
+      const repUserIds = Array.from(
+        new Set(Array.from(photoById.values()).map((p) => p.user_id)),
+      )
+      if (repUserIds.length > 0) {
+        const { data: profs } = await supabase
+          .from('user_profiles')
+          .select('user_id, prenom')
+          .in('user_id', repUserIds)
+        for (const p of (profs ?? []) as Array<{ user_id: string; prenom: string }>) {
+          prenomById.set(p.user_id, p.prenom)
+        }
+      }
+    }
+    communityReports = reportRows.map((r) => {
+      const pic = photoById.get(r.target_id) ?? null
+      return {
+        report_id: r.id,
+        photo_id: r.target_id,
+        reason: r.reason,
+        reported_at: r.created_at,
+        url: pic
+          ? supabase.storage.from('recommendation-photos').getPublicUrl(pic.storage_path)
+              .data.publicUrl
+          : null,
+        photo_status: pic?.status ?? null,
+        prenom: pic ? prenomById.get(pic.user_id) ?? 'Une copine' : 'Une copine',
+        place: pic?.place ?? null,
+      }
+    })
+  }
+
   return (
     <section className="px-6 py-10 md:px-12 md:py-14">
       <header className="border-b border-or/15 pb-6">
@@ -71,12 +159,14 @@ export default async function PhotosAModererPage({
           {status === 'flagged' && 'Photos signalées.'}
           {status === 'published' && 'Toutes les photos.'}
           {status === 'removed' && 'Photos retirées.'}
+          {status === 'community' && 'Signalées par la communauté.'}
         </h1>
       </header>
 
       <nav className="mt-6 flex flex-wrap gap-2">
         {(
           [
+            { key: 'community', label: 'Communauté' },
             { key: 'flagged', label: 'Signalées' },
             { key: 'published', label: 'Publiées' },
             { key: 'removed', label: 'Retirées' },
@@ -99,14 +189,28 @@ export default async function PhotosAModererPage({
         })}
       </nav>
 
-      {error && (
+      {(error || communityError) && (
         <p className="mt-6 rounded-sm border border-red-900/20 bg-red-900/5 px-3 py-2 text-[13px] text-red-900">
-          {error.message}
+          {error?.message ?? communityError}
         </p>
       )}
 
       <div className="mt-8">
-        {photos.length === 0 ? (
+        {isCommunity ? (
+          communityReports.length === 0 ? (
+            <div className="rounded-sm border border-or/15 bg-blanc p-10 text-center">
+              <p className="font-serif text-xl italic text-vert">
+                Aucun signalement en attente — la communauté est sage.
+              </p>
+            </div>
+          ) : (
+            <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {communityReports.map((r) => (
+                <CommunityReportRow key={r.report_id} report={r} />
+              ))}
+            </ul>
+          )
+        ) : photos.length === 0 ? (
           <div className="rounded-sm border border-or/15 bg-blanc p-10 text-center">
             <p className="font-serif text-xl italic text-vert">
               {status === 'flagged'

--- a/app/api/admin/content-reports/[id]/status/route.ts
+++ b/app/api/admin/content-reports/[id]/status/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin/guard";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * POST /api/admin/content-reports/[id]/status
+ * Met à jour le statut d'un signalement générique `content_reports` (PR-c :
+ * photos communauté, target_type='place_photo'). Sert à VIDER la file de
+ * modération : 'reviewed' (traité) ou 'dismissed' (rejeté). Ne touche PAS la
+ * photo elle-même (le retrait se fait via /api/admin/place-photos/[id]/remove).
+ *
+ * Body : { status: 'reviewed' | 'dismissed' }
+ */
+const ALLOWED = new Set(["reviewed", "dismissed"]);
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const guard = await requireAdmin();
+  if (guard.error) return guard.error;
+
+  const { id } = await params;
+  const body = await request.json().catch(() => ({}));
+  const status = typeof body?.status === "string" ? body.status : "";
+
+  if (!ALLOWED.has(status)) {
+    return NextResponse.json(
+      { error: "Statut invalide (reviewed | dismissed)." },
+      { status: 400 },
+    );
+  }
+
+  const admin = createAdminClient();
+  const { error } = await admin
+    .from("content_reports")
+    .update({ status })
+    .eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/place-photos/[id]/report/route.ts
+++ b/app/api/place-photos/[id]/report/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * POST /api/place-photos/[id]/report — signale une photo communauté.
+ *
+ * Signalement RÉSERVÉ aux connectées (décision PR-c) : on insère dans la table
+ * générique `content_reports` (target_type='place_photo') via le client SESSION
+ * → l'INSERT est gaté Postgres-side par la RLS `user_id = auth.uid()`.
+ *
+ * La photo RESTE published : un signalement ne masque RIEN. Il alimente la file
+ * de modération admin (modération a posteriori), l'admin décide du retrait.
+ *
+ * Body : { reason?: string }.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: photoId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Non authentifiée" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const reason =
+    typeof body?.reason === "string" ? body.reason.trim() || null : null;
+
+  const { error } = await supabase.from("content_reports").insert({
+    user_id: user.id,
+    target_type: "place_photo",
+    target_id: photoId,
+    reason,
+    status: "pending",
+  });
+
+  // Doublon (déjà signalé) → on considère que c'est noté.
+  if (error && !error.message.toLowerCase().includes("duplicate")) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/recommandation/[slug]/page.tsx
+++ b/app/recommandation/[slug]/page.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/lib/supabase/queries/places'
 import {
   getPublicPlaceDetail,
+  getPublicPlacePhotos,
   getPublicPlaceRecos,
   getPublicSimilar,
 } from '@/lib/supabase/queries/places-public'
@@ -120,15 +121,17 @@ export default async function RecommandationPage({
   if (!user) {
     const detail = await getPublicPlaceDetail(slug)
     if (!detail) notFound()
-    const [recos, similaires] = await Promise.all([
+    const [recos, similaires, communityPhotos] = await Promise.all([
       getPublicPlaceRecos(slug),
       getPublicSimilar(detail.hilmy_category, slug),
+      getPublicPlacePhotos(slug),
     ])
     return (
       <RecommandationDetailPublic
         detail={detail}
         recos={recos}
         similaires={similaires}
+        communityPhotos={communityPhotos}
       />
     )
   }
@@ -138,6 +141,9 @@ export default async function RecommandationPage({
   // que la fiche publique → garantit des valeurs strictement identiques à ce
   // que voit un visiteur anonyme. Lancé en parallèle (ne dépend que du slug).
   const publicStatsPromise = getPublicPlaceDetail(slug)
+  // Galerie communauté — MÊME vue anon-safe que la fiche publique (zéro identité,
+  // published only, source place_user_photos). Identique connecté/anonyme.
+  const communityPhotosPromise = getPublicPlacePhotos(slug)
   const { data: row, error } = await getPlaceBySlug(slug)
   if (error || !row) notFound()
   const l: MockLieu = adaptDbPlace(row)
@@ -230,6 +236,7 @@ export default async function RecommandationPage({
   }
 
   const publicStats = await publicStatsPromise
+  const communityPhotos = await communityPhotosPromise
 
   // PR-a — SA reco existante sur ce lieu (le cas échéant) → édition vs ajout
   // depuis la fiche. Filtre identique au verrou RLS (user_id = auth.uid()) ;
@@ -255,6 +262,7 @@ export default async function RecommandationPage({
       heroPriceMode={publicStats?.price_mode ?? null}
       currentUserId={user.id}
       myReco={myReco}
+      communityPhotos={communityPhotos}
     />
   )
 }

--- a/components/v2/CommunityPhotos.tsx
+++ b/components/v2/CommunityPhotos.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState } from 'react'
+import { PhotoLightbox } from '@/components/v2/PhotoLightbox'
+import { ReportPhotoButton } from '@/components/v2/ReportPhotoButton'
+
+export type CommunityPhoto = {
+  /** id de la LIGNE photo (clé React + cible du signalement, NON identitaire). */
+  photo_id: string
+  /** URL publique calculée serveur depuis storage_path (aucune identité). */
+  url: string
+}
+
+/**
+ * Galerie AGRÉGÉE des photos communauté d'un lieu, détachée des commentaires
+ * (la vue place_public_photos n'expose aucun recommendation_id → impossible de
+ * relier une photo à un texte donc à une autrice). Réutilise la lightbox
+ * partagée ; le bouton « Signaler » vit dans la lightbox via actionSlot.
+ *
+ * `canReport` : true sur la fiche connectée (POST direct), false en anonyme
+ * (le bouton devient un lien vers la connexion). Aucune identité n'est rendue.
+ */
+export function CommunityPhotos({
+  photos,
+  canReport,
+  loginHref,
+  ariaLabel = 'Photos de la communauté',
+}: {
+  photos: CommunityPhoto[]
+  canReport: boolean
+  loginHref: string
+  ariaLabel?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const [startIndex, setStartIndex] = useState(0)
+
+  if (photos.length === 0) return null
+
+  const urls = photos.map((p) => p.url)
+
+  return (
+    <>
+      <div className="grid grid-cols-3 gap-2 md:grid-cols-4">
+        {photos.map((p, i) => (
+          <button
+            key={p.photo_id}
+            type="button"
+            onClick={() => {
+              setStartIndex(i)
+              setOpen(true)
+            }}
+            aria-label={`Agrandir la photo ${i + 1}`}
+            className="group relative aspect-square overflow-hidden rounded-sm border border-or/15 focus:outline-none focus:ring-2 focus:ring-or"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={p.url}
+              alt=""
+              loading="lazy"
+              className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+            />
+          </button>
+        ))}
+      </div>
+
+      <PhotoLightbox
+        images={urls}
+        open={open}
+        startIndex={startIndex}
+        onClose={() => setOpen(false)}
+        ariaLabel={ariaLabel}
+        actionSlot={(i) => (
+          <ReportPhotoButton
+            photoId={photos[i].photo_id}
+            canReport={canReport}
+            loginHref={loginHref}
+          />
+        )}
+      />
+    </>
+  )
+}

--- a/components/v2/CommunityPhotosSection.tsx
+++ b/components/v2/CommunityPhotosSection.tsx
@@ -1,0 +1,63 @@
+import { GoldLine } from '@/components/ui/GoldLine'
+import {
+  CommunityPhotos,
+  type CommunityPhoto,
+} from '@/components/v2/CommunityPhotos'
+
+/**
+ * Bloc « Les photos des copines » de la fiche lieu — affiché à l'identique sur
+ * la fiche CONNECTÉE et la fiche PUBLIQUE (anonyme). Server Component : le grid
+ * + ses <img> sont dans le HTML SSR → photos INDEXABLES Google (exigence SEO).
+ *
+ * Les photos viennent EXCLUSIVEMENT de la vue anon-safe place_public_photos
+ * (source place_user_photos, status='published', JAMAIS l'array legacy
+ * recommendations.photo_urls). Aucune identité n'est rendue : pas de prénom,
+ * pas d'avatar, pas de recommendation_id (galerie détachée des commentaires).
+ *
+ * `canReport` : true → signalement direct (fiche connectée) ; false → le bouton
+ * devient un lien vers la connexion (fiche publique). Mention légale sous la
+ * galerie : Hilmy = hébergeur, modération a posteriori, voie de signalement.
+ */
+export function CommunityPhotosSection({
+  photos,
+  canReport,
+  loginHref,
+  placeName,
+}: {
+  photos: CommunityPhoto[]
+  canReport: boolean
+  loginHref: string
+  placeName: string
+}) {
+  if (photos.length === 0) return null
+
+  return (
+    <section aria-label={`Photos partagées par la communauté pour ${placeName}`}>
+      <header className="flex items-center gap-5">
+        <GoldLine width={60} />
+        <span className="overline text-or">
+          Les photos des copines
+          {photos.length > 1 ? ` · ${photos.length}` : ''}
+        </span>
+      </header>
+
+      <div className="mt-6">
+        <CommunityPhotos
+          photos={photos}
+          canReport={canReport}
+          loginHref={loginHref}
+          ariaLabel={`Photos partagées par la communauté pour ${placeName}`}
+        />
+      </div>
+
+      {/* Mention légale — Hilmy hébergeur, modération a posteriori, signalement. */}
+      <p className="mt-4 text-[12px] leading-[1.6] text-texte-sec">
+        Photos partagées par les membres de la communauté. Hilmy héberge ces
+        contenus, modérés a posteriori : ils n&apos;engagent que leurs autrices.
+        Un contenu te semble inapproprié (visage d&apos;un tiers, droit à
+        l&apos;image, contenu illicite)&nbsp;? Signale-le, il sera examiné et
+        retiré le cas échéant.
+      </p>
+    </section>
+  )
+}

--- a/components/v2/PhotoLightbox.tsx
+++ b/components/v2/PhotoLightbox.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 
 interface Props {
@@ -10,6 +10,12 @@ interface Props {
   onClose: () => void
   /** Label accessible du lightbox. */
   ariaLabel?: string
+  /**
+   * Slot d'action contextuelle rendu en bas à gauche de l'overlay, recalculé
+   * pour la photo affichée (ex : bouton « Signaler »). Reçoit l'index courant.
+   * Optionnel — aucun impact sur les usages existants (galerie, reco).
+   */
+  actionSlot?: (index: number) => ReactNode
 }
 
 /**
@@ -30,6 +36,7 @@ export function PhotoLightbox({
   startIndex,
   onClose,
   ariaLabel = 'Galerie photo',
+  actionSlot,
 }: Props) {
   const [index, setIndex] = useReducerIndex(startIndex, images.length)
 
@@ -158,6 +165,16 @@ export function PhotoLightbox({
               <path d="M6 6l12 12M18 6L6 18" />
             </svg>
           </button>
+
+          {/* Action contextuelle (ex : signaler) — bas gauche, au-dessus du backdrop */}
+          {actionSlot && (
+            <div
+              onClick={(e) => e.stopPropagation()}
+              className="absolute bottom-6 left-5 z-10"
+            >
+              {actionSlot(safeIndex)}
+            </div>
+          )}
 
           {/* Nav prev / next */}
           {hasMultiple && (

--- a/components/v2/RecommandationDetail.tsx
+++ b/components/v2/RecommandationDetail.tsx
@@ -10,6 +10,8 @@ import { LieuCard } from '@/components/v2/LieuCard'
 import { VideoPlayer } from '@/components/v2/VideoPlayer'
 import { AddRecoModal } from '@/components/v2/AddRecoModal'
 import { PhotoGallery } from '@/components/v2/PhotoGallery'
+import { CommunityPhotosSection } from '@/components/v2/CommunityPhotosSection'
+import type { CommunityPhoto } from '@/components/v2/CommunityPhotos'
 import type { ExistingReco } from '@/components/v2/RecoForm'
 import { categoriesLieux, type Lieu as MockLieu } from '@/lib/mock-data'
 import { isSelectionHilmy } from '@/lib/permissions-lieux'
@@ -60,12 +62,16 @@ export function RecommandationDetail({
   heroPriceMode,
   currentUserId,
   myReco,
+  communityPhotos,
 }: {
   l: MockLieu
   row: Place
   recoViews: RecoView[]
   videoEntries: VideoEntry[]
   similaires: MockLieu[]
+  // Galerie communauté (vue anon-safe place_public_photos). Signalement DIRECT
+  // ici (connectée) → canReport=true.
+  communityPhotos: CommunityPhoto[]
   // Stats hero NATIVES Hilmy — lues depuis la MÊME source que la fiche
   // publique (vue place_public_detail) → valeur/format identiques à l'anon.
   heroRating: number | null
@@ -245,6 +251,17 @@ export function RecommandationDetail({
                         : 'aspect-square',
                     )}
                     ariaLabel={`${l.nom} en images`}
+                  />
+                </FadeInSection>
+              )}
+
+              {communityPhotos.length > 0 && (
+                <FadeInSection>
+                  <CommunityPhotosSection
+                    photos={communityPhotos}
+                    canReport
+                    loginHref=""
+                    placeName={l.nom}
                   />
                 </FadeInSection>
               )}

--- a/components/v2/RecommandationDetailPublic.tsx
+++ b/components/v2/RecommandationDetailPublic.tsx
@@ -7,6 +7,8 @@ import { categoriesLieux, type Lieu as MockLieu } from '@/lib/mock-data'
 import { isSelectionHilmy } from '@/lib/permissions-lieux'
 import { DIET_TAGS_MAP, dietTagLabel, recTagLabel } from '@/lib/constants'
 import { formatRating, copineWord } from '@/lib/reco-format'
+import { CommunityPhotosSection } from '@/components/v2/CommunityPhotosSection'
+import type { CommunityPhoto } from '@/components/v2/CommunityPhotos'
 import type {
   PublicPlaceDetail,
   PublicPlaceReco,
@@ -88,10 +90,14 @@ export function RecommandationDetailPublic({
   detail,
   recos,
   similaires,
+  communityPhotos,
 }: {
   detail: PublicPlaceDetail
   recos: PublicPlaceReco[]
   similaires: PublicPlaceDetail[]
+  // Galerie communauté (vue anon-safe place_public_photos). Signalement INDIRECT
+  // ici (anonyme) → canReport=false, le bouton renvoie vers l'inscription.
+  communityPhotos: CommunityPhoto[]
 }) {
   const photosArr = Array.isArray(detail.photos) ? detail.photos : []
   const coverUrl =
@@ -235,6 +241,17 @@ export function RecommandationDetailPublic({
                       />
                     ))}
                   </div>
+                </FadeInSection>
+              )}
+
+              {communityPhotos.length > 0 && (
+                <FadeInSection>
+                  <CommunityPhotosSection
+                    photos={communityPhotos}
+                    canReport={false}
+                    loginHref={signupHref}
+                    placeName={detail.name}
+                  />
                 </FadeInSection>
               )}
 

--- a/components/v2/ReportPhotoButton.tsx
+++ b/components/v2/ReportPhotoButton.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useState } from 'react'
+
+/**
+ * Bouton « Signaler » d'une photo communauté, posé dans la lightbox.
+ *
+ * Signalement RÉSERVÉ aux connectées (décision PR-c) :
+ *  - non connectée → lien vers la connexion (aucune action possible) ;
+ *  - connectée → POST /api/place-photos/[id]/report (gaté RLS user_id=auth.uid()).
+ *
+ * Un signalement ne masque RIEN : la photo reste publiée, il alimente la file
+ * de modération admin (modération a posteriori). L'UI ne fait que déclencher.
+ */
+export function ReportPhotoButton({
+  photoId,
+  canReport,
+  loginHref,
+}: {
+  photoId: string
+  canReport: boolean
+  loginHref: string
+}) {
+  const [open, setOpen] = useState(false)
+  const [reason, setReason] = useState('')
+  const [state, setState] = useState<'idle' | 'sending' | 'done' | 'error'>('idle')
+
+  // Non connectée : pas de signalement direct, on invite à se connecter.
+  if (!canReport) {
+    return (
+      <a
+        href={loginHref}
+        className="inline-flex items-center gap-1.5 rounded-full border border-or/40 bg-blanc/10 px-3 py-1.5 text-[11px] tracking-[0.18em] text-creme uppercase backdrop-blur transition-colors hover:border-or hover:bg-or/20"
+      >
+        Connecte-toi pour signaler
+      </a>
+    )
+  }
+
+  if (state === 'done') {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-or/40 bg-blanc/10 px-3 py-1.5 text-[11px] tracking-[0.18em] text-creme uppercase backdrop-blur">
+        Merci, c'est noté
+      </span>
+    )
+  }
+
+  const submit = async () => {
+    setState('sending')
+    try {
+      const res = await fetch(`/api/place-photos/${photoId}/report`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: reason.trim() || undefined }),
+      })
+      if (!res.ok) throw new Error('report failed')
+      setState('done')
+      setOpen(false)
+    } catch {
+      setState('error')
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setState('idle')
+          setOpen(true)
+        }}
+        className="inline-flex items-center gap-1.5 rounded-full border border-or/40 bg-blanc/10 px-3 py-1.5 text-[11px] tracking-[0.18em] text-creme uppercase backdrop-blur transition-colors hover:border-or hover:bg-or/20"
+      >
+        Signaler
+      </button>
+    )
+  }
+
+  return (
+    <div className="w-[min(86vw,340px)] rounded-sm border border-or/30 bg-vert/90 p-4 text-creme shadow-2xl backdrop-blur">
+      <p className="text-[13px] leading-[1.55]">
+        Signaler cette photo (visage d'un tiers, droit à l'image, contenu illicite) ?
+        Elle sera examinée par la modération.
+      </p>
+      <textarea
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        placeholder="Motif (facultatif)"
+        rows={2}
+        className="mt-3 w-full resize-none rounded-sm border border-or/30 bg-blanc/10 px-3 py-2 text-[13px] text-creme placeholder:text-creme/50 focus:border-or focus:outline-none"
+      />
+      {state === 'error' && (
+        <p className="mt-2 text-[12px] text-or-light">Échec de l'envoi, réessaie.</p>
+      )}
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          disabled={state === 'sending'}
+          className="rounded-full px-3 py-1.5 text-[11px] tracking-[0.18em] text-creme/80 uppercase transition-colors hover:text-creme disabled:opacity-60"
+        >
+          Annuler
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={state === 'sending'}
+          className="rounded-full border border-or/50 bg-or/20 px-3 py-1.5 text-[11px] tracking-[0.18em] text-creme uppercase transition-colors hover:bg-or/30 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {state === 'sending' ? 'Envoi…' : 'Signaler'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/lib/supabase/queries/places-public.ts
+++ b/lib/supabase/queries/places-public.ts
@@ -44,6 +44,25 @@ export type PublicPlaceReco = {
   created_at: string;
 };
 
+/**
+ * Photo communauté publique. AUCUN champ identitaire (pas de user_id, prenom,
+ * recommendation_id) — la vue place_public_photos ne les expose pas. photo_id
+ * sert de clé React + cible du signalement (id de ligne photo, non-perso).
+ */
+export type PublicPlacePhoto = {
+  photo_id: string;
+  url: string;
+  created_at: string;
+};
+
+type PublicPlacePhotoRow = {
+  photo_id: string;
+  storage_path: string;
+  created_at: string;
+};
+
+const PHOTO_SELECT = "photo_id, storage_path, created_at";
+
 const DETAIL_SELECT =
   "place_slug, name, hilmy_category, google_category, city, country, address, latitude, longitude, description, main_photo_url, photos, palier, google_place_id, avg_rating, nb_avis, nb_copines, price_mode";
 
@@ -76,6 +95,32 @@ export async function getPublicPlaceRecos(
     .order("created_at", { ascending: false });
   if (error || !data) return [];
   return data as unknown as PublicPlaceReco[];
+}
+
+/**
+ * Photos PUBLIQUES de la communauté pour un lieu (galerie agrégée, plus
+ * récentes d'abord). Lit UNIQUEMENT la vue anon-safe `place_public_photos`
+ * (status='published', source `place_user_photos` — JAMAIS l'array legacy
+ * `recommendations.photo_urls`). L'URL publique est calculée CÔTÉ SERVEUR
+ * depuis le storage_path → rendu SSR indexable, aucune identité exposée.
+ */
+export async function getPublicPlacePhotos(
+  slug: string
+): Promise<PublicPlacePhoto[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("place_public_photos")
+    .select(PHOTO_SELECT)
+    .eq("place_slug", slug)
+    .order("created_at", { ascending: false });
+  if (error || !data) return [];
+  return (data as unknown as PublicPlacePhotoRow[]).map((r) => ({
+    photo_id: r.photo_id,
+    created_at: r.created_at,
+    url: supabase.storage
+      .from("recommendation-photos")
+      .getPublicUrl(r.storage_path).data.publicUrl,
+  }));
 }
 
 /** Lieux similaires (même catégorie), pour le maillage interne SEO. */

--- a/supabase/migrations/67_place_public_photos.sql
+++ b/supabase/migrations/67_place_public_photos.sql
@@ -1,0 +1,52 @@
+-- =====================================================================
+-- HILMY · 67 — PR-c : photos des copines en PUBLIC (« robinet RGPD »).
+--               Vue anon-safe dédiée pour exposer les photos membres aux
+--               visiteurs anonymes (fiche /recommandation/[slug], SEO).
+--
+-- POURQUOI UNE VUE DÉDIÉE SECURITY DEFINER (security_invoker=false)
+-- `place_user_photos` n'a AUCUNE policy RLS pour anon → anon lit 0 ligne en
+-- direct (vérifié prod). Cette vue tourne avec les droits du propriétaire
+-- (bypass RLS) et n'expose QUE des colonnes non-identitaires.
+--
+-- ⚠️ VUE EXPOSÉE À ANON — toute colonne du SELECT devient PUBLIQUE et
+-- indexable Google. Interdits ABSOLUS (réidentifient une photographe) :
+--   user_id, recommendation_id (corrèle à une reco anonymisée → réidentif),
+--   moderation_motif, moderated_at, prenom, avatar.
+-- photo_id = id de la LIGNE photo (clé React + cible du signalement),
+--   PAS une identité — même statut public que reco_id (vue 64).
+--
+-- VERROUS :
+--   * status = 'published' UNIQUEMENT  → flagged / removed JAMAIS publics.
+--   * Source = place_user_photos UNIQUEMENT → JAMAIS l'array legacy
+--     recommendations.photo_urls (règle d'or du chantier photos).
+--   * Clé publique = slug, jamais d'uuid de lieu.
+--
+-- Idempotent (CREATE OR REPLACE). Rollback : 67_..._rollback.sql.
+-- =====================================================================
+
+-- ─── Vue : photos publiées d'un lieu (1 ligne / photo published) ──────────
+-- Galerie agrégée par lieu, DÉTACHÉE des commentaires (pas de
+-- recommendation_id) → casse toute corrélation photo↔texte→identité.
+create or replace view public.place_public_photos
+with (security_invoker = false) as
+select
+  pup.id           as photo_id,      -- clé React + cible signalement (non-perso)
+  p.slug           as place_slug,    -- jointure publique, aucun uuid de lieu
+  pup.storage_path as storage_path,  -- chemin SANS user_id (PR-b) ; URL calculée serveur
+  pup.created_at   as created_at     -- tri (plus récentes d'abord)
+from public.place_user_photos pup
+join public.places p on p.id = pup.place_id
+where pup.status = 'published'       -- flagged / removed exclus structurellement
+  and p.slug is not null;
+
+-- ─── Grants : strictement SELECT (Supabase accorde tout par défaut) ───────
+revoke all on public.place_public_photos from public, anon, authenticated;
+grant select on public.place_public_photos to anon, authenticated, service_role;
+
+-- ─── Comment de garde (visible dans pg_views.viewdef) ─────────────────────
+comment on view public.place_public_photos is
+  '⚠️ Vue SECURITY DEFINER (security_invoker=false) — exposée à anon (galerie photos communauté de la fiche publique, SEO). 1 ligne par photo place_user_photos status=published. Colonnes : photo_id (clé React + cible signalement), place_slug (jointure), storage_path (chemin sans user_id, URL calculée serveur), created_at. Source = place_user_photos UNIQUEMENT (jamais recommendations.photo_urls legacy). Ne JAMAIS ajouter user_id, recommendation_id, moderation_motif, moderated_at, prenom, avatar. Seules les published sortent.';
+
+-- =====================================================================
+-- ROLLBACK : voir supabase/migrations/67_place_public_photos_rollback.sql
+-- =====================================================================

--- a/supabase/migrations/67_place_public_photos_rollback.sql
+++ b/supabase/migrations/67_place_public_photos_rollback.sql
@@ -1,0 +1,6 @@
+-- =====================================================================
+-- HILMY · 67 ROLLBACK — supprime la vue publique des photos communauté.
+-- Ne touche NI place_user_photos NI les policies (PR-b intacte).
+-- =====================================================================
+
+drop view if exists public.place_public_photos;

--- a/supabase/migrations/68_content_reports_place_photo.sql
+++ b/supabase/migrations/68_content_reports_place_photo.sql
@@ -1,0 +1,24 @@
+-- =====================================================================
+-- HILMY · 68 — PR-c : autorise le signalement des photos communauté.
+--
+-- La table générique `content_reports` portait un CHECK qui n'acceptait
+-- que target_type ∈ {place, event, recommendation}. PR-c ajoute le
+-- signalement des photos membres (route /api/place-photos/[id]/report,
+-- target_type='place_photo') → on étend le CHECK, sans rien casser des
+-- valeurs existantes.
+--
+-- AUCUNE donnée touchée : on remplace seulement la contrainte. Les lignes
+-- existantes (place/event/recommendation) restent valides.
+-- Idempotent : DROP IF EXISTS puis ADD. Rollback : 68_..._rollback.sql.
+-- =====================================================================
+
+alter table public.content_reports
+  drop constraint if exists content_reports_target_type_check;
+
+alter table public.content_reports
+  add constraint content_reports_target_type_check
+  check (target_type = any (array['place', 'event', 'recommendation', 'place_photo']));
+
+-- =====================================================================
+-- ROLLBACK : voir supabase/migrations/68_content_reports_place_photo_rollback.sql
+-- =====================================================================

--- a/supabase/migrations/68_content_reports_place_photo_rollback.sql
+++ b/supabase/migrations/68_content_reports_place_photo_rollback.sql
@@ -1,0 +1,12 @@
+-- =====================================================================
+-- HILMY · 68 ROLLBACK — revient au CHECK sans 'place_photo'.
+-- ⚠️ À n'exécuter QUE si aucune ligne place_photo n'existe (sinon le ADD
+--    échoue : des lignes violeraient la contrainte restaurée).
+-- =====================================================================
+
+alter table public.content_reports
+  drop constraint if exists content_reports_target_type_check;
+
+alter table public.content_reports
+  add constraint content_reports_target_type_check
+  check (target_type = any (array['place', 'event', 'recommendation']));


### PR DESCRIPTION
## Résumé — le « robinet RGPD » (PR-c)

Dernier morceau du chantier photos : rendre visibles aux **visiteurs anonymes** (et indexables Google) les photos partagées par les membres, **sans jamais exposer une identité**.

- **Vue anon-safe `place_public_photos`** (mig 67, SECURITY DEFINER) : expose **exactement 4 colonnes non-identitaires** — `photo_id`, `place_slug`, `storage_path`, `created_at`. Jamais `user_id`, `recommendation_id`, `prenom`, `moderation_motif`, `moderated_at`. `status='published'` uniquement → flagged/removed exclus structurellement. Source = `place_user_photos` **uniquement**, jamais l'array legacy `recommendations.photo_urls` (règle d'or).
- **Galerie agrégée** sur la fiche connectée ET publique, **détachée des commentaires** (aucun `recommendation_id` → casse la réidentification photo↔texte→autrice), réutilisant la lightbox partagée. Rendu **SSR** → photos indexables.
- **Signalement connecté-only** (décision produit) : `content_reports` (`target_type='place_photo'`, autorisé par mig 68). La photo **reste publiée** — un signalement ne masque rien, l'admin décide. Anonyme → lien vers l'inscription.
- **Admin** : nouvelle file « Signalées par la communauté » dans `/admin/photos-a-moderer?status=community` (Retirer la photo / Marquer traité) + badge dans le layout.
- **Mention légale** sous la galerie : Hilmy hébergeur, modération a posteriori, voie de signalement.

## Preuves zéro-fuite (avant merge)
- `pg_get_viewdef` : 4 colonnes, `published` only, anon SELECT-only.
- Test transactionnel published/flagged/removed : seule la `published` apparaît dans la vue, ROLLBACK propre.
- REST anon : vue lisible (200), `select=user_id` → `400 colonne inexistante`, table source → `[]` (RLS, pas de bypass).

## Migrations
- `67_place_public_photos.sql` (+ rollback) — **déjà appliquée** en prod.
- `68_content_reports_place_photo.sql` (+ rollback) — **déjà appliquée** (CHECK étendu à `place_photo`, dry-run BEGIN/ROLLBACK validé).

## Test plan
- [ ] Anonyme : fiche d'un lieu avec photos publiées → galerie visible, lightbox OK, **aucun prénom/identité**, bouton « Connecte-toi pour signaler ».
- [ ] Connectée : galerie visible + bouton « Signaler » dans la lightbox → apparaît dans `/admin/photos-a-moderer?status=community`.
- [ ] Admin : « Retirer la photo » → disparaît de la fiche publique ; « Marquer traité » → sort de la file.
- [ ] `curl` anon post-deploy : photos présentes, identité absente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)