### PR TITLE
copy(photos): mention légale galerie communauté — retrait si illicite

### DIFF
--- a/components/v2/CommunityPhotosSection.tsx
+++ b/components/v2/CommunityPhotosSection.tsx
@@ -50,13 +50,15 @@ export function CommunityPhotosSection({
         />
       </div>
 
-      {/* Mention légale — Hilmy hébergeur, modération a posteriori, signalement. */}
+      {/* Mention légale — Hilmy hébergeur, modération a posteriori, retrait SI
+          illicite (formulation validée, le « si elle est illicite » est gardé
+          mot pour mot pour sa portée juridique). */}
       <p className="mt-4 text-[12px] leading-[1.6] text-texte-sec">
-        Photos partagées par les membres de la communauté. Hilmy héberge ces
-        contenus, modérés a posteriori : ils n&apos;engagent que leurs autrices.
-        Un contenu te semble inapproprié (visage d&apos;un tiers, droit à
-        l&apos;image, contenu illicite)&nbsp;? Signale-le, il sera examiné et
-        retiré le cas échéant.
+        Ces photos sont partagées par les copines de la communauté, qui en sont
+        responsables. Hilmy les héberge et les modère a posteriori. Une photo te
+        semble problématique — visage d&apos;un tiers, droit à l&apos;image,
+        contenu illicite&nbsp;? Signale-la&nbsp;: on l&apos;examine et on la
+        retire si elle est illicite.
       </p>
     </section>
   )


### PR DESCRIPTION
## Résumé
Remplace la mention légale sous la galerie communauté (PR-c) par la formulation validée (ton Hilmy + protections juridiques).

Texte exact en prod :
> Ces photos sont partagées par les copines de la communauté, qui en sont responsables. Hilmy les héberge et les modère a posteriori. Une photo te semble problématique — visage d'un tiers, droit à l'image, contenu illicite ? Signale-la : on l'examine et **on la retire si elle est illicite**.

Le « on la retire **si elle est illicite** » est conservé mot pour mot pour sa portée juridique (retrait conditionné, Hilmy hébergeur).

## Test plan
- [ ] La mention s'affiche sous la galerie communauté, fiche connectée ET publique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)