### PR TITLE
fix(tarifs): plus d'impasse pour une prospecte prête à payer

### DIFF
--- a/app/tarifs/page.tsx
+++ b/app/tarifs/page.tsx
@@ -72,6 +72,7 @@ type SearchParams = Promise<{
   promo?: string
   utm_source?: string
   from?: string
+  stripe_canceled?: string
 }>
 
 export const metadata: Metadata = {
@@ -175,8 +176,8 @@ const DIALOGUE_QA = [
     q: 'Combien de temps avant que ma fiche soit en ligne ?',
     a: (
       <>
-        Tu paies, tu reçois un email de bienvenue dans la minute avec le lien pour
-        créer ta fiche.{' '}
+        Tu crées ta fiche en quelques minutes, tu choisis ta formule, et dès le
+        paiement elle est en ligne.{' '}
         <em className="not-italic font-medium text-vert">
           On valide ton profil sous 24h, et tu es dans la team.
         </em>
@@ -215,6 +216,10 @@ export default async function TarifsPage({
   // prestataire — et on propage le contexte au checkout pour qu'elle
   // atterrisse sur /publiee après paiement.
   const fromOnboarding = params.from === 'onboarding'
+  // Retour d'un checkout Stripe abandonné (cancel_url). Rien n'a été
+  // débité — on rassure et on remet la formule sous les yeux, au lieu
+  // de laisser revenir sur la page sans un mot.
+  const stripeCanceled = params.stripe_canceled === '1'
 
   // Log analytics dev mode (deep-link mobile UTM tracking).
   if (process.env.NODE_ENV !== 'production' && params.utm_source) {
@@ -228,6 +233,24 @@ export default async function TarifsPage({
   return (
     <PageShell navVariant="solid">
       <div className="scroll-smooth">
+        {/* BANDEAU RETOUR CHECKOUT ABANDONNÉ */}
+        {stripeCanceled && (
+          <div
+            role="status"
+            className="border-b border-or/30 bg-creme-deep px-6 py-4 pt-24 text-center md:px-20"
+          >
+            <p className="mx-auto max-w-[640px] text-[15px] leading-relaxed text-vert">
+              Ton paiement n&apos;a pas abouti — rien n&apos;a été débité,
+              aucune inquiétude.{' '}
+              <em className="not-italic font-medium">
+                {fromOnboarding
+                  ? 'Ta fiche est prête, il ne lui manque que ta formule.'
+                  : 'Ta formule t’attend juste en dessous, reprends où tu en étais.'}
+              </em>
+            </p>
+          </div>
+        )}
+
         {/* HERO */}
         <section className="overflow-hidden px-6 py-28 text-center md:px-20 md:py-32">
           <div className="mx-auto max-w-[780px]">

--- a/components/SubscribeButton.tsx
+++ b/components/SubscribeButton.tsx
@@ -30,8 +30,10 @@ interface Props {
  * Voix Sara : "Je m'abonne", "Je choisis cette formule", "Je souscris".
  * Pas "Acheter" ni "Buy now".
  *
- * Gère les erreurs serveur (founder qui tente de souscrire = 403,
- * price_id inconnu = 422, Stripe down = 502) avec toast voix Sara.
+ * Gère les erreurs serveur avec toast voix Sara (founder qui tente de
+ * souscrire = 403, price_id inconnu = 422, Stripe down = 502) — sauf
+ * 401 (pas de compte) et 404 (pas de fiche) qui redirigent vers le
+ * funnel d'inscription au lieu de laisser la prospecte dans une impasse.
  */
 export function SubscribeButton({
   priceId,
@@ -57,6 +59,24 @@ export function SubscribeButton({
       })
 
       if (!res.ok) {
+        // 401 = visiteuse sans compte, 404 = compte sans fiche prestataire.
+        // Dans les deux cas on la remet sur le bon rail au lieu d'un toast
+        // sans issue : le funnel d'inscription la ramène sur /tarifs
+        // (?from=onboarding) une fois sa fiche créée.
+        if (res.status === 401) {
+          toast.info('Crée ton compte, on te ramène ici juste après.', {
+            duration: 4000,
+          })
+          window.location.href = '/auth/signup?role=prestataire'
+          return
+        }
+        if (res.status === 404) {
+          toast.info('Il te manque juste ta fiche — deux minutes, promis.', {
+            duration: 4000,
+          })
+          window.location.href = '/onboarding/prestataire'
+          return
+        }
         const json = (await res.json().catch(() => null)) as { error?: string } | null
         const msg = json?.error ?? 'Impossible de démarrer la souscription.'
         toast.error(msg, { duration: 5000 })


### PR DESCRIPTION
## Quoi
Trois corrections du funnel de vente /tarifs → checkout, issues de l'audit du 2 juillet :
1. **SubscribeButton** : une visiteuse non connectée (401) est redirigée vers `/auth/signup?role=prestataire` ; une connectée sans fiche prestataire (404) vers `/onboarding/prestataire`. Avant : un toast d'erreur sans issue (« Non authentifiée » / « Profil introuvable »).
2. **/tarifs** : bandeau de réassurance quand on revient d'un checkout Stripe abandonné (`stripe_canceled=1`), avec variante `from=onboarding` (« Ta fiche est prête, il ne lui manque que ta formule »).
3. **FAQ** : la réponse « Combien de temps avant que ma fiche soit en ligne ? » décrivait un parcours inversé (payer d'abord, fiche ensuite). Alignée sur le vrai flow.

## Pourquoi
Le code lui-même note que la majorité des visiteuses /tarifs sont non connectées : chaque clic « Je choisis cette formule » d'une prospecte convaincue finissait en impasse. En période de sprint de vente directe, c'est la fuite n°1 du funnel.

## Comment tester
- `npm run dev`, ouvrir `/tarifs?stripe_canceled=1` → bandeau visible sous la nav ; `/tarifs?from=onboarding&stripe_canceled=1` → variante onboarding.
- Déconnectée, répondre au wizard puis cliquer « Je choisis cette formule » → redirection vers /auth/signup?role=prestataire (nécessite les env vars `STRIPE_PRICE_*` en local, sinon le bouton est le fallback mailto — comportement inchangé).
- Connectée en simple membre (sans fiche) → redirection vers /onboarding/prestataire.
- Vérifié en local : bandeau OK (2 variantes), FAQ OK, `POST /api/stripe/checkout` sans session répond bien 401, `npm run build` passe, eslint n'ajoute aucune erreur sur les 2 fichiers (les 12 existantes sur `app/tarifs/page.tsx` préexistent sur main).

## Risques
- Faible : aucun changement côté API/checkout/webhook, uniquement UI + navigation client.
- Le redirect 404 suppose que tout détenteur de compte sans `profiles` doit passer par l'onboarding prestataire — c'est le cas aujourd'hui (le 404 ne concerne que le flow prestataire, le Pass Copine a ses propres composants).

## Sécurité
Pas de modif auth, RLS, secrets ni paiements. Les redirections sont des chemins internes en dur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)