### PR TITLE
feat: téléphone + horaires membres (Google live à la demande)

### DIFF
--- a/app/api/places/[id]/contact/route.ts
+++ b/app/api/places/[id]/contact/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getPlaceContactLive } from "@/lib/google/places";
+import { enforceRateLimit } from "@/lib/rate-limit";
+
+/**
+ * GET /api/places/[id]/contact — téléphone + horaires LIVE d'un lieu.
+ *
+ * RÉSERVÉ AUX MEMBRES CONNECTÉES (verrou coût + cohérence : anonyme = QUOI,
+ * membre = COMMENT). Ordre IMPÉRATIF :
+ *   1. session vérifiée → pas de session = 401 AVANT tout appel Google
+ *      (aucune fuite de donnée, aucun coût déclenché) ;
+ *   2. [id] = UUID INTERNE du lieu → on lit son google_place_id en base (un
+ *      membre ne peut donc interroger que de vrais lieux Hilmy, pas un place_id
+ *      Google arbitraire) ;
+ *   3. appel Google live (field mask minimal phone+horaires, cache perf 6 h).
+ *
+ * AUCUN stockage : la donnée transite Google → route → client. Rien en base.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  // Garde-fou anti-abus (compte connecté qui spammerait la route).
+  const limited = enforceRateLimit(request, {
+    tag: "places-contact",
+    max: 30,
+    windowMs: 60 * 1000,
+  });
+  if (limited) return limited;
+
+  // 1. VERROU session — AVANT tout appel Google.
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Non authentifiée" }, { status: 401 });
+  }
+
+  // 2. Résolution google_place_id depuis l'UUID interne (read RLS-safe).
+  const { id } = await params;
+  const { data: place } = await supabase
+    .from("places")
+    .select("google_place_id")
+    .eq("id", id)
+    .maybeSingle();
+
+  const googlePlaceId = (place as { google_place_id: string | null } | null)
+    ?.google_place_id;
+  if (!googlePlaceId) {
+    return NextResponse.json(
+      { error: "Lieu sans identifiant Google" },
+      { status: 404 },
+    );
+  }
+
+  // 3. Appel Google live (minimal + caché 6 h).
+  try {
+    const contact = await getPlaceContactLive(googlePlaceId);
+    if (!contact) {
+      return NextResponse.json({ error: "Lieu introuvable" }, { status: 404 });
+    }
+    return NextResponse.json({ contact });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Erreur inconnue";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/components/v2/PlaceLiveInfo.tsx
+++ b/components/v2/PlaceLiveInfo.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useState } from 'react'
+
+type Contact = {
+  phone: string | null
+  opening_hours: string[] | null
+}
+
+/**
+ * Téléphone + horaires d'un lieu, À LA DEMANDE (Google live).
+ *
+ * Rendu UNIQUEMENT dans la fiche connectée (RecommandationDetail) → invisible
+ * en anonyme par construction. RIEN ne part au chargement : l'appel Google ne
+ * se déclenche QUE si la membre clique le bouton (protection coût). La donnée
+ * n'est ni stockée ni mise en cache durablement — elle vit dans ce composant
+ * le temps de la session de page. Un re-clic ne rappelle pas (déjà chargé).
+ */
+export function PlaceLiveInfo({ placeId }: { placeId: string }) {
+  const [status, setStatus] = useState<'idle' | 'loading' | 'loaded' | 'error'>(
+    'idle',
+  )
+  const [contact, setContact] = useState<Contact | null>(null)
+
+  const load = async () => {
+    if (status === 'loading' || status === 'loaded') return // pas de rappel
+    setStatus('loading')
+    try {
+      const res = await fetch(`/api/places/${placeId}/contact`)
+      if (!res.ok) throw new Error('contact failed')
+      const body = (await res.json()) as { contact: Contact }
+      setContact(body.contact)
+      setStatus('loaded')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  if (status === 'idle' || status === 'loading') {
+    return (
+      <button
+        type="button"
+        onClick={load}
+        disabled={status === 'loading'}
+        className="mt-5 inline-flex h-11 w-full items-center justify-center gap-2 rounded-full border border-or/40 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-or hover:bg-blanc disabled:opacity-60"
+      >
+        {status === 'loading' ? 'Chargement…' : 'Voir horaires & téléphone'}
+        {status !== 'loading' && (
+          <span className="text-or" aria-hidden="true">
+            →
+          </span>
+        )}
+      </button>
+    )
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="mt-5">
+        <p className="text-[12px] text-red-900">
+          Impossible de récupérer les infos pour l&apos;instant.
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            setStatus('idle')
+          }}
+          className="mt-2 text-[11px] tracking-[0.18em] text-or uppercase hover:text-or-deep"
+        >
+          Réessayer
+        </button>
+      </div>
+    )
+  }
+
+  // loaded
+  const hours = contact?.opening_hours ?? []
+  const phone = contact?.phone ?? null
+
+  return (
+    <div className="mt-5 space-y-4">
+      {hours.length > 0 ? (
+        <div>
+          <p className="overline text-or">Horaires</p>
+          <ul className="mt-2 space-y-1">
+            {hours.map((line, i) => (
+              <li key={i} className="text-[13px] leading-[1.5] text-vert">
+                {line}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <p className="text-[12px] text-texte-sec">Horaires non communiqués.</p>
+      )}
+
+      {phone && (
+        <div>
+          <p className="overline text-or">Téléphone</p>
+          <a
+            href={`tel:${phone.replace(/\s+/g, '')}`}
+            className="mt-2 inline-flex text-[14px] font-medium text-vert underline decoration-or/40 underline-offset-4 transition-colors hover:decoration-or"
+          >
+            {phone}
+          </a>
+        </div>
+      )}
+
+      {/* Attribution Google requise par les CGU pour l'affichage hors carte. */}
+      <p className="text-[10px] tracking-[0.18em] text-texte-sec uppercase">
+        Source : Google
+      </p>
+    </div>
+  )
+}

--- a/components/v2/RecommandationDetail.tsx
+++ b/components/v2/RecommandationDetail.tsx
@@ -12,6 +12,7 @@ import { AddRecoModal } from '@/components/v2/AddRecoModal'
 import { PhotoGallery } from '@/components/v2/PhotoGallery'
 import { CommunityPhotosSection } from '@/components/v2/CommunityPhotosSection'
 import type { CommunityPhoto } from '@/components/v2/CommunityPhotos'
+import { PlaceLiveInfo } from '@/components/v2/PlaceLiveInfo'
 import type { ExistingReco } from '@/components/v2/RecoForm'
 import { categoriesLieux, type Lieu as MockLieu } from '@/lib/mock-data'
 import { isSelectionHilmy } from '@/lib/permissions-lieux'
@@ -417,6 +418,9 @@ export function RecommandationDetail({
                     →
                   </span>
                 </PlaceContactLink>
+                {/* Téléphone + horaires LIVE, à la demande (membre connectée).
+                    Rien ne part tant que la membre n'a pas cliqué. */}
+                <PlaceLiveInfo placeId={row.id} />
                 <div className="mt-3 flex flex-col gap-3">
                   <AddRecoModal
                     userId={currentUserId}

--- a/lib/google/places.ts
+++ b/lib/google/places.ts
@@ -199,6 +199,57 @@ export async function getPlaceDetails(
   };
 }
 
+/**
+ * Contact LIVE d'un lieu (téléphone + horaires) — réservé aux membres.
+ *
+ * Field mask MINIMAL (`internationalPhoneNumber,regularOpeningHours`) → on ne
+ * tire QUE ces deux champs, jamais photos/rating/atmosphere. SKU Place Details
+ * (Enterprise), payload réduit. La clé reste dans le header (jamais en URL).
+ *
+ * Cache de PERFORMANCE 6 h (Data Cache Next, `revalidate`) keyé par l'URL donc
+ * par place_id : si plusieurs membres regardent le même lieu dans la journée,
+ * 1 seul appel Google. Conforme CGU (cache temporaire < 30 j ; AUCUN stockage
+ * durable en base). La donnée renvoyée est non-personnelle (donnée lieu).
+ */
+export type PlaceContactLive = {
+  phone: string | null;
+  opening_hours: string[] | null;
+};
+
+const CONTACT_FIELD_MASK = "internationalPhoneNumber,regularOpeningHours";
+const CONTACT_CACHE_SECONDS = 6 * 60 * 60; // 6 h
+
+export async function getPlaceContactLive(
+  placeId: string,
+): Promise<PlaceContactLive | null> {
+  if (!placeId) return null;
+  const apiKey = getApiKey();
+
+  const res = await fetch(
+    `${PLACES_BASE}/places/${encodeURIComponent(placeId)}?languageCode=fr`,
+    {
+      method: "GET",
+      headers: {
+        "X-Goog-Api-Key": apiKey,
+        "X-Goog-FieldMask": CONTACT_FIELD_MASK,
+      },
+      // Cache partagé entre membres (donnée lieu, non perso). Le verrou session
+      // est en amont dans la route → l'anonyme n'atteint jamais ce fetch.
+      next: { revalidate: CONTACT_CACHE_SECONDS },
+    },
+  );
+
+  if (!res.ok) return null;
+  const p = (await res.json()) as {
+    internationalPhoneNumber?: string;
+    regularOpeningHours?: { weekdayDescriptions?: string[] };
+  };
+  return {
+    phone: p.internationalPhoneNumber ?? null,
+    opening_hours: p.regularOpeningHours?.weekdayDescriptions ?? null,
+  };
+}
+
 // Domaine canonique de prod. `hilmy.io` redirige 307 vers `www.hilmy.io` :
 // on stocke directement le www pour éviter un hop de redirect à chaque
 // chargement d'image (mobile expo-image + web <img>). NE PAS utiliser


### PR DESCRIPTION
## Résumé
- Bloc **téléphone + horaires** sur la fiche, **réservé aux membres connectées**, en **Google live à la demande** : rien ne part au chargement, l'appel Google ne se déclenche QUE sur clic du bouton « Voir horaires & téléphone » (1 clic = 1 appel pour les deux infos).
- **Verrou 401** : la route `/api/places/[id]/contact` vérifie la session AVANT tout appel Google. Un anonyme reçoit `401 Non authentifiée` sans aucune fuite ni coût déclenché.
- **Zéro stockage** : la donnée transite Google → route → client. Rien en base. Cache de performance 6 h (Data Cache Next, keyé par place_id) conforme CGU. Attribution « Source : Google » sous le bloc.
- `[id]` = UUID interne → `google_place_id` résolu côté serveur (un membre ne peut pas interroger un place_id Google arbitraire). Field mask minimal `internationalPhoneNumber,regularOpeningHours`.

## Preuve verrou 401 (curl anonyme, UUID bidon)
\`\`\`
$ curl -i .../api/places/00000000-0000-0000-0000-000000000000/contact
HTTP/1.1 401 Unauthorized
{"error":"Non authentifiée"}
\`\`\`
La session répond avant la résolution google_place_id et avant tout appel Google.

## Zéro régression
- `PlaceLiveInfo` rendu uniquement dans la branche connectée (`RecommandationDetail`), invisible en anonyme par construction.
- Rendu anonyme, chantier photos (PR #117/#118) intacts.

## Recette de test connectée (à dérouler après déploiement)
- [ ] Cliquer « Voir horaires & téléphone » → horaires + téléphone s'affichent
- [ ] Re-cliquer → pas de nouvel appel (déjà chargé)
- [ ] Anonyme : le bloc n'apparaît pas

🤖 Generated with [Claude Code](https://claude.com/claude-code)