### PR TITLE
feat(onboarding): activer Google Places + scaffold Instagram dormant + nettoyage grille méthodes

### DIFF
--- a/app/api/onboarding/instagram/callback/route.ts
+++ b/app/api/onboarding/instagram/callback/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getSessionUser } from "@/lib/supabase/session";
+import {
+  isInstagramConfigured,
+  exchangeCodeForToken,
+  fetchInstagramImport,
+} from "@/lib/instagram/config";
+
+const INSTAGRAM_PAGE = "/onboarding/prestataire/instagram";
+
+/**
+ * Callback OAuth Instagram. DORMANT tant que l'app Meta n'est pas validée.
+ *
+ * Étapes : vérifie le state anti-CSRF → échange le code contre un token →
+ * récupère username/bio/photo + 6 posts → stocke le résultat dans un cookie
+ * httpOnly court (`ig_import`) pour pré-remplir la preview côté page.
+ *
+ * TODO (à brancher quand l'app Meta sera live) : transformer cette preview en
+ * insert `profiles` (source_import='instagram', status='pending'), sur le même
+ * modèle que la voie Google Places (app/onboarding/prestataire/google).
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const origin = url.origin;
+  const back = (reason: string) =>
+    NextResponse.redirect(`${origin}${INSTAGRAM_PAGE}?error=${reason}`);
+
+  const user = await getSessionUser();
+  if (!user) {
+    return NextResponse.redirect(
+      `${origin}/auth/login?next=${encodeURIComponent(INSTAGRAM_PAGE)}`,
+    );
+  }
+  if (!isInstagramConfigured()) return back("not_configured");
+
+  // Meta renvoie error_reason si la prestataire refuse l'autorisation.
+  if (url.searchParams.get("error")) return back("denied");
+
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const cookieStore = await cookies();
+  const expectedState = cookieStore.get("ig_oauth_state")?.value;
+
+  if (!code || !state || !expectedState || state !== expectedState) {
+    return back("bad_state");
+  }
+
+  const token = await exchangeCodeForToken(code);
+  if (!token) return back("token_failed");
+
+  const imported = await fetchInstagramImport(token.access_token);
+  if (!imported) return back("fetch_failed");
+
+  // On stocke la preview (pas le token) dans un cookie httpOnly court. Le token
+  // n'est jamais persisté : une fois les données lues, il n'est plus utile.
+  const res = NextResponse.redirect(`${origin}${INSTAGRAM_PAGE}?connected=1`);
+  res.cookies.delete("ig_oauth_state");
+  res.cookies.set("ig_import", JSON.stringify(imported), {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 15 * 60, // 15 min : le temps de relire/valider la preview
+  });
+  return res;
+}

--- a/app/api/onboarding/instagram/start/route.ts
+++ b/app/api/onboarding/instagram/start/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { getSessionUser } from "@/lib/supabase/session";
+import {
+  isInstagramConfigured,
+  instagramAuthorizeUrl,
+} from "@/lib/instagram/config";
+
+const INSTAGRAM_PAGE = "/onboarding/prestataire/instagram";
+
+/**
+ * Démarre le flux OAuth Instagram (voie officielle). DORMANT : si l'app Meta
+ * n'est pas branchée, on renvoie la prestataire vers la page d'onboarding avec
+ * un message "non configuré" — aucune erreur dure.
+ *
+ * On exige une session : l'import sert à pré-remplir SA fiche prestataire.
+ */
+export async function GET(request: Request) {
+  const origin = new URL(request.url).origin;
+
+  // Pas connectée → login, puis retour ici.
+  const user = await getSessionUser();
+  if (!user) {
+    return NextResponse.redirect(
+      `${origin}/auth/login?next=${encodeURIComponent(INSTAGRAM_PAGE)}`,
+    );
+  }
+
+  // App Meta pas encore validée / clés absentes → feature OFF.
+  if (!isInstagramConfigured()) {
+    return NextResponse.redirect(`${origin}${INSTAGRAM_PAGE}?error=not_configured`);
+  }
+
+  // Anti-CSRF : state aléatoire posé en cookie httpOnly, revérifié au callback.
+  const state = randomUUID();
+  const res = NextResponse.redirect(instagramAuthorizeUrl(state));
+  res.cookies.set("ig_oauth_state", state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 10 * 60, // 10 min : le temps de l'autorisation
+  });
+  return res;
+}

--- a/app/onboarding/prestataire/google/page.tsx
+++ b/app/onboarding/prestataire/google/page.tsx
@@ -39,6 +39,37 @@ function slugify(s: string) {
     .slice(0, 60)
 }
 
+// Google renvoie `opening_hours` (regularOpeningHours.weekdayDescriptions) sous
+// forme de lignes humaines en français, ordonnées du lundi au dimanche, ex.
+// "lundi: 09:00 – 19:00". La fiche publique attend `profiles.horaires` au format
+// { monday: "09:00 – 19:00", ... } (cf. formatHoraires dans la fiche publique).
+// On convertit en retirant le préfixe jour (avant le premier ":") et en mappant
+// par index sur les clés anglaises. La prestataire pourra corriger ensuite.
+const HORAIRES_KEYS = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+] as const
+
+function googleHoursToHoraires(
+  descriptions: string[] | null,
+): Record<string, string> | null {
+  if (!descriptions || descriptions.length === 0) return null
+  const out: Record<string, string> = {}
+  descriptions.slice(0, 7).forEach((line, i) => {
+    const key = HORAIRES_KEYS[i]
+    if (!key) return
+    const sep = line.indexOf(':')
+    const value = (sep >= 0 ? line.slice(sep + 1) : line).trim()
+    if (value) out[key] = value
+  })
+  return Object.keys(out).length > 0 ? out : null
+}
+
 function guessCategorie(googleType: string | null): string {
   if (!googleType) return 'beaute'
   const t = googleType.toLowerCase()
@@ -168,6 +199,7 @@ export default function GoogleOnboardingPage() {
       description: description.trim() || null,
       copine_discount_pct: copineDiscountPct,
       copine_discount_note: copineDiscountNote.trim() || null,
+      horaires: googleHoursToHoraires(details.opening_hours),
       galerie: details.photos,
       photos: details.photos,
       services: [],
@@ -333,6 +365,21 @@ export default function GoogleOnboardingPage() {
                             className="aspect-square w-full rounded-sm object-cover"
                           />
                         ))}
+                      </div>
+                    )}
+                    {details.opening_hours && details.opening_hours.length > 0 && (
+                      <div className="mt-6 border-t border-or/10 pt-5">
+                        <p className="overline text-or">Horaires importés</p>
+                        <ul className="mt-3 space-y-1">
+                          {details.opening_hours.map((line, i) => (
+                            <li key={i} className="text-[13px] text-texte-sec">
+                              {line}
+                            </li>
+                          ))}
+                        </ul>
+                        <p className="mt-3 text-[11px] text-texte-sec/80">
+                          Tu pourras les ajuster depuis ton tableau de bord.
+                        </p>
                       </div>
                     )}
                   </div>

--- a/app/onboarding/prestataire/instagram/page.tsx
+++ b/app/onboarding/prestataire/instagram/page.tsx
@@ -1,11 +1,13 @@
-'use client'
-
-import Link from 'next/link'
-import { motion } from 'motion/react'
+import Link from "next/link";
+import { cookies } from "next/headers";
 import {
   OnboardingShell,
   OnboardingHeader,
-} from '@/components/onboarding/OnboardingShell'
+} from "@/components/onboarding/OnboardingShell";
+import {
+  isInstagramConfigured,
+  type InstagramImport,
+} from "@/lib/instagram/config";
 
 function InstagramIcon() {
   return (
@@ -25,78 +27,221 @@ function InstagramIcon() {
       <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
       <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" />
     </svg>
-  )
+  );
 }
 
-export default function InstagramOnboardingPage() {
+function readImport(raw: string | undefined): InstagramImport | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as InstagramImport;
+  } catch {
+    return null;
+  }
+}
+
+export default async function InstagramOnboardingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ connected?: string; error?: string }>;
+}) {
+  const { connected, error } = await searchParams;
+  const configured = isInstagramConfigured();
+  const cookieStore = await cookies();
+  const imported =
+    connected === "1" ? readImport(cookieStore.get("ig_import")?.value) : null;
+
   return (
     <OnboardingShell step={2} totalSteps={3} backLabel="Changer de méthode">
       <section className="bg-creme pt-16 pb-20 md:pt-24 md:pb-28">
         <div className="mx-auto max-w-3xl px-6 md:px-20">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.7 }}
-          >
-            <OnboardingHeader
-              number="03"
-              kicker="DEPUIS INSTAGRAM"
-              title={
+          <OnboardingHeader
+            number="03"
+            kicker="DEPUIS INSTAGRAM"
+            title={
+              imported ? (
                 <>
-                  Bientôt,{' '}
+                  Compte connecté,{" "}
+                  <em className="font-serif italic text-or">on a tout.</em>
+                </>
+              ) : configured ? (
+                <>
+                  Ta vitrine,{" "}
+                  <em className="font-serif italic text-or">importée.</em>
+                </>
+              ) : (
+                <>
+                  Bientôt,{" "}
                   <em className="font-serif italic text-or">promis.</em>
                 </>
-              }
-              subtitle={
+              )
+            }
+            subtitle={
+              imported ? (
+                <>
+                  Voici ta bio, ta photo et tes six derniers posts. Tu pourras
+                  tout corriger avant de publier.
+                </>
+              ) : configured ? (
+                <>
+                  Connecte ton compte Business ou Creator : on récupère ta bio,
+                  ta photo de profil et tes six derniers posts pour ta galerie.
+                </>
+              ) : (
                 <>
                   L&apos;import depuis un compte Business ou Creator arrivera
-                  dans la prochaine version. En attendant, le remplissage
-                  manuel prend 8 minutes.
+                  dans la prochaine version. En attendant, le remplissage manuel
+                  prend 8 minutes.
                 </>
-              }
-            />
-          </motion.div>
+              )
+            }
+          />
 
-          <motion.div
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.2 }}
-            className="mt-12 rounded-sm border border-or/20 bg-blanc p-10 text-center md:p-14"
-          >
-            <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-or/10">
-              <InstagramIcon />
+          {error && (
+            <div className="mt-8 rounded-sm border border-red-900/20 bg-red-900/5 px-4 py-3 text-[13px] text-red-900">
+              {error === "denied"
+                ? "Connexion annulée. Tu peux réessayer ou remplir ta fiche à la main."
+                : "La connexion Instagram n'a pas abouti. Réessaie dans un instant."}
             </div>
-            <p className="mt-6 font-serif text-3xl font-light text-vert">
-              🚧 En préparation
-            </p>
-            <p className="mt-4 text-[14px] leading-[1.7] text-texte-sec">
-              On finalise l&apos;intégration avec Meta pour récupérer ta bio,
-              ton avatar et tes derniers posts. Tu pourras créer ta fiche en
-              2 minutes.
-            </p>
-            <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
-              <Link
-                href="/onboarding/prestataire/manuel"
-                className="group inline-flex h-12 items-center gap-2 rounded-full bg-vert px-7 text-[12px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
-              >
-                Remplir manuellement
-                <span
-                  className="text-or-light transition-transform group-hover:translate-x-1"
-                  aria-hidden="true"
+          )}
+
+          {/* État 3 : compte connecté → preview de ce qu'on a récupéré. */}
+          {imported ? (
+            <div className="mt-10 space-y-6">
+              <div className="rounded-sm border border-or/20 bg-blanc p-8 md:p-10">
+                <div className="flex items-center gap-4">
+                  {imported.profile_picture_url && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={imported.profile_picture_url}
+                      alt={imported.username}
+                      className="h-16 w-16 rounded-full object-cover"
+                    />
+                  )}
+                  <div>
+                    <p className="font-serif text-2xl font-light text-vert">
+                      @{imported.username}
+                    </p>
+                    {imported.biography && (
+                      <p className="mt-1 text-[13px] text-texte-sec">
+                        {imported.biography}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                {imported.posts.length > 0 && (
+                  <div className="mt-6 grid grid-cols-3 gap-2">
+                    {imported.posts.map((p) =>
+                      p.media_url ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          key={p.id}
+                          src={p.media_url}
+                          alt=""
+                          className="aspect-square w-full rounded-sm object-cover"
+                        />
+                      ) : null,
+                    )}
+                  </div>
+                )}
+              </div>
+              <p className="text-center text-[12px] italic text-texte-sec">
+                La publication de la fiche depuis Instagram s&apos;activera à la
+                sortie de l&apos;app — d&apos;ici là, finalise via le remplissage
+                manuel.
+              </p>
+              <div className="flex justify-center">
+                <Link
+                  href="/onboarding/prestataire/manuel"
+                  className="group inline-flex h-12 items-center gap-2 rounded-full bg-vert px-7 text-[12px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
                 >
-                  →
-                </span>
-              </Link>
-              <Link
-                href="/onboarding/prestataire"
-                className="text-[11px] tracking-[0.22em] text-texte-sec uppercase hover:text-or"
-              >
-                Retour aux méthodes
-              </Link>
+                  Finaliser ma fiche
+                  <span
+                    className="text-or-light transition-transform group-hover:translate-x-1"
+                    aria-hidden="true"
+                  >
+                    →
+                  </span>
+                </Link>
+              </div>
             </div>
-          </motion.div>
+          ) : (
+            <div className="mt-12 rounded-sm border border-or/20 bg-blanc p-10 text-center md:p-14">
+              <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-or/10">
+                <InstagramIcon />
+              </div>
+
+              {/* État 2 : app Meta branchée → bouton de connexion officiel. */}
+              {configured ? (
+                <>
+                  <p className="mt-6 font-serif text-3xl font-light text-vert">
+                    Connecte ton Instagram
+                  </p>
+                  <p className="mt-4 text-[14px] leading-[1.7] text-texte-sec">
+                    Compte Business ou Creator. On ne lit que ta bio, ta photo
+                    et tes posts — rien d&apos;autre, et jamais de publication en
+                    ton nom.
+                  </p>
+                  <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+                    {/* Navigation réelle vers un route handler qui 302 vers
+                        Meta — surtout pas un <Link> (prefetch/intercept). */}
+                    {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+                    <a
+                      href="/api/onboarding/instagram/start"
+                      className="group inline-flex h-12 items-center gap-2 rounded-full bg-vert px-7 text-[12px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+                    >
+                      Connecter mon compte
+                      <span
+                        className="text-or-light transition-transform group-hover:translate-x-1"
+                        aria-hidden="true"
+                      >
+                        →
+                      </span>
+                    </a>
+                    <Link
+                      href="/onboarding/prestataire/manuel"
+                      className="text-[11px] tracking-[0.22em] text-texte-sec uppercase hover:text-or"
+                    >
+                      Remplir à la main
+                    </Link>
+                  </div>
+                </>
+              ) : (
+                /* État 1 : app Meta pas encore validée → en préparation. */
+                <>
+                  <p className="mt-6 font-serif text-3xl font-light text-vert">
+                    🚧 En préparation
+                  </p>
+                  <p className="mt-4 text-[14px] leading-[1.7] text-texte-sec">
+                    On finalise l&apos;intégration avec Meta pour récupérer ta
+                    bio, ton avatar et tes derniers posts. Tu pourras créer ta
+                    fiche en 2 minutes.
+                  </p>
+                  <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+                    <Link
+                      href="/onboarding/prestataire/manuel"
+                      className="group inline-flex h-12 items-center gap-2 rounded-full bg-vert px-7 text-[12px] font-medium tracking-[0.22em] text-creme uppercase transition-all hover:bg-vert-dark"
+                    >
+                      Remplir manuellement
+                      <span
+                        className="text-or-light transition-transform group-hover:translate-x-1"
+                        aria-hidden="true"
+                      >
+                        →
+                      </span>
+                    </Link>
+                    <Link
+                      href="/onboarding/prestataire"
+                      className="text-[11px] tracking-[0.22em] text-texte-sec uppercase hover:text-or"
+                    >
+                      Retour aux méthodes
+                    </Link>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
         </div>
       </section>
     </OnboardingShell>
-  )
+  );
 }

--- a/components/onboarding/PrestataireMethodsClient.tsx
+++ b/components/onboarding/PrestataireMethodsClient.tsx
@@ -9,58 +9,6 @@ import {
 import { MethodCard } from '@/components/onboarding/MethodCard'
 import { MapPin, PenLine } from 'lucide-react'
 
-function Instagram({
-  size = 18,
-  strokeWidth = 1.5,
-}: {
-  size?: number
-  strokeWidth?: number
-}) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={strokeWidth}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <rect x="2" y="2" width="20" height="20" rx="5" />
-      <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
-      <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" />
-    </svg>
-  )
-}
-
-function Linkedin({
-  size = 18,
-  strokeWidth = 1.5,
-}: {
-  size?: number
-  strokeWidth?: number
-}) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={strokeWidth}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-4 0v7h-4v-7a6 6 0 0 1 6-6z" />
-      <rect x="2" y="9" width="4" height="12" />
-      <circle cx="4" cy="4" r="2" />
-    </svg>
-  )
-}
-
 const methods = [
   {
     slug: 'manuel',
@@ -79,32 +27,9 @@ const methods = [
     icon: <MapPin size={18} strokeWidth={1.5} />,
     titre: 'Depuis Google Places',
     accroche:
-      'On récupérera ton adresse, tes horaires, tes photos. Tu corriges, tu publies.',
+      'On récupère ton adresse, tes horaires, tes photos. Tu corriges, tu publies.',
     ideal: 'Restaurants, spas, salons, boutiques — tout lieu physique.',
     duree: '2 min',
-    bientot: true,
-  },
-  {
-    slug: 'instagram',
-    numero: '03',
-    icon: <Instagram size={18} strokeWidth={1.5} />,
-    titre: 'Depuis Instagram',
-    accroche:
-      'Ta bio, ta photo, tes six derniers posts — importés direct pour ta galerie.',
-    ideal: 'Créatrices, influenceuses, marques. Compte Business ou Creator.',
-    duree: '2 min',
-    bientot: true,
-  },
-  {
-    slug: 'linkedin',
-    numero: '04',
-    icon: <Linkedin size={18} strokeWidth={1.5} />,
-    titre: 'Depuis LinkedIn',
-    accroche:
-      'Ton parcours pro reformaté version HILMY. Chaleureux, humain, pas corporate.',
-    ideal: 'Coachs, thérapeutes en ligne, consultantes, avocates.',
-    duree: '3 min',
-    bientot: true,
   },
 ]
 
@@ -135,16 +60,17 @@ export function PrestataireMethodsClient() {
               }
               subtitle={
                 <>
-                  Quelques infos et tu es prête à rejoindre la team. Trois
-                  formules d&apos;abonnement à partir de 19€/mois, sans
+                  Deux façons de créer ta fiche : à la main, ou depuis Google
+                  Places. Quelques infos et tu es prête à rejoindre la team.
+                  Trois formules d&apos;abonnement à partir de 19€/mois, sans
                   commission sur tes prestations — le détail sur{' '}
-                  <a
+                  <Link
                     href="/tarifs"
                     className="text-or-deep underline-offset-4 hover:text-or hover:underline"
                   >
                     /tarifs
-                  </a>
-                  . Les imports automatiques arriveront bientôt.
+                  </Link>
+                  .
                 </>
               }
             />
@@ -156,24 +82,18 @@ export function PrestataireMethodsClient() {
         <div className="mx-auto max-w-container px-6 md:px-20">
           <div className="grid gap-5 md:grid-cols-2">
             {methods.map((m, i) => (
-              <div key={m.slug} className="relative">
-                <MethodCard
-                  index={i}
-                  icon={m.icon}
-                  numero={m.numero}
-                  titre={m.titre}
-                  accroche={m.accroche}
-                  ideal={m.ideal}
-                  duree={m.duree}
-                  recommande={m.recommande}
-                  href={`/onboarding/prestataire/${m.slug}`}
-                />
-                {m.bientot && (
-                  <span className="absolute top-5 right-5 rounded-full bg-or/15 px-3 py-1 text-[10px] tracking-[0.22em] text-or-deep uppercase">
-                    Bientôt
-                  </span>
-                )}
-              </div>
+              <MethodCard
+                key={m.slug}
+                index={i}
+                icon={m.icon}
+                numero={m.numero}
+                titre={m.titre}
+                accroche={m.accroche}
+                ideal={m.ideal}
+                duree={m.duree}
+                recommande={m.recommande}
+                href={`/onboarding/prestataire/${m.slug}`}
+              />
             ))}
           </div>
 

--- a/lib/instagram/config.ts
+++ b/lib/instagram/config.ts
@@ -1,0 +1,164 @@
+/**
+ * Scaffold Instagram — VOIE OFFICIELLE uniquement (Instagram API with Instagram
+ * Login). AUCUN scraping, jamais.
+ *
+ * Ce module est DORMANT tant que l'app Meta n'est pas validée : tout est gardé
+ * derrière `getInstagramConfig()`, qui renvoie `null` si les variables d'env
+ * `INSTAGRAM_APP_ID` / `INSTAGRAM_APP_SECRET` sont absentes. Les routes OAuth
+ * refusent alors de démarrer (redirect "non configuré"), donc rien ne casse en
+ * prod tant que les clés ne sont pas fournies côté Vercel.
+ *
+ * Données ciblées (et UNIQUEMENT celles-ci) :
+ *   - username
+ *   - biography (bio)
+ *   - profile_picture_url (photo de profil)
+ *   - 6 derniers posts (media_url + permalink + caption)
+ *
+ * Scopes : `instagram_business_basic` (lecture profil + media d'un compte
+ * Business ou Creator connecté par sa propriétaire). On ne demande RIEN de
+ * plus (pas de publication, pas de messagerie, pas d'insights).
+ *
+ * Réf. Meta : "Instagram API with Instagram Login" (remplace l'ancien
+ * Instagram Basic Display, déprécié le 4 décembre 2024).
+ */
+
+const AUTHORIZE_BASE = "https://www.instagram.com/oauth/authorize";
+const TOKEN_URL = "https://api.instagram.com/oauth/access_token";
+const GRAPH_BASE = "https://graph.instagram.com";
+
+// On ne demande que la lecture basique du profil + des médias.
+export const INSTAGRAM_SCOPES = ["instagram_business_basic"] as const;
+
+// Nombre de posts importés pour la galerie de la fiche.
+export const INSTAGRAM_POST_COUNT = 6;
+
+export type InstagramConfig = {
+  appId: string;
+  appSecret: string;
+  redirectUri: string;
+};
+
+export function instagramRedirectUri(): string {
+  const site = (
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.SITE_URL ||
+    "https://www.hilmy.io"
+  ).replace(/\/$/, "");
+  return `${site}/api/onboarding/instagram/callback`;
+}
+
+/**
+ * Renvoie la config Instagram, ou `null` si l'app Meta n'est pas branchée.
+ * C'est le seul point de vérité : si ça renvoie null, la feature est OFF.
+ */
+export function getInstagramConfig(): InstagramConfig | null {
+  const appId = process.env.INSTAGRAM_APP_ID?.trim();
+  const appSecret = process.env.INSTAGRAM_APP_SECRET?.trim();
+  if (!appId || !appSecret) return null;
+  return { appId, appSecret, redirectUri: instagramRedirectUri() };
+}
+
+export function isInstagramConfigured(): boolean {
+  return getInstagramConfig() !== null;
+}
+
+/** URL d'autorisation OAuth vers laquelle on redirige la prestataire. */
+export function instagramAuthorizeUrl(state: string): string {
+  const cfg = getInstagramConfig();
+  if (!cfg) throw new Error("Instagram non configuré");
+  const params = new URLSearchParams({
+    client_id: cfg.appId,
+    redirect_uri: cfg.redirectUri,
+    response_type: "code",
+    scope: INSTAGRAM_SCOPES.join(","),
+    state,
+  });
+  return `${AUTHORIZE_BASE}?${params.toString()}`;
+}
+
+type ShortTokenResponse = { access_token: string; user_id: string };
+
+/** Échange le `code` OAuth contre un access token court (1h). */
+export async function exchangeCodeForToken(
+  code: string,
+): Promise<ShortTokenResponse | null> {
+  const cfg = getInstagramConfig();
+  if (!cfg) return null;
+  const body = new URLSearchParams({
+    client_id: cfg.appId,
+    client_secret: cfg.appSecret,
+    grant_type: "authorization_code",
+    redirect_uri: cfg.redirectUri,
+    code,
+  });
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  if (!res.ok) return null;
+  const data = (await res.json()) as Partial<ShortTokenResponse>;
+  if (!data.access_token || !data.user_id) return null;
+  return { access_token: data.access_token, user_id: String(data.user_id) };
+}
+
+export type InstagramPost = {
+  id: string;
+  media_url: string | null;
+  permalink: string | null;
+  caption: string | null;
+};
+
+export type InstagramImport = {
+  username: string;
+  biography: string | null;
+  profile_picture_url: string | null;
+  posts: InstagramPost[];
+};
+
+/**
+ * Récupère le profil (username, bio, photo) + les 6 derniers posts via la
+ * Graph API Instagram. Aucune donnée n'est persistée ici : on renvoie l'objet
+ * brut, c'est la couche au-dessus (preview puis publication) qui décide.
+ */
+export async function fetchInstagramImport(
+  accessToken: string,
+): Promise<InstagramImport | null> {
+  const profileFields = "username,biography,profile_picture_url";
+  const profileRes = await fetch(
+    `${GRAPH_BASE}/me?fields=${profileFields}&access_token=${encodeURIComponent(accessToken)}`,
+  );
+  if (!profileRes.ok) return null;
+  const profile = (await profileRes.json()) as {
+    username?: string;
+    biography?: string;
+    profile_picture_url?: string;
+  };
+
+  const mediaFields = "id,media_url,permalink,caption,media_type";
+  const mediaRes = await fetch(
+    `${GRAPH_BASE}/me/media?fields=${mediaFields}&limit=${INSTAGRAM_POST_COUNT}&access_token=${encodeURIComponent(accessToken)}`,
+  );
+  const media = mediaRes.ok
+    ? ((await mediaRes.json()) as {
+        data?: {
+          id: string;
+          media_url?: string;
+          permalink?: string;
+          caption?: string;
+        }[];
+      })
+    : { data: [] };
+
+  return {
+    username: profile.username ?? "",
+    biography: profile.biography ?? null,
+    profile_picture_url: profile.profile_picture_url ?? null,
+    posts: (media.data ?? []).slice(0, INSTAGRAM_POST_COUNT).map((m) => ({
+      id: m.id,
+      media_url: m.media_url ?? null,
+      permalink: m.permalink ?? null,
+      caption: m.caption ?? null,
+    })),
+  };
+}


### PR DESCRIPTION
## Quoi

Active la voie **Google Places** pour la création de fiche prestataire, ajoute un **scaffold dormant Instagram** (OAuth officiel), et **nettoie la page méthodes** pour ne montrer que les 2 cartes livrables.

## Pourquoi

La voie Google Places était déjà codée mais masquée par un badge « Bientôt » (et jetait les horaires récupérées). Instagram/LinkedIn affichaient des cartes « Bientôt » sans backend. On passe à un état honnête : ce qui marche est live, ce qui n'est pas prêt n'est plus promis dans l'UI.

---

### 🟢 Devient live — Google Places
- Recherche de lieu → pré-remplissage (nom, adresse, photos) → correction → publication. Logique + ghost profiles réutilisés du module Recommandations.
- **Horaires désormais persistées** : conversion des `weekdayDescriptions` Google (FR, lundi-first) → `{monday: "09:00 – 19:00", …}` dans **`profiles.horaires`** (colonne existante, mig 41), lues par `formatHoraires` sur la fiche publique. Affichées aussi dans la preview.

### 🟠 Dormant — Instagram
- *Instagram API with Instagram Login* (voie officielle ; Basic Display déprécié déc. 2024). **Aucun scraping.**
- **OFF tant que `INSTAGRAM_APP_ID` / `INSTAGRAM_APP_SECRET` sont absents** → la page reste « En préparation », rien ne casse.
- Routes `/api/onboarding/instagram/start` + `/callback` (state anti-CSRF, token jamais persisté), scope `instagram_business_basic`. TODO post-validation Meta : brancher l'insert `profiles`.

### ⚪ Retiré de l'UI — cartes Instagram + LinkedIn
- La grille ne montre plus que **01 Manuel** + **02 Google Places** (sans badge). Sous-titre reformulé (« Deux façons de créer ta fiche… »).
- **Code Instagram conservé** (`lib/instagram/*`, `app/api/onboarding/instagram/*`, page IG) + stub LinkedIn : orphelins, réactivables. Aucune carte n'y mène.

---

## ⚠️ À vérifier AVANT merge — clé Google Places

`GOOGLE_PLACES_API_KEY` est appelée **server-side** (header `X-Goog-Api-Key`, appels server-to-server depuis Vercel).

> **Si la clé a une restriction « HTTP referrers », les appels casseront en prod** (pas de Referer navigateur côté serveur → `403 PERMISSION_DENIED`).
>
> **Config attendue dans Google Cloud Console :**
> - Restriction d'**API** : limiter à **Places API (New)**.
> - Restriction d'**application** : **Aucune** (ou par IP si l'IP sortante est fixe) — **PAS** « HTTP referrers ».
> - Facturation active + quota Places API suffisant.

## Nouvelles variables d'env (à fournir côté Vercel)
`.env.example` est gitignoré dans ce repo, donc documenté ici :
- `GOOGLE_PLACES_API_KEY` — server-side only (déjà présent en prod a priori).
- `INSTAGRAM_APP_ID` / `INSTAGRAM_APP_SECRET` — server-side only, **à ne renseigner qu'après validation de l'app Meta** (sinon la feature reste OFF, voulu).

## Comment tester
- Google : voir la procédure de test fournie dans le fil (endpoints `/api/places/search` + `/api/places/details` sur la preview).
- Build / typecheck / lint : ✅ verts en local.

## Risques
- Aucune migration, aucune structure de table modifiée (écriture sur colonne `horaires` existante).
- Auth, pricing, catégories : non touchés.
- Instagram dormant : inerte sans les clés.

## Sécurité
- Aucun secret committé. `GOOGLE_PLACES_API_KEY` server-side only. Token Instagram jamais persisté. State anti-CSRF sur le flow OAuth.
