### PR TITLE
feat: Canada+Maroc, ville libre import Google, accueil rempli par prestataires

### DIFF
--- a/app/accueil/page.tsx
+++ b/app/accueil/page.tsx
@@ -14,6 +14,7 @@ import {
   formatVilleDisplay,
 } from '@/lib/geo/city-centroids'
 import type { Evenement as MockEvenement } from '@/lib/mock-data'
+import { categoryLabel } from '@/lib/constants'
 
 export const dynamic = 'force-dynamic'
 
@@ -243,6 +244,49 @@ export default async function AccueilPage() {
     }
   }
 
+  // ── Fallback prestataires ─────────────────────────────────────────
+  // Si aucune reco publiée, on remplit la section "pépites" avec les
+  // prestataires déjà en ligne (annuaire approved) — pas de vide au lancement.
+  type PrestaForHome = {
+    id: string
+    nom: string
+    href: string
+    tagline: string | null
+    categorie: string
+    cover: string | null
+  }
+  let prestatairesFallback: PrestaForHome[] = []
+  if (recos.length === 0) {
+    const { data: prestaRows } = await supabase
+      .from('profiles')
+      .select('id, nom, slug, tagline, categorie, galerie, photos')
+      .eq('status', 'approved')
+      .order('created_at', { ascending: false })
+      .limit(3)
+    prestatairesFallback = (
+      (prestaRows ?? []) as Array<{
+        id: string
+        nom: string
+        slug: string
+        tagline: string | null
+        categorie: string
+        galerie: unknown
+        photos: string[] | null
+      }>
+    ).map((p) => {
+      const galerieArr = Array.isArray(p.galerie) ? (p.galerie as string[]) : []
+      const photos = Array.isArray(p.photos) ? p.photos : []
+      return {
+        id: p.id,
+        nom: p.nom,
+        href: `/prestataires/${p.slug}`,
+        tagline: p.tagline ?? null,
+        categorie: p.categorie,
+        cover: galerieArr[0] ?? photos[0] ?? null,
+      }
+    })
+  }
+
   // ── 6 events à venir ─────────────────────────────────────────────
   const { data: eventsRows } = await supabase
     .from('events')
@@ -427,11 +471,49 @@ export default async function AccueilPage() {
               </Link>
             </div>
 
-            {recos.length === 0 ? (
+            {recos.length === 0 && prestatairesFallback.length === 0 ? (
               <div className="rounded-sm border border-dashed border-or/30 bg-creme-soft py-16 text-center">
                 <p className="font-serif text-xl italic text-vert">
                   Le carnet se remplit — reviens dans quelques jours.
                 </p>
+              </div>
+            ) : recos.length === 0 ? (
+              <div className="grid gap-6 md:grid-cols-3">
+                {prestatairesFallback.map((p) => (
+                  <Link
+                    key={p.id}
+                    href={p.href}
+                    className="group flex h-full flex-col overflow-hidden rounded-sm border border-or/15 bg-blanc transition-all duration-500 hover:-translate-y-1 hover:shadow-[0_30px_60px_-30px_rgba(15,61,46,0.25)]"
+                  >
+                    <div className="relative h-56 w-full overflow-hidden bg-creme-deep">
+                      {p.cover && (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={p.cover}
+                          alt={p.nom}
+                          className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-[1.04]"
+                          loading="lazy"
+                        />
+                      )}
+                      <div className="absolute left-4 top-4 inline-flex items-center gap-2 rounded-full bg-blanc/85 px-3 py-1 text-[10px] tracking-[0.22em] text-vert backdrop-blur uppercase">
+                        Prestataire
+                      </div>
+                    </div>
+                    <div className="flex flex-1 flex-col gap-3 p-6">
+                      <h3 className="font-serif text-xl font-light leading-tight text-vert">
+                        {p.nom}
+                      </h3>
+                      {p.tagline && (
+                        <p className="line-clamp-3 font-serif text-[14px] italic leading-[1.55] text-texte-sec">
+                          « {p.tagline} »
+                        </p>
+                      )}
+                      <p className="mt-auto border-t border-or/10 pt-3 text-[11px] tracking-[0.18em] text-or-deep uppercase">
+                        {categoryLabel(p.categorie)}
+                      </p>
+                    </div>
+                  </Link>
+                ))}
               </div>
             ) : (
               <div className="grid gap-6 md:grid-cols-3">

--- a/app/onboarding/prestataire/google/page.tsx
+++ b/app/onboarding/prestataire/google/page.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/google/PlaceAutocomplete'
 import { createClient } from '@/lib/supabase/client'
 import { CopineDiscountField } from '@/components/onboarding/CopineDiscountField'
-import { CATEGORIES_MAP } from '@/lib/constants'
+import { CATEGORIES_MAP, PAYS } from '@/lib/constants'
 import { formatVilleDisplay } from '@/lib/geo/city-centroids'
 import { COUNTRY_CODES, toE164, nationalDigits } from '@/lib/phone'
 
@@ -98,6 +98,10 @@ export default function GoogleOnboardingPage() {
   // Overrides éditables par l'utilisatrice
   const [nom, setNom] = useState('')
   const [categorie, setCategorie] = useState('')
+  // Pays + ville pré-remplis depuis Google mais éditables : la prestataire
+  // peut corriger / écrire librement sa ville (champ texte ouvert).
+  const [pays, setPays] = useState('')
+  const [ville, setVille] = useState('')
   const [tagline, setTagline] = useState('')
   const [description, setDescription] = useState('')
   // WhatsApp en deux parties : indicatif pays (obligatoire, sans défaut) +
@@ -149,6 +153,11 @@ export default function GoogleOnboardingPage() {
       setDetails(full)
       setNom(full.name)
       setCategorie(guessCategorie(full.google_category))
+      // Pré-remplissage éditable : pays seulement s'il fait partie des pays
+      // cible (sinon on laisse vide pour qu'elle choisisse), ville en texte
+      // libre repris de Google.
+      setPays(PAYS.includes(full.country) ? full.country : '')
+      setVille(formatVilleDisplay(full.city) ?? full.city ?? '')
       setTagline('')
       setDescription('')
       setStep('preview')
@@ -163,6 +172,8 @@ export default function GoogleOnboardingPage() {
     setDetails(null)
     setNom('')
     setCategorie('')
+    setPays('')
+    setVille('')
     setTagline('')
     setDescription('')
     setError(null)
@@ -189,8 +200,8 @@ export default function GoogleOnboardingPage() {
       nom: nom.trim(),
       slug,
       categorie,
-      pays: details.country || null,
-      ville: formatVilleDisplay(details.city) ?? details.city ?? '',
+      pays: pays.trim() || null,
+      ville: formatVilleDisplay(ville.trim()) ?? ville.trim(),
       whatsapp: toE164(waDial, waNumber),
       email: userEmail || null,
       instagram: instagram.trim() || null,
@@ -414,6 +425,33 @@ export default function GoogleOnboardingPage() {
                           </option>
                         ))}
                       </select>
+                    </Field>
+                    <Field label="Pays">
+                      <select
+                        value={pays}
+                        onChange={(e) => setPays(e.target.value)}
+                        className="line"
+                      >
+                        <option value="">Choisir…</option>
+                        {PAYS.map((p) => (
+                          <option key={p} value={p}>
+                            {p}
+                          </option>
+                        ))}
+                      </select>
+                    </Field>
+                    <Field
+                      label="Ville"
+                      hint="Tu peux la corriger ou en écrire une autre."
+                    >
+                      <input
+                        type="text"
+                        value={ville}
+                        onChange={(e) => setVille(e.target.value)}
+                        placeholder="Genève, Paris, Montréal, Casablanca…"
+                        className="line"
+                        autoComplete="off"
+                      />
                     </Field>
                     <Field label="WhatsApp (obligatoire)" hint="Indicatif pays + numéro sans le 0 initial">
                       <div className="flex gap-2">

--- a/app/onboarding/prestataire/manuel/page.tsx
+++ b/app/onboarding/prestataire/manuel/page.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/onboarding/OnboardingShell'
 import { createClient } from '@/lib/supabase/client'
 import { CopineDiscountField } from '@/components/onboarding/CopineDiscountField'
-import { CATEGORIES_MAP } from '@/lib/constants'
+import { CATEGORIES_MAP, PAYS } from '@/lib/constants'
 import { villesSuggestions } from '@/lib/mock-data'
 import { formatVilleDisplay } from '@/lib/geo/city-centroids'
 import { COUNTRY_CODES, toE164, nationalDigits } from '@/lib/phone'
@@ -329,13 +329,11 @@ export default function ManuelOnboardingPage() {
                       className="line"
                     >
                       <option value="">Choisir…</option>
-                      {['Suisse', 'France', 'Belgique', 'Luxembourg', 'Monaco'].map(
-                        (p) => (
-                          <option key={p} value={p}>
-                            {p}
-                          </option>
-                        ),
-                      )}
+                      {PAYS.map((p) => (
+                        <option key={p} value={p}>
+                          {p}
+                        </option>
+                      ))}
                     </select>
                   </Field>
                   <Field

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -87,6 +87,8 @@ export const PAYS_MAP: Record<string, string> = {
   "Belgique": "Belgique",
   "Luxembourg": "Luxembourg",
   "Monaco": "Monaco",
+  "Canada": "Canada",
+  "Maroc": "Maroc",
 };
 
 export const PAYS = Object.keys(PAYS_MAP);


### PR DESCRIPTION
## Quoi
Trois ajustements produit demandés :
1. **Pays cible** : ajout de **Canada** 🇨🇦 et **Maroc** 🇲🇦 (5 → 7 pays).
2. **Ville libre à l'import Google** : champs **Pays** + **Ville (texte libre)** éditables dans la preview Google Places.
3. **Accueil** : la section « Les dernières pépites déposées » se remplit avec les **prestataires existants** quand aucune reco n'est encore publiée.

## Pourquoi
- Élargir la cible géographique (demande explicite).
- Une prestataire qui importe depuis Google ne pouvait pas corriger sa ville/son pays (verrouillés sur Google) → maintenant case ville ouverte.
- La home affichait un vide « reviens dans quelques jours » alors que des fiches existent déjà → on montre du contenu réel.

## Détail
- **`lib/constants.ts`** — `PAYS_MAP` : + Canada, + Maroc. Les indicatifs WhatsApp `+1` / `+212` existaient déjà dans `COUNTRY_CODES`.
- **`manuel/page.tsx`** — lit `PAYS` (constante) au lieu d'une liste codée en dur ; la ville y était déjà un champ texte libre.
- **`google/page.tsx`** — nouveaux champs `Pays` (select) + `Ville` (input texte libre) pré-remplis depuis Google, éditables ; le submit utilise les valeurs corrigées.
- **`accueil/page.tsx`** — si `recos = 0`, requête `profiles` (status `approved`, 3 plus récents) rendus en cartes « Prestataire » (cover + nom + tagline + catégorie). Dès qu'une reco existe, priorité aux recos.

## Comment tester (tu es connectée → sur l'URL preview Vercel)
1. `/onboarding/prestataire/google` → cherche un lieu → la preview montre **Pays** + **Ville** modifiables (écris une ville à la main, ex. Montréal).
2. `/onboarding/prestataire/manuel` → le select **Pays** propose Canada + Maroc ; ville = champ libre.
3. `/accueil` → la section « pépites » affiche les prestataires approuvés (si aucune reco publiée).

## Risques
- Aucune migration, aucune structure de table modifiée. `PAYS_MAP` est un check applicatif (pas une contrainte DB) — vérifier qu'aucune contrainte `profiles.pays` ne rejette « Canada »/« Maroc » (a priori pays est du texte libre en base).
- Build / typecheck / lint : ✅ verts en local.

## Sécurité
- Aucun secret. Auth/pricing/catégories non touchés. La requête prestataires de l'accueil reste sous RLS (status approved, lecture publique).
