### PR TITLE
feat: teaser verrouillé horaires + téléphone (rendu public)

### DIFF
--- a/components/v2/RecommandationDetailPublic.tsx
+++ b/components/v2/RecommandationDetailPublic.tsx
@@ -375,6 +375,44 @@ export function RecommandationDetailPublic({
                     →
                   </span>
                 </a>
+
+                {/* Teaser verrouillé horaires + téléphone (rendu ANONYME).
+                    100% statique : aucun fetch, aucune interactivité — juste un
+                    lien vers l'inscription. Le vrai bloc fonctionnel
+                    (PlaceLiveInfo, appel Google au clic) reste connecté-only.
+                    Aucun appel à /api/places/[id]/contact n'est possible d'ici. */}
+                <div className="mt-6 border-t border-or/20 pt-6">
+                  <div className="flex items-center gap-2">
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="text-or"
+                      aria-hidden="true"
+                    >
+                      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                    </svg>
+                    <p className="overline text-or">Horaires &amp; téléphone</p>
+                  </div>
+                  <p className="mt-3 text-[12px] leading-[1.6] text-texte-sec">
+                    Réservés aux membres Hilmy.
+                  </p>
+                  <Link
+                    href={signupHref}
+                    className="mt-5 inline-flex h-11 w-full items-center justify-center gap-2 rounded-full border border-or/40 text-[11px] font-medium tracking-[0.22em] text-vert uppercase transition-all hover:border-or hover:bg-blanc"
+                  >
+                    Connecte-toi pour voir les horaires et appeler
+                    <span className="text-or" aria-hidden="true">
+                      →
+                    </span>
+                  </Link>
+                </div>
               </div>
 
               {detail.nb_copines > 0 && (


### PR DESCRIPTION
## Résumé
Sur le rendu **anonyme** (`RecommandationDetailPublic`), ajout d'un **teaser verrouillé** dans la carte « Où c'est », au même emplacement que le vrai bloc côté connecté : cadenas + « Horaires & téléphone — Réservés aux membres Hilmy » + lien **« Connecte-toi pour voir les horaires et appeler → »** vers l'inscription (`signupHref`, redirect retour fiche).

## Verrous (non négociables)
- **100% statique** : le teaser est un simple `<Link>`. Aucun `onClick`, aucun `fetch`, aucun état → **aucun appel possible** à `/api/places/[id]/contact`. Le clic ne fait que naviguer vers `/auth/signup`.
- **Côté connecté inchangé** : `PlaceLiveInfo` (bouton + appel Google au clic) et la route gatée 401 ne sont PAS touchés.
- **Un seul fichier** : `components/v2/RecommandationDetailPublic.tsx`.

## Preuve zéro-appel (grep sur le composant public)
\`\`\`
$ grep -nE "fetch|PlaceLiveInfo|/contact|api/places" components/v2/RecommandationDetailPublic.tsx
# → uniquement le commentaire explicatif, aucun appel réel
\`\`\`

## Zéro régression
Rendu connecté (vrai bloc fonctionnel), chantier photos (#117/#118), feature live (#119) intacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)