### PR TITLE
db: versionner les migrations 70→73 (déjà appliquées en prod)

### DIFF
--- a/supabase/migrations/70_profile_promos.sql
+++ b/supabase/migrations/70_profile_promos.sql
@@ -1,0 +1,58 @@
+-- =====================================================================
+-- HILMY · 70 — Promos temporaires datées sur les fiches prestataires
+--
+-- Une prestataire peut publier une offre limitée dans le temps (« soldes »)
+-- affichée sur sa fiche publique pendant la fenêtre [starts_at, ends_at].
+--
+-- Sûr & additif : CREATE TABLE IF NOT EXISTS, RLS + policies dans la même
+-- migration, DROP POLICY IF EXISTS avant CREATE (idempotent). Aucune
+-- donnée existante touchée.
+-- =====================================================================
+
+create table if not exists public.profile_promos (
+  id          uuid primary key default gen_random_uuid(),
+  profile_id  uuid not null references public.profiles(id) on delete cascade,
+  title       text not null,            -- ex. « -20% sur les soins du visage »
+  description text,                     -- conditions / détails (optionnel)
+  starts_at   date not null,
+  ends_at     date not null,
+  created_at  timestamptz not null default now(),
+  constraint promos_dates_chk check (ends_at >= starts_at),
+  constraint promos_title_chk check (char_length(title) between 3 and 80),
+  constraint promos_desc_chk  check (description is null or char_length(description) <= 200)
+);
+
+create index if not exists idx_profile_promos_profile
+  on public.profile_promos (profile_id);
+
+alter table public.profile_promos enable row level security;
+
+-- SELECT public : uniquement les promos ACTIVES (dans la fenêtre), et
+-- seulement pour des fiches visibles (la sous-requête sur profiles est
+-- soumise à la RLS "public read visible profiles" → anon ne voit que les
+-- promos de fiches publiques).
+drop policy if exists "promos_public_read_active" on public.profile_promos;
+create policy "promos_public_read_active"
+  on public.profile_promos for select
+  using (
+    current_date between starts_at and ends_at
+    and profile_id in (select id from public.profiles)
+  );
+
+-- SELECT owner : la prestataire voit TOUTES ses promos (passées/à venir).
+drop policy if exists "promos_owner_read_all" on public.profile_promos;
+create policy "promos_owner_read_all"
+  on public.profile_promos for select
+  to authenticated
+  using (profile_id in (select id from public.profiles where user_id = auth.uid()));
+
+-- INSERT/UPDATE/DELETE : owner-only (propriétaire de la fiche).
+drop policy if exists "promos_owner_write" on public.profile_promos;
+create policy "promos_owner_write"
+  on public.profile_promos for all
+  to authenticated
+  using      (profile_id in (select id from public.profiles where user_id = auth.uid()))
+  with check (profile_id in (select id from public.profiles where user_id = auth.uid()));
+
+comment on table public.profile_promos is
+  'Promos temporaires datées des prestataires (mobile PR C). Lecture publique limitée aux promos actives de fiches visibles ; écriture owner-only.';

--- a/supabase/migrations/70_profile_promos_rollback.sql
+++ b/supabase/migrations/70_profile_promos_rollback.sql
@@ -1,0 +1,9 @@
+-- =====================================================================
+-- HILMY · 70 ROLLBACK — supprime la table profile_promos et ses policies
+-- =====================================================================
+
+drop policy if exists "promos_public_read_active" on public.profile_promos;
+drop policy if exists "promos_owner_read_all" on public.profile_promos;
+drop policy if exists "promos_owner_write" on public.profile_promos;
+
+drop table if exists public.profile_promos;

--- a/supabase/migrations/71_profiles_email.sql
+++ b/supabase/migrations/71_profiles_email.sql
@@ -1,0 +1,23 @@
+-- =====================================================================
+-- HILMY · 71 — Email de contact public sur les fiches prestataires
+--
+-- Ajoute une colonne `email` (optionnelle) sur profiles : email de contact
+-- public que la prestataire peut renseigner, en plus de WhatsApp/réseaux.
+-- Éditable par l'owner (policy UPDATE existante), lisible par tous (policy
+-- SELECT "public read visible profiles" existante — RLS row-level, donc la
+-- nouvelle colonne est couverte). Aucune nouvelle policy nécessaire.
+--
+-- Sûr & additif : ADD COLUMN IF NOT EXISTS, contrainte longueur idempotente.
+-- =====================================================================
+
+alter table public.profiles
+  add column if not exists email text;
+
+alter table public.profiles
+  drop constraint if exists profiles_email_len_chk;
+alter table public.profiles
+  add constraint profiles_email_len_chk
+  check (email is null or char_length(email) <= 160);
+
+comment on column public.profiles.email is
+  'Email de contact public (optionnel), éditable par la prestataire (owner). Affiché sur la fiche.';

--- a/supabase/migrations/72_voix_hilmy_public_avatar.sql
+++ b/supabase/migrations/72_voix_hilmy_public_avatar.sql
@@ -1,0 +1,23 @@
+-- =====================================================================
+-- HILMY · 72 — avatar_url sur la vue voix_hilmy_public
+--
+-- Expose la photo de profil (user_profiles.avatar_url) sur la vue publique
+-- des Créatrices, pour l'afficher sur leur profil créatrice + les cartes.
+-- CREATE OR REPLACE en AJOUTANT la colonne EN FIN de SELECT (ordre des
+-- colonnes existantes inchangé → remplacement de vue autorisé). Idempotent.
+-- Reprend exactement la def de la migration 52 + avatar_url.
+-- =====================================================================
+
+CREATE OR REPLACE VIEW voix_hilmy_public AS
+ SELECT user_id, prenom, voix_hilmy_slug AS slug, voix_hilmy_bio AS bio,
+    voix_hilmy_activated_at AS activated_at,
+    ( SELECT count(*) AS count
+           FROM recommendations r
+          WHERE r.user_id = up.user_id AND r.status = 'published'::text
+            AND r.comment IS NOT NULL
+            AND length(TRIM(BOTH FROM r.comment)) > 0) AS recos_count,
+    get_voix_followers_count(user_id) AS followers_count,
+    is_copine,
+    avatar_url
+   FROM user_profiles up
+  WHERE is_voix_hilmy = true AND voix_hilmy_slug IS NOT NULL;

--- a/supabase/migrations/73_voix_hilmy_auto_eligibility.sql
+++ b/supabase/migrations/73_voix_hilmy_auto_eligibility.sql
@@ -1,0 +1,219 @@
+-- =====================================================================
+-- HILMY · 73 — Voix Hilmy : éligibilité automatique + activation opt-in
+--
+-- Récompense automatiquement les membres actives : dès qu'une membre
+-- atteint 5 recommandations PUBLIÉES AVEC commentaire (exactement la
+-- définition de recos_count de la vue voix_hilmy_public), elle devient
+-- « éligible » Voix Hilmy. Un trigger pose voix_hilmy_eligible_at + une
+-- notification. Elle reste maître de la suite : l'activation réelle
+-- (profil + recos rendus publics) passe par un opt-in en 1 tap côté app,
+-- via la RPC activate_voix_hilmy() — ce qui satisfait aussi la contrainte
+-- user_profiles_voix_complete (slug + bio requis quand is_voix_hilmy).
+--
+-- Le trigger ne fait que PROMOUVOIR : supprimer une reco plus tard ne
+-- déclasse jamais. Détection 100 % serveur (pas de cron), à toute épreuve
+-- (exception capturée → ne casse jamais l'écriture de la reco).
+--
+-- Idempotent. Voir 73_voix_hilmy_auto_eligibility_rollback.sql.
+-- =====================================================================
+
+-- ─── 1. Colonne d'éligibilité ─────────────────────────────────────
+alter table public.user_profiles
+  add column if not exists voix_hilmy_eligible_at timestamptz;
+
+comment on column public.user_profiles.voix_hilmy_eligible_at is
+  'Date à laquelle la membre a franchi le seuil de recos pour devenir Voix Hilmy. NULL = pas encore éligible. Posé par le trigger trg_voix_hilmy_eligibility. N''implique PAS l''activation : is_voix_hilmy reste false jusqu''à l''opt-in via activate_voix_hilmy().';
+
+-- ─── 2. Nouveau type de notification ──────────────────────────────
+alter table public.notifications drop constraint if exists notifications_type_check;
+alter table public.notifications add constraint notifications_type_check
+  check (type in (
+    'palier_franchi',
+    'reco_sauvegardee',
+    'parrainage_inscrit',
+    'top_recos_semaine',
+    'voix_hilmy_eligible'
+  ));
+
+-- ─── 3. Trigger de détection sur recommendations ──────────────────
+-- AFTER INSERT OR UPDATE OF status : recompte les recos publiées avec
+-- commentaire de l'autrice ; au franchissement du seuil, pose
+-- eligible_at + notifie. Early-return si déjà Voix ou déjà éligible
+-- (la plupart des recos d'une créatrice existante ne déclenchent donc
+-- aucun COUNT).
+create or replace function public.voix_hilmy_check_eligibility()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_threshold constant int := 5;
+  v_count int;
+  v_is_voix boolean;
+  v_eligible timestamptz;
+begin
+  select is_voix_hilmy, voix_hilmy_eligible_at
+    into v_is_voix, v_eligible
+  from public.user_profiles
+  where user_id = new.user_id;
+
+  -- Déjà Voix, déjà éligible, ou pas de profil membre → rien à faire.
+  if coalesce(v_is_voix, false) or v_eligible is not null then
+    return new;
+  end if;
+
+  select count(*) into v_count
+  from public.recommendations r
+  where r.user_id = new.user_id
+    and r.status = 'published'
+    and r.comment is not null
+    and length(trim(r.comment)) > 0;
+
+  if v_count >= v_threshold then
+    update public.user_profiles
+      set voix_hilmy_eligible_at = now()
+    where user_id = new.user_id
+      and voix_hilmy_eligible_at is null
+      and is_voix_hilmy = false;
+
+    insert into public.notifications (user_id, type, payload)
+    values (
+      new.user_id,
+      'voix_hilmy_eligible',
+      jsonb_build_object('recos_count', v_count, 'threshold', v_threshold)
+    );
+  end if;
+
+  return new;
+exception when others then
+  raise notice '[voix_hilmy_check_eligibility] failed: %', sqlerrm;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_voix_hilmy_eligibility on public.recommendations;
+create trigger trg_voix_hilmy_eligibility
+  after insert or update of status on public.recommendations
+  for each row execute function public.voix_hilmy_check_eligibility();
+
+-- ─── 4. RPC d'activation (opt-in 1 tap) ───────────────────────────
+-- La membre, une fois éligible ET sa présentation (voix_hilmy_bio)
+-- renseignée, appelle cette RPC pour devenir Voix Hilmy. Génère un slug
+-- propre depuis le prénom (accents repliés sans dépendance unaccent),
+-- en évitant les routes web réservées et les collisions. Idempotente :
+-- si déjà active, renvoie le slug existant.
+create or replace function public.activate_voix_hilmy()
+returns text
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_prenom text;
+  v_bio text;
+  v_eligible timestamptz;
+  v_is_voix boolean;
+  v_existing text;
+  v_base text;
+  v_slug text;
+  v_n int := 0;
+  -- Routes web top-level : un slug Voix résout à hilmy.io/{slug} via
+  -- app/[slug], il ne doit donc jamais entrer en collision.
+  v_reserved constant text[] := array[
+    'a-propos','accueil','admin','annuaire','api','auth','charte',
+    'comment-ca-marche','connexion','contact','dashboard','evenement-v2',
+    'evenements-v2','inscription','inscription-prestataire','je-cherche',
+    'lieux','manifeste','mon-espace','mot-de-passe-oublie','onboarding',
+    'pass-copine','prestataire-v2','prestataires','recommandation',
+    'recommandations','reinitialiser-mot-de-passe','tarifs','hilmy'
+  ];
+begin
+  if v_uid is null then
+    raise exception 'not_authenticated';
+  end if;
+
+  select prenom, voix_hilmy_bio, voix_hilmy_eligible_at, is_voix_hilmy, voix_hilmy_slug
+    into v_prenom, v_bio, v_eligible, v_is_voix, v_existing
+  from public.user_profiles
+  where user_id = v_uid;
+
+  -- Déjà active → idempotent.
+  if coalesce(v_is_voix, false) then
+    return v_existing;
+  end if;
+
+  if v_eligible is null then
+    raise exception 'not_eligible';
+  end if;
+
+  if v_bio is null or length(trim(v_bio)) = 0 then
+    raise exception 'bio_required';
+  end if;
+
+  -- Slugify le prénom : repli d'accents (1:1) + multi-char + nettoyage.
+  v_base := lower(coalesce(v_prenom, 'copine'));
+  v_base := replace(replace(v_base, 'œ', 'oe'), 'æ', 'ae');
+  v_base := translate(
+    v_base,
+    'àâäáãåçéèêëíìîïñóòôöõúùûü',
+    'aaaaaaceeeeiiiinooooouuuu'
+  );
+  v_base := regexp_replace(v_base, '[^a-z0-9]+', '-', 'g');
+  v_base := trim(both '-' from v_base);
+  if v_base = '' then
+    v_base := 'copine';
+  end if;
+
+  -- Premier slug libre (non réservé + non pris).
+  v_slug := v_base;
+  loop
+    if not (v_slug = any(v_reserved))
+       and not exists (
+         select 1 from public.user_profiles where voix_hilmy_slug = v_slug
+       ) then
+      exit;
+    end if;
+    v_n := v_n + 1;
+    v_slug := v_base || '-' || v_n::text;
+  end loop;
+
+  update public.user_profiles
+    set is_voix_hilmy = true,
+        voix_hilmy_slug = v_slug,
+        voix_hilmy_activated_at = now()
+  where user_id = v_uid;
+
+  return v_slug;
+end;
+$$;
+
+revoke all on function public.activate_voix_hilmy() from public;
+grant execute on function public.activate_voix_hilmy() to authenticated;
+
+comment on function public.activate_voix_hilmy() is
+  'Opt-in Voix Hilmy : la membre éligible (voix_hilmy_eligible_at non NULL) avec une présentation (voix_hilmy_bio) renseignée devient Voix Hilmy. Génère le slug, pose is_voix_hilmy + activated_at. Idempotente. Erreurs : not_authenticated / not_eligible / bio_required.';
+
+-- ─── 5. Backfill des membres déjà au-dessus du seuil ──────────────
+-- One-shot idempotent : marque éligibles les membres existantes ayant
+-- déjà ≥ 5 recos publiées avec commentaire, et les notifie. Re-jouer la
+-- migration ne re-notifie pas (eligible_at déjà posé → 0 ligne).
+with newly_eligible as (
+  update public.user_profiles up
+    set voix_hilmy_eligible_at = now()
+  where up.is_voix_hilmy = false
+    and up.voix_hilmy_eligible_at is null
+    and (
+      select count(*)
+      from public.recommendations r
+      where r.user_id = up.user_id
+        and r.status = 'published'
+        and r.comment is not null
+        and length(trim(r.comment)) > 0
+    ) >= 5
+  returning up.user_id
+)
+insert into public.notifications (user_id, type, payload)
+select user_id, 'voix_hilmy_eligible', jsonb_build_object('backfill', true, 'threshold', 5)
+from newly_eligible;

--- a/supabase/migrations/73_voix_hilmy_auto_eligibility_rollback.sql
+++ b/supabase/migrations/73_voix_hilmy_auto_eligibility_rollback.sql
@@ -1,0 +1,24 @@
+-- =====================================================================
+-- HILMY · 73 ROLLBACK — Voix Hilmy éligibilité automatique
+--
+-- Retire le trigger, la fonction de détection, la RPC d'activation et
+-- restaure le CHECK type des notifications à ses 4 valeurs d'origine.
+-- NE retire PAS la colonne voix_hilmy_eligible_at ni les éligibilités
+-- déjà posées (conservation des données ; ALTER COLUMN > DROP COLUMN).
+-- =====================================================================
+
+drop trigger if exists trg_voix_hilmy_eligibility on public.recommendations;
+drop function if exists public.voix_hilmy_check_eligibility();
+drop function if exists public.activate_voix_hilmy();
+
+alter table public.notifications drop constraint if exists notifications_type_check;
+alter table public.notifications add constraint notifications_type_check
+  check (type in (
+    'palier_franchi',
+    'reco_sauvegardee',
+    'parrainage_inscrit',
+    'top_recos_semaine'
+  ));
+
+-- Pour repartir totalement de zéro (optionnel, destructif) :
+-- alter table public.user_profiles drop column if exists voix_hilmy_eligible_at;


### PR DESCRIPTION
## Quoi
Versionne les migrations **70 à 73**, jusque-là appliquées en prod via le SQL Editor mais **non commitées**.

## Pourquoi
Éviter de perdre l'historique SQL et garder le repo aligné avec l'état réel de la base.

## Contenu
- **70** `profile_promos` (+ rollback) — promos/soldes prestataires
- **71** `profiles_email` — email de contact sur `profiles`
- **72** `voix_hilmy_public_avatar` — `avatar_url` sur la vue `voix_hilmy_public`
- **73** `voix_hilmy_auto_eligibility` (+ rollback) — éligibilité auto Voix Hilmy (trigger + RPC `activate_voix_hilmy` + backfill)

## Risques
Aucun pour la prod : **déjà appliquées**. Toutes idempotentes (`if not exists`, `drop ... if exists`, `create or replace`). Ce PR ne fait que tracer les fichiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)